### PR TITLE
Update to Spapack structs v39.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,9 +347,6 @@ https://www.gnu.org/licenses/gpl-3.0.html
   is busy and the CUI won't exit until the timeout has been reached (this can
   be reproduced by making the simulator stop responding to watercare requests)
 
-## Done/Fixed in 0.4.9
-- Rebuild pack accessors from SpaStructPack.xml v39.0
-
 ## Done/Fixed in 0.4.8
 
 - Split radio strength & channel into two separate sensors

--- a/README.md
+++ b/README.md
@@ -347,6 +347,9 @@ https://www.gnu.org/licenses/gpl-3.0.html
   is busy and the CUI won't exit until the timeout has been reached (this can
   be reproduced by making the simulator stop responding to watercare requests)
 
+## Done/Fixed in 0.4.9
+- Rebuild pack accessors from SpaStructPack.xml v39.0
+
 ## Done/Fixed in 0.4.8
 
 - Split radio strength & channel into two separate sensors

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-# python_requires = >=3.7
+python_requires = >=3.7
 packages = find:
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,7 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-install_requires =
-    python_version>="3.7"
+# python_requires = >=3.7
 packages = find:
 package_dir =
     =src

--- a/src/geckolib/_version.py
+++ b/src/geckolib/_version.py
@@ -1,3 +1,3 @@
 """ Single module version """
 
-VERSION = "0.4.8"
+VERSION = "0.4.9"

--- a/src/geckolib/_version.py
+++ b/src/geckolib/_version.py
@@ -1,3 +1,3 @@
 """ Single module version """
 
-VERSION = "0.4.9"
+VERSION = "0.4.8"

--- a/src/geckolib/driver/packs/inxe-2-cfg-60.py
+++ b/src/geckolib/driver/packs/inxe-2-cfg-60.py
@@ -12,911 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACQFFT = "".join(chr(c) for c in [65, 109, 80, 109])
-AFIKJP = 46
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(chr(c) for c in [52])
-AMJMAO = "".join(chr(c) for c in [70, 50])
-AONPYY = "".join(chr(c) for c in [72, 105])
-ASSAKQ = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AWBSIR = 84
-BFEGZU = 48
-BIAMJM = 83
-BJEUTO = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-BLKXSJ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 88
-BQSNQL = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-BSIRYX = 85
-BSKSOK = 17
-BSSUHB = 4
-BVWVUB = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BWJYKL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-BXTIAC = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-BXYBQS = 4
-BYGDSB = 43
-CBFEGZ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-CCPQIP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-CHWDAF = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-CPQIPO = 28
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [50, 52, 104])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 53])
-DAFIKJ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-DGKEAK = 127
-DJQRJJ = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DNIBXT = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DNQGVU = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-DQLAII = 76
-DSBDJQ = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DZXNQT = 124
-EAKSTS = "".join(chr(c) for c in [51])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 62
-EGZUQE = 32
-EJNIBX = 106
-EKCWAO = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-EKVKZI = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ELHBQN = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-EMCGET = 60
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-EUTOPH = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-FCRTFM = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-FEFJTA = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FEGZUQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-FFTTID = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-FMNHTB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 122
-FTTIDU = 64
-FWRKIN = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-FYLJUI = 89
-FZDGKE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-GDSBDJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-GKEAKS = "".join(chr(c) for c in [49])
-GLRAHE = 37
-GSELHB = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-GTYIYW = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-GVUNXN = "".join(chr(c) for c in [80, 68, 67])
-GYOUSP = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-GZUQEX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-HBQNRX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-HBSKSO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 55
-HTBJEU = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-HUGTYI = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-HWDAFI = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-HXEKVK = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-IACQFF = 34
-IAMJMA = "".join(chr(c) for c in [70, 49])
-IBXYBQ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-ICXQIE = 15
-IDNIBX = 73
-IDUBSS = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IEFXQG = 18
-IFJBIA = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-IGYOUS = 68
-IIDNIB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IJUGSE = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-IKFWRK = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-IKJPUN = 47
-ILXWAJ = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-INEJNI = 105
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IRYXBQ = 86
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IUXFEF = 60
-IVDNQG = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-JBIAMJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JEUTOP = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-JHIUSO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JIGYOU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JJJVYF = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JJVYFC = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-JMCBFE = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JNIBXY = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JPUNRJ = 121
-JQRJJJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-JRJHIU = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-JTACCP = 78
-JUGSEL = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-JUIKFW = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-JUTYEK = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-JVDQLA = 5
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [66, 76, 85, 69])
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-JYKLGQ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-JYMOUN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-JZTATD = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-KEAKST = "".join(chr(c) for c in [50])
-KFWRKI = 100
-KINEJN = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-KJPUNR = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-KLGQPL = "".join(chr(c) for c in [85, 76])
-KMLOIJ = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-KPHUOJ = 79
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-KVKZIL = 82
-KWIVDN = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-KXSJWM = "".join(chr(c) for c in [70])
-KZILXW = 72
-LAIIDN = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [67, 69])
-LHBQNR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-LIUXFE = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-LJUIKF = 98
-LKXSJW = 33
-LNMHXE = 10
-LOIJUG = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-LSXUJU = 27
-LXWAJV = 1
-MAOAWB = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-MCBFEG = 118
-MFZDGK = 126
-MHXEKV = 71
-MJIGYO = 66
-MJMAOA = "".join(chr(c) for c in [70, 51])
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-MNHTBJ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-MNZMJI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-MOUNBL = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NBLKXS = 1
-NEJNIB = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-NIBXYB = 3
-NKMLOI = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-NPYYLI = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-NQGVUN = "".join(chr(c) for c in [77, 65, 65, 88])
-NQJYMO = 30
-NQLNMH = 8
-NQTMFZ = 125
-NRJZTA = "".join(chr(c) for c in [82, 71, 66])
-NRXCHW = 45
-NXNKML = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NZMJIG = 35
-OAWBSI = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-OCTHBS = 40
-OIJUGS = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-OJRJHI = 80
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OOQNRS = 81
-OPHUGT = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-OQNRSJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OUNBLK = 63
-OUSPBW = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-OUYNQJ = 29
-PBWJYK = 77
-PFTSIF = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-PHUGTY = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-PHUOJR = "".join(chr(c) for c in [76, 73])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 52])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 52
-POUYNQ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PQIPOU = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-PUNRJZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-PYYLIU = 58
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-QFYLJU = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-QIPOUY = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-QJYMOU = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-QLAIID = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-QLNMHX = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-QNRSJM = "".join(chr(c) for c in [79, 119, 110])
-QNRXCH = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QPLSPF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-QRJJJV = "".join(chr(c) for c in [79, 70, 70])
-QSNQLN = 23
-QTMFZD = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 38
-RJHIUS = 54
-RJJJVY = "".join(chr(c) for c in [82, 69, 68])
-RSJMCB = 0
-RTFMNH = 8
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-RYXBQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-SBDJQR = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-SELHBQ = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-SIFJBI = 74
-SIRYXB = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-SJMCBF = 2
-SKWIVD = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-SNQLNM = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-SOKPHU = 41
-SOOQNR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-SPBWJY = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-SPFTSI = 53
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-SUHBVW = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-SXUJUT = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-TACCPQ = "".join(chr(c) for c in [80, 49])
-TATDZX = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-TBJEUT = 44
-TDZXNQ = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-TFMNHT = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-THBSKS = 42
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-TIDUBS = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TMFZDG = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-TOPHUG = "".join(chr(c) for c in [65, 108, 112, 115])
-TSIFJB = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-TTIDUB = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-TYEKCW = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TYIYWS = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-UBSSUH = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-UBYGDS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UGSELH = "".join(chr(c) for c in [73, 100, 111, 108])
-UGTYIY = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-UHBVWV = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-UIKFWR = 99
-UNBLKX = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-UNRJZT = 123
-UNXNKM = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-UOJRJH = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UQEXLS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-USOOQN = 56
-UTOPHU = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-UTYEKC = 57
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [76, 65])
-VDQLAI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = 7
-VUNXNK = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-VWVUBY = 6
-VYFCRT = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 3
-WAONPY = "".join(chr(c) for c in [76, 111])
-WBSIRY = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-WIVDNQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-WJYKLG = 26
-WMNZMJ = 31
-WRKINE = 104
-WSKWIV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-WVUBYG = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-XBQFYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 70, 117, 115, 101])
-XCHWDA = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-XFEFJT = 61
-XLSXUJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-XNKMLO = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-XPICXQ = 14
-XQGLRA = 36
-XQIEFX = 16
-XSJWMN = "".join(chr(c) for c in [67])
-XTIACQ = 75
-XUJUTY = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-XWAJVD = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-XYBQSN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-YBQSNQ = 6
-YEKCWA = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-YFCRTF = "".join(chr(c) for c in [67, 89, 65, 78])
-YGDSBD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-YIYWSK = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-YKLGQP = 51
-YLIUXF = 59
-YLJUIK = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YNQJYM = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-YOUSPB = 70
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-YXBQFY = 87
-YYLIUX = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-ZILXWA = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZTATDZ = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-ZUQEXL = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-ZXNQTM = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-ACCPQI = [JVHFTH, TACCPQ, PIPIVL]
-AIIDNI = [QLAIID, LAIIDN]
-AOAWBS = [IAMJMA, AMJMAO, MJMAOA, VLASSA, VLASSA, VLASSA, JMAOAW, MAOAWB]
-ATDZXN = [ZTATDZ, TATDZX]
-BDJQRJ = [DSBDJQ, SBDJQR]
-BQNRXC = [
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-]
-CRTFMN = [QRJJJV, RJJJVY, JJJVYF, JJVYFC, JVYFCR, VYFCRT, YFCRTF, FCRTFM]
-DUBSSU = [TIDUBS, IDUBSS]
-EFXQGL = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-EXLSXU = [GZUQEX, ZUQEXL, UQEXLS, QEXLSX]
-FJBIAM = [QJYMOU, IFJBIA]
-GQPLSP = [KLGQPL, LGQPLS]
-HBVWVU = [SUHBVW, UHBVWV]
-HUOJRJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PHUOJR,
-]
-IBXTIA = [VLASSA, DNIBXT, NIBXTI]
-IPOUYN = [PQIPOU, QIPOUY]
-KCWAON = [TYEKCW, YEKCWA, EKCWAO]
-KSTSEM = [VLASSA, GKEAKS, KEAKST, EAKSTS, AKSTSE]
-NHTBJE = [FMNHTB, MNHTBJ]
-NRSJMC = [OQNRSJ, QNRSJM]
-ONPYYL = [WAONPY, AONPYY]
-QFFTTI = [JVHFTH, ACQFFT, CQFFTT]
-RJZTAT = [NRJZTA, FCRTFM]
-RKINEJ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, JMAOAW, MAOAWB]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    SSAKQX,
-]
-SEMCGE = []
-SJWMNZ = [KXSJWM, XSJWMN]
-SKSOKP = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-STSEMC = [BMJVHF, AKQXPI, QXPICX, PICXQI, CXQIEF, QIEFXQ, HBSKSO, OKPHUO]
-TSEMCG = [PHUOJR]
-UJUTYE = [SXUJUT, XUJUTY]
-USPBWJ = [QJYMOU, OUSPBW]
-UYNQJY = [PIPIVL, TACCPQ]
-WDAFIK = [CHWDAF, HWDAFI, VLASSA, VLASSA]
-XEKVKZ = [JVHFTH, SXUJUT, HXEKVK]
-YMOUNB = [QJYMOU, JYMOUN]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -924,253 +19,706 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return EMCGET
+        return 60
 
     @property
     def output_keys(self):
-        return STSEMC
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, SAKQXP, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, SAKQXP, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, EFXQGL, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, SKSOKP, None, None, QBMJVH
-            ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, HUOJRJ, None, None, None
-            ),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, None),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, RSJMCB, NRSJMC, None, SJMCBF, QBMJVH
-            ),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, EGZUQE, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, UJUTYE, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, KCWAON, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, OOQNRS, SJMCBF, ONPYYL, None, SJMCBF, QBMJVH
-            ),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, ACCPQI, None, None, QBMJVH
-            ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, IPOUYN, None, None, QBMJVH
-            ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, OUYNQJ, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoTempStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, SJWMNZ, None, None, QBMJVH
-            ),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, WMNZMJ, None, UYNQJY, None, None, QBMJVH
-            ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoTempStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoTempStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, USPBWJ, None, None, QBMJVH
-            ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoByteStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoEnumStructAccessor(
-                self.struct, TSIFJB, SIFJBI, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, AOAWBS, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, BSIRYX, None, AOAWBS, None, None, QBMJVH
-            ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, AOAWBS, None, None, QBMJVH
-            ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, AOAWBS, None, None, QBMJVH
-            ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, AOAWBS, None, None, QBMJVH
-            ),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, None, AOAWBS, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoByteStructAccessor(self.struct, JUIKFW, UIKFWR, QBMJVH),
-            IKFWRK: GeckoByteStructAccessor(self.struct, IKFWRK, KFWRKI, QBMJVH),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, RKINEJ, None, None, QBMJVH
-            ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, RKINEJ, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoTimeStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoTimeStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoTimeStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoTimeStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, XEKVKZ, None, None, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, KVKZIL, RSJMCB, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, KZILXW, SJMCBF, QBMJVH
-            ),
-            ZILXWA: GeckoBoolStructAccessor(
-                self.struct, ZILXWA, KZILXW, RSJMCB, QBMJVH
-            ),
-            ILXWAJ: GeckoBoolStructAccessor(
-                self.struct, ILXWAJ, KZILXW, LXWAJV, QBMJVH
-            ),
-            XWAJVD: GeckoBoolStructAccessor(
-                self.struct, XWAJVD, KZILXW, WAJVDQ, QBMJVH
-            ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, KZILXW, JVDQLA, QBMJVH
-            ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, None, AIIDNI, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, IBXTIA, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, QBMJVH),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, QFFTTI, None, None, QBMJVH
-            ),
-            FFTTID: GeckoWordStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, OOQNRS, LXWAJV, DUBSSU, None, SJMCBF, QBMJVH
-            ),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, OOQNRS, BSSUHB, QBMJVH
-            ),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, OOQNRS, JVDQLA, HBVWVU, None, SJMCBF, QBMJVH
-            ),
-            BVWVUB: GeckoBoolStructAccessor(
-                self.struct, BVWVUB, OOQNRS, VWVUBY, QBMJVH
-            ),
-            WVUBYG: GeckoBoolStructAccessor(
-                self.struct, WVUBYG, OOQNRS, VUBYGD, QBMJVH
-            ),
-            UBYGDS: GeckoBoolStructAccessor(
-                self.struct, UBYGDS, BYGDSB, RSJMCB, QBMJVH
-            ),
-            YGDSBD: GeckoBoolStructAccessor(
-                self.struct, YGDSBD, BYGDSB, LXWAJV, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, BYGDSB, SJMCBF, BDJQRJ, None, SJMCBF, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, BYGDSB, WAJVDQ, BDJQRJ, None, SJMCBF, QBMJVH
-            ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, BYGDSB, BSSUHB, CRTFMN, None, RTFMNH, QBMJVH
-            ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, BYGDSB, VUBYGD, NHTBJE, None, SJMCBF, QBMJVH
-            ),
-            QNRXCH: GeckoBoolStructAccessor(
-                self.struct, QNRXCH, NRXCHW, RSJMCB, QBMJVH
-            ),
-            RXCHWD: GeckoBoolStructAccessor(
-                self.struct, RXCHWD, NRXCHW, LXWAJV, QBMJVH
-            ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, NRXCHW, SJMCBF, WDAFIK, None, BSSUHB, QBMJVH
-            ),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, QBMJVH),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, IKJPUN, RSJMCB, QBMJVH
-            ),
-            KJPUNR: GeckoByteStructAccessor(self.struct, KJPUNR, JPUNRJ, QBMJVH),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            JZTATD: GeckoEnumStructAccessor(
-                self.struct, JZTATD, UNRJZT, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, DZXNQT, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, NQTMFZ, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, NQTMFZ, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, MFZDGK, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            FZDGKE: GeckoEnumStructAccessor(
-                self.struct, FZDGKE, MFZDGK, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, RSJMCB, KSTSEM, None, RTFMNH, None
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "DirectFuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/inxe-2-cfg-61.py
+++ b/src/geckolib/driver/packs/inxe-2-cfg-61.py
@@ -12,970 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 78
-ACQFFT = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-AFIKJP = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-AMJMAO = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-AONPYY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-ASSAKQ = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-ATDZXN = "".join(chr(c) for c in [82, 71, 66])
-AWBSIR = "".join(chr(c) for c in [70, 49])
-BDJQRJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-BFEGZU = 118
-BHZVOA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BJEUTO = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-BLKXSJ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BQNRXC = "".join(chr(c) for c in [73, 100, 111, 108])
-BQSNQL = 106
-BSIRYX = "".join(chr(c) for c in [70, 51])
-BSKSOK = 17
-BSSUHB = 64
-BVWVUB = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BWJYKL = 68
-BXIBHZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-BXYBQS = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-CBFEGZ = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-CCPQIP = "".join(chr(c) for c in [80, 49])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-CHWDAF = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-CQBMJV = 0
-CRTFMN = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 53])
-DAFIKJ = 45
-DGKEAK = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-DJQRJJ = 43
-DNIBXT = 76
-DNQGVU = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-DQLAII = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-DSBDJQ = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-EAKSTS = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 61
-EGZUQE = 48
-EJNIBX = 100
-EKCWAO = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-EKVKZI = 8
-ELHBQN = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-EUTOPH = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-EXLSXU = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FCRTFM = "".join(chr(c) for c in [82, 69, 68])
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-FFTTID = 75
-FIKJPU = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-FJBIAM = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-FJTACC = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FMNHTB = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 69])
-FTTIDU = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-FWRKIN = 89
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-FZDGKE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-GDSBDJ = 6
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-GKEAKS = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-GLRAHE = 37
-GQPLSP = 77
-GSELHB = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-GTYIYW = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-GVUNXN = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-GYOUSP = 3
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-HBQNRX = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-HBSKSO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-HBXIBH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HUGTYI = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-HXEKVK = 23
-IACQFF = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IAMJMA = 122
-IBHZVO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-IBXTIA = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-ICXQIE = 15
-IDNIBX = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-IDUBSS = "".join(chr(c) for c in [50, 52, 104])
-IEFXQG = 18
-IFJBIA = 52
-IHBXIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-IIDNIB = 5
-IJUGSE = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-IKFWRK = 88
-IKJPUN = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-ILXWAJ = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-INEJNI = 99
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-IRYXBQ = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-IUSOOQ = 54
-IUXFEF = 59
-IVDNQG = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-IYWSKW = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-JBIAMJ = 53
-JEUTOP = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JHIUSO = 80
-JIGYOU = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JJJVYF = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JMAOAW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JNIBXY = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JPUNRJ = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-JQRJJJ = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-JTACCP = 62
-JUGSEL = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-JUIKFW = 87
-JUTYEK = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JVDQLA = 72
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-JWMNZM = "".join(chr(c) for c in [67])
-JYKLGQ = 70
-JYMOUN = 30
-JZTATD = 121
-KCWAON = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-KEAKST = 126
-KFWRKI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-KINEJN = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-KMLOIJ = "".join(chr(c) for c in [80, 68, 67])
-KPHUOJ = 47
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-KSTSEM = 127
-KVKZIL = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-KWIVDN = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-KXSJWM = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-LHBQNR = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-LIUXFE = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-LJUIKF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-LKXSJW = 1
-LNMHXE = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LOIJUG = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-MCBFEG = 0
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-MFZDGK = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-MHXEKV = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-MJIGYO = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MJMAOA = 74
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-MNHTBJ = "".join(chr(c) for c in [67, 89, 65, 78])
-MNZMJI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-MOUNBL = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-NBLKXS = 63
-NEJNIB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-NHTBJE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-NIBXTI = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-NIBXYB = 104
-NKMLOI = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-NMHXEK = 6
-NPYYLI = "".join(chr(c) for c in [72, 105])
-NQGVUN = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-NQLNMH = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-NRJZTA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-NRSJMC = 81
-NRXCHW = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-NXNKML = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-NZMJIG = 31
-OACMCV = 61
-OAWBSI = 83
-OCTHBS = 40
-OIHBXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-OIJUGS = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-OJRJHI = "".join(chr(c) for c in [76, 73])
-OKPHUO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-ONPYYL = "".join(chr(c) for c in [76, 111])
-OOQNRS = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-OPHUGT = 44
-OQNRSJ = 56
-OUSPBW = 35
-PBWJYK = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PFTSIF = "".join(chr(c) for c in [85, 76])
-PHUGTY = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-PHUOJR = 2
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 52])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 26
-POUYNQ = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-PQIPOU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-PUNRJZ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-QFFTTI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-QFYLJU = 85
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-QIPOUY = 28
-QJYMOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-QLAIID = 1
-QLNMHX = 4
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-QNRXCH = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-QRJJJV = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-QSNQLN = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-QTMFZD = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 38
-RJHIUS = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-RJJJVY = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-RJZTAT = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-RKINEJ = 98
-RSJMCB = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-RTFMNH = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-RXCHWD = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-SBDJQR = 7
-SELHBQ = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-SEMCGE = "".join(chr(c) for c in [51])
-SIFJBI = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-SIRYXB = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-SJMCBF = "".join(chr(c) for c in [79, 119, 110])
-SJWMNZ = "".join(chr(c) for c in [70])
-SKWIVD = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-SNQLNM = 3
-SOKPHU = 41
-SOOQNR = 55
-SPBWJY = 66
-SPFTSI = 51
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-STSEMC = "".join(chr(c) for c in [49])
-SUHBVW = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-SXUJUT = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-TACCPQ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-TATDZX = 123
-TBJEUT = 8
-TFMNHT = "".join(chr(c) for c in [66, 76, 85, 69])
-THBSKS = 42
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 73
-TIDUBS = "".join(chr(c) for c in [65, 109, 80, 109])
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-TMFZDG = 124
-TOPHUG = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-TSEMCG = "".join(chr(c) for c in [50])
-TTIDUB = 34
-TYEKCW = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-TYIYWS = "".join(chr(c) for c in [65, 108, 112, 115])
-UBSSUH = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-UBYGDS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-UGSELH = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-UGTYIY = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-UHBVWV = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-UIKFWR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 70, 117, 115, 101])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-UNBLKX = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UNRJZT = 46
-UNXNKM = "".join(chr(c) for c in [76, 65])
-UOJRJH = 79
-UQEXLS = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-USOOQN = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-USPBWJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UYNQJY = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-VDNQGV = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-VDQLAI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 10
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-VUNXNK = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-VWVUBY = 4
-VXOIHB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-VYFCRT = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 82
-WBSIRY = "".join(chr(c) for c in [70, 50])
-WDAFIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-WIVDNQ = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-WJYKLG = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-WRKINE = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-WSKWIV = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-WVUBYG = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XBQFYL = 84
-XCHWDA = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-XEKVKZ = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-XFEFJT = 60
-XIBHZV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-XLSXUJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-XNKMLO = "".join(chr(c) for c in [77, 65, 65, 88])
-XNQTMF = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-XOIHBX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XPICXQ = 14
-XQGLRA = 36
-XQIEFX = 16
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-XSJWMN = 33
-XTIACQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-XUJUTY = 27
-XWAJVD = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-XYBQSN = 105
-YBQSNQ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-YEKCWA = 57
-YFCRTF = "".join(chr(c) for c in [79, 70, 70])
-YGDSBD = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-YIYWSK = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-YKLGQP = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-YLIUXF = 58
-YLJUIK = 86
-YMOUNB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YNQJYM = 29
-YOUSPB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-YXBQFY = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-YYLIUX = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = 125
-ZILXWA = 71
-ZMJIGY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-ZUQEXL = 32
-ZXNQTM = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-BXTIAC = [NIBXTI, IBXTIA]
-BYGDSB = [VUBYGD, UBYGDS]
-CPQIPO = [JVHFTH, CCPQIP, PIPIVL]
-CQFFTT = [VLASSA, IACQFF, ACQFFT]
-DUBSSU = [JVHFTH, TIDUBS, IDUBSS]
-EFXQGL = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-EMCGET = [VLASSA, STSEMC, TSEMCG, SEMCGE]
-HBVWVU = [SUHBVW, UHBVWV]
-HTBJEU = [YFCRTF, FCRTFM, CRTFMN, RTFMNH, TFMNHT, FMNHTB, MNHTBJ, NHTBJE]
-HWDAFI = [
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-]
-HZVOAC = [BMJVHF, AKQXPI, QXPICX, PICXQI, CXQIEF, QIEFXQ, HBSKSO, HUOJRJ]
-IBXYBQ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, SIRYXB, IRYXBQ]
-IGYOUS = [MJIGYO, JIGYOU]
-JJVYFC = [RJJJVY, JJJVYF]
-JMCBFE = [RSJMCB, SJMCBF]
-JRJHIU = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OJRJHI,
-]
-KJPUNR = [FIKJPU, IKJPUN, VLASSA, VLASSA]
-KLGQPL = [YMOUNB, YKLGQP]
-LSXUJU = [UQEXLS, QEXLSX, EXLSXU, XLSXUJ]
-LXWAJV = [JVHFTH, UJUTYE, ILXWAJ]
-MAOAWB = [YMOUNB, JMAOAW]
-NQJYMO = [PIPIVL, CCPQIP]
-NQTMFZ = [ZXNQTM, XNQTMF]
-OUNBLK = [YMOUNB, MOUNBL]
-OUYNQJ = [IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-RYXBQF = [AWBSIR, WBSIRY, BSIRYX, VLASSA, VLASSA, VLASSA, SIRYXB, IRYXBQ]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    SSAKQX,
-]
-SKSOKP = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-TDZXNQ = [ATDZXN, NHTBJE]
-TSIFJB = [PFTSIF, FTSIFJ]
-UTOPHU = [JEUTOP, EUTOPH]
-UTYEKC = [UJUTYE, JUTYEK]
-VOACMC = []
-WAONPY = [EKCWAO, KCWAON, CWAONP]
-WMNZMJ = [SJWMNZ, JWMNZM]
-ZVOACM = [OJRJHI]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -983,276 +19,763 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return OACMCV
+        return 61
 
     @property
     def output_keys(self):
-        return HZVOAC
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, SAKQXP, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, SAKQXP, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, EFXQGL, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, SKSOKP, None, None, QBMJVH
-            ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoBoolStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, PHUOJR, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 47, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "DirectFuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 45, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct, "NumberOfZones", 127, 0, ["", "1", "2", "3"], None, 8, None
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, JRJHIU, None, None, None
-            ),
-            RJHIUS: GeckoByteStructAccessor(self.struct, RJHIUS, JHIUSO, None),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, QBMJVH),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, MCBFEG, JMCBFE, None, PHUOJR, QBMJVH
-            ),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, LSXUJU, None, None, QBMJVH
-            ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, UTYEKC, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, WAONPY, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, NRSJMC, PHUOJR, PYYLIU, None, PHUOJR, QBMJVH
-            ),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, NQJYMO, None, None, QBMJVH
-            ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, OUNBLK, None, None, QBMJVH
-            ),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoTempStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, XSJWMN, None, WMNZMJ, None, None, QBMJVH
-            ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, NQJYMO, None, None, QBMJVH
-            ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, NRSJMC, GYOUSP, IGYOUS, None, PHUOJR, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoTempStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoEnumStructAccessor(
-                self.struct, WJYKLG, JYKLGQ, None, KLGQPL, None, None, QBMJVH
-            ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, TSIFJB, None, None, QBMJVH
-            ),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoByteStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, RYXBQF, None, None, QBMJVH
-            ),
-            YXBQFY: GeckoEnumStructAccessor(
-                self.struct, YXBQFY, XBQFYL, None, RYXBQF, None, None, QBMJVH
-            ),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, RYXBQF, None, None, QBMJVH
-            ),
-            FYLJUI: GeckoEnumStructAccessor(
-                self.struct, FYLJUI, YLJUIK, None, RYXBQF, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, RYXBQF, None, None, QBMJVH
-            ),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, RYXBQF, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, RYXBQF, None, None, QBMJVH
-            ),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoByteStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, NIBXYB, None, IBXYBQ, None, None, QBMJVH
-            ),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, IBXYBQ, None, None, QBMJVH
-            ),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, IBXYBQ, None, None, QBMJVH
-            ),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, QBMJVH),
-            NQLNMH: GeckoTimeStructAccessor(self.struct, NQLNMH, QLNMHX, QBMJVH),
-            LNMHXE: GeckoTimeStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoTimeStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoTimeStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoTimeStructAccessor(self.struct, KVKZIL, VKZILX, QBMJVH),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, LXWAJV, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoBoolStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, MCBFEG, QBMJVH
-            ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, JVDQLA, PHUOJR, QBMJVH
-            ),
-            VDQLAI: GeckoBoolStructAccessor(
-                self.struct, VDQLAI, JVDQLA, MCBFEG, QBMJVH
-            ),
-            DQLAII: GeckoBoolStructAccessor(
-                self.struct, DQLAII, JVDQLA, QLAIID, QBMJVH
-            ),
-            LAIIDN: GeckoBoolStructAccessor(
-                self.struct, LAIIDN, JVDQLA, GYOUSP, QBMJVH
-            ),
-            AIIDNI: GeckoBoolStructAccessor(
-                self.struct, AIIDNI, JVDQLA, IIDNIB, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, CQFFTT, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, QBMJVH),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, DUBSSU, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoWordStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, NRSJMC, QLAIID, HBVWVU, None, PHUOJR, QBMJVH
-            ),
-            BVWVUB: GeckoBoolStructAccessor(
-                self.struct, BVWVUB, NRSJMC, VWVUBY, QBMJVH
-            ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, NRSJMC, IIDNIB, BYGDSB, None, PHUOJR, QBMJVH
-            ),
-            YGDSBD: GeckoBoolStructAccessor(
-                self.struct, YGDSBD, NRSJMC, GDSBDJ, QBMJVH
-            ),
-            DSBDJQ: GeckoBoolStructAccessor(
-                self.struct, DSBDJQ, NRSJMC, SBDJQR, QBMJVH
-            ),
-            BDJQRJ: GeckoBoolStructAccessor(
-                self.struct, BDJQRJ, DJQRJJ, MCBFEG, QBMJVH
-            ),
-            JQRJJJ: GeckoBoolStructAccessor(
-                self.struct, JQRJJJ, DJQRJJ, QLAIID, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, DJQRJJ, PHUOJR, JJVYFC, None, PHUOJR, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, DJQRJJ, GYOUSP, JJVYFC, None, PHUOJR, QBMJVH
-            ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, DJQRJJ, VWVUBY, HTBJEU, None, TBJEUT, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, DJQRJJ, SBDJQR, UTOPHU, None, PHUOJR, QBMJVH
-            ),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, QLAIID, QBMJVH
-            ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, DAFIKJ, PHUOJR, KJPUNR, None, VWVUBY, QBMJVH
-            ),
-            JPUNRJ: GeckoBoolStructAccessor(
-                self.struct, JPUNRJ, DAFIKJ, VWVUBY, QBMJVH
-            ),
-            PUNRJZ: GeckoByteStructAccessor(self.struct, PUNRJZ, UNRJZT, QBMJVH),
-            NRJZTA: GeckoBoolStructAccessor(
-                self.struct, NRJZTA, KPHUOJ, MCBFEG, QBMJVH
-            ),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, TATDZX, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, TATDZX, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, TMFZDG, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            FZDGKE: GeckoEnumStructAccessor(
-                self.struct, FZDGKE, ZDGKEA, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, ZDGKEA, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, KEAKST, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            EAKSTS: GeckoEnumStructAccessor(
-                self.struct, EAKSTS, KEAKST, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, MCBFEG, EMCGET, None, TBJEUT, None
-            ),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, KSTSEM, SBDJQR, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, TATDZX, VWVUBY, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, TATDZX, IIDNIB, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, TATDZX, GDSBDJ, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, TATDZX, SBDJQR, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, TMFZDG, VWVUBY, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, TMFZDG, IIDNIB, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, TMFZDG, GDSBDJ, None),
-            VXOIHB: GeckoBoolStructAccessor(self.struct, VXOIHB, TMFZDG, SBDJQR, None),
-            XOIHBX: GeckoBoolStructAccessor(self.struct, XOIHBX, ZDGKEA, VWVUBY, None),
-            OIHBXI: GeckoBoolStructAccessor(self.struct, OIHBXI, ZDGKEA, IIDNIB, None),
-            IHBXIB: GeckoBoolStructAccessor(self.struct, IHBXIB, ZDGKEA, GDSBDJ, None),
-            HBXIBH: GeckoBoolStructAccessor(self.struct, HBXIBH, ZDGKEA, SBDJQR, None),
-            BXIBHZ: GeckoBoolStructAccessor(self.struct, BXIBHZ, KEAKST, VWVUBY, None),
-            XIBHZV: GeckoBoolStructAccessor(self.struct, XIBHZV, KEAKST, IIDNIB, None),
-            IBHZVO: GeckoBoolStructAccessor(self.struct, IBHZVO, KEAKST, GDSBDJ, None),
-            BHZVOA: GeckoBoolStructAccessor(self.struct, BHZVOA, KEAKST, SBDJQR, None),
         }

--- a/src/geckolib/driver/packs/inxe-2-log-58.py
+++ b/src/geckolib/driver/packs/inxe-2-log-58.py
@@ -12,1052 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 470
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [52, 56, 75])
-AJVDQL = "".join(chr(c) for c in [105, 110, 89, 84])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 57])
-AMJMAO = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 449
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-BBEKBD = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-BDFSRO = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-BDJQRJ = 300
-BEKBDF = 372
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-BIAMJM = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BJEUTO = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BQSNQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BVWVUB = 294
-BWJYKL = 275
-BXIBHZ = 466
-BXYBQS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 460
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [53, 79, 80])
-CRTFMN = "".join(chr(c) for c in [75, 52, 48, 48])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = 330
-DDPMXF = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-DFSROG = 374
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 55])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-DNIBXT = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-DNQGVU = "".join(chr(c) for c in [80, 50, 72])
-DPMXFU = 375
-DQLAII = 290
-DSBDJQ = 299
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-DUBSSU = "".join(chr(c) for c in [51, 48, 65])
-DZXNQT = 450
-EAKSTS = 456
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-EKBDFS = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [105, 110, 88, 69])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-EMCGET = 459
-EOCTHB = 308
-ETIXQV = 461
-EUTOPH = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FCRTFM = "".join(chr(c) for c in [75, 50, 48, 48])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FIKJPU = 331
-FJBIAM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-FMNHTB = "".join(chr(c) for c in [75, 52])
-FSROGM = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 54])
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-GKEAKS = 455
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-GTYIYW = 361
-GVUNXN = "".join(chr(c) for c in [80, 51, 76])
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [72, 84, 82])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [75, 49, 48, 48])
-HTZBBE = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-HUGTYI = 360
-HUOJRJ = 305
-HWDAFI = 329
-HXEKVK = 289
-HZVOAC = 468
-IAMJMA = 283
-IBHZVO = 467
-IBXTIA = "".join(chr(c) for c in [67, 69])
-IBXYBQ = 315
-ICXQIE = 0
-IDUBSS = "".join(chr(c) for c in [50, 53, 65])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = 465
-IIDNIB = "".join(chr(c) for c in [54, 52, 75])
-IJUGSE = 322
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-ILXWAJ = "".join(chr(c) for c in [105, 110, 88, 77])
-INEJNI = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [80, 49, 72])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 462
-IYWSKW = "".join(chr(c) for c in [45, 45, 45])
-JBIAMJ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JEUTOP = "".join(chr(c) for c in [75, 51, 48, 48])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-JJVYFC = "".join(chr(c) for c in [70, 117, 108, 108])
-JLOINE = 58
-JMAOAW = 284
-JMCBFE = 260
-JNIBXY = 314
-JPUNRJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-JQRJJJ = 301
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-JUIKFW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVHFTH = 274
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 48])
-KBDFSR = 373
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 56])
-KFWRKI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KHTZBB = 479
-KJPUNR = 333
-KPHUOJ = 304
-KQTDKH = 477
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 457
-KVKZIL = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-KWIVDN = 320
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [68, 74, 83, 52])
-LAIIDN = "".join(chr(c) for c in [51, 50, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 326
-LIUXFE = 263
-LJUIKF = 354
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-LOIJUG = 321
-LOINEL = 256
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [75, 54, 48, 48])
-MAOAWB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-MCVDSS = 471
-MFZDGK = 453
-MHXEKV = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-MNHTBJ = "".join(chr(c) for c in [75, 53])
-MNZMJI = 313
-MOUNBL = 273
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = 311
-NHTBJE = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-NIBXTI = "".join(chr(c) for c in [85, 76])
-NIBXYB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NKMLOI = "".join(chr(c) for c in [65, 85, 88])
-NMHXEK = 288
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [80, 50, 76])
-NQJYMO = 271
-NQLNMH = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 52])
-NRJZTA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 327
-NXNKML = "".join(chr(c) for c in [66, 76, 79])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-OAWBSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-OINELW = 479
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = 358
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = 325
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [51, 79, 80])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-QGVUNX = "".join(chr(c) for c in [80, 51, 72])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [49, 54, 75])
-QLNMHX = 287
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-QSNQLN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-QTMFZD = 452
-QVXOIH = 463
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 475
-RJHIUS = 362
-RJJJVY = 316
-RJZTAT = 332
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-ROGMDD = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(chr(c) for c in [75, 56, 53])
-RURAZM = 474
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SELHBQ = 324
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-SIFJBI = 352
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-SNQLNM = 285
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-SSRURA = 473
-SSUHBV = 291
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49])
-TBJEUT = "".join(chr(c) for c in [75, 56, 48, 48])
-TDKHTZ = 478
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 50])
-TFMNHT = "".join(chr(c) for c in [75, 56])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 50, 50])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 53])
-TOPHUG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-TSEMCG = 458
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-TZBBEK = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-UBYGDS = 296
-UGSELH = 323
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-UHBVWV = 293
-UIKFWR = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNXNKM = "".join(chr(c) for c in [80, 52, 76])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-USOOQN = 261
-USPBWJ = 355
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = "".join(chr(c) for c in [80, 49, 76])
-VDQLAI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-VDSSRU = 472
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [77, 73, 65])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 469
-VUBYGD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VUNXNK = "".join(chr(c) for c in [80, 52, 72])
-VWVUBY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-WAONPY = 367
-WBSIRY = 350
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-WIVDNQ = "".join(chr(c) for c in [78, 65])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = 309
-WVUBYG = 295
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XCHWDA = 328
-XEKVKZ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = "".join(chr(c) for c in [76, 73])
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-XNQTMF = 451
-XOIHBX = 464
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-XSJWMN = 282
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-XYBQSN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YBQSNQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-YEKCWA = 364
-YFCRTF = 357
-YGDSBD = 297
-YIYWSK = 376
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-YXBQFY = 351
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 371
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 454
-ZILXWA = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = 476
-ZTATDZ = 448
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 51])
-BJLOIN = [
-    XYBQSN,
-    XBQFYL,
-    FYLJUI,
-    MAOAWB,
-    SPBWJY,
-    BXYBQS,
-    YBQSNQ,
-    LGQPLS,
-    BLKXSJ,
-    IRYXBQ,
-    AWBSIR,
-    IFJBIA,
-    TSIFJB,
-    NIBXYB,
-    OAWBSI,
-    RYXBQF,
-    SIRYXB,
-    AMJMAO,
-    YLJUIK,
-    BIAMJM,
-    FJBIAM,
-    BQFYLJ,
-    IKFWRK,
-    QFYLJU,
-    JBIAMJ,
-    BSIRYX,
-    AOAWBS,
-    MJMAOA,
-]
-BQNRXC = [
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HBQNRX,
-]
-BXTIAC = [NIBXTI, IBXTIA]
-FFTTID = [CQFFTT, QFFTTI]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FUBJLO = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    XFUBJL,
-]
-IACQFF = [CBFEGZ, TIACQF]
-IDNIBX = [QLAIID, LAIIDN, AIIDNI, IIDNIB]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JVDQLA = [
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-]
-JVYFCR = [JJJVYF, JJVYFC]
-KINEJN = [HECVYY, RKINEJ, RKINEJ, RKINEJ]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-KMLOIJ = [
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    SJMCBF,
-    NXNKML,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XNKMLO,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    NKMLOI,
-]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDDPMX = [FSROGM, SROGMD, ROGMDD, OGMDDP, GMDDPM]
-MXFUBJ = []
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UBJLOI = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-UBSSUH = [IDUBSS, DUBSSU]
-UNRJZT = [
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-UTOPHU = [
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-WSKWIV = [IYWSKW, YWSKWI]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1065,282 +19,861 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return JLOINE
+        return 58
 
     @property
     def begin(self):
-        return LOINEL
+        return 256
 
     @property
     def end(self):
-        return OINELW
+        return 479
 
     @property
     def all_device_keys(self):
-        return FUBJLO
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return UBJLOI
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return BJLOIN
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, EGZUQE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, XSJWMN, ICXQIE, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, XSJWMN, AHEOCT, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QIEFXQ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, EGZUQE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, CXQIEF, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JMAOAW, UQEXLS, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JMAOAW, VHFTHE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, WBSIRY, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, WBSIRY, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, QIEFXQ, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, EGZUQE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, SIFJBI, EGZUQE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, GYOUSP, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, GYOUSP, AHEOCT, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, LSPFTS, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IAMJMA, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, IAMJMA, AHEOCT, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, IAMJMA, CXQIEF, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, WRKINE, ICXQIE, None),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, WRKINE, AHEOCT, KINEJN, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            INEJNI: GeckoWordStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, JNIBXY, ICXQIE, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, IBXYBQ, ICXQIE, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, IBXYBQ, AHEOCT, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, YXBQFY, ICXQIE, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, YXBQFY, AHEOCT, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YXBQFY, CXQIEF, None),
-            QSNQLN: GeckoWordStructAccessor(self.struct, QSNQLN, SNQLNM, None),
-            NQLNMH: GeckoByteStructAccessor(self.struct, NQLNMH, QLNMHX, None),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, None),
-            MHXEKV: GeckoEnumStructAccessor(
-                self.struct, MHXEKV, HXEKVK, None, JVDQLA, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, ICXQIE, IDNIBX, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, DQLAII, QIEFXQ, BXTIAC, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, DQLAII, EGZUQE, IACQFF, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, DQLAII, CXQIEF, FFTTID, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, DQLAII, UQEXLS, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, DQLAII, VHFTHE, None),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, DQLAII, XLSXUJ, UBSSUH, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoWordStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoWordStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, JVYFCR, None, QIEFXQ, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, UTOPHU, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            TOPHUG: GeckoWordStructAccessor(self.struct, TOPHUG, OPHUGT, None),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, None),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, WSKWIV, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, KMLOIJ, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, LOIJUG, None, KMLOIJ, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, KMLOIJ, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, KMLOIJ, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, KMLOIJ, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, BQNRXC, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, SAKQXP),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, SAKQXP),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, SAKQXP),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, SAKQXP),
-            IKJPUN: GeckoByteStructAccessor(self.struct, IKJPUN, KJPUNR, SAKQXP),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, UNRJZT, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            NRJZTA: GeckoByteStructAccessor(self.struct, NRJZTA, RJZTAT, SAKQXP),
-            HTZBBE: GeckoBoolStructAccessor(self.struct, HTZBBE, JVHFTH, UQEXLS, None),
-            TZBBEK: GeckoByteStructAccessor(self.struct, TZBBEK, ZBBEKB, SAKQXP),
-            BBEKBD: GeckoByteStructAccessor(self.struct, BBEKBD, BEKBDF, SAKQXP),
-            EKBDFS: GeckoByteStructAccessor(self.struct, EKBDFS, KBDFSR, SAKQXP),
-            BDFSRO: GeckoEnumStructAccessor(
-                self.struct, BDFSRO, DFSROG, None, MDDPMX, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            DDPMXF: GeckoBoolStructAccessor(
-                self.struct, DDPMXF, DPMXFU, ICXQIE, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            PMXFUB: GeckoBoolStructAccessor(self.struct, PMXFUB, YIYWSK, ICXQIE, None),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-2-log-60.py
+++ b/src/geckolib/driver/packs/inxe-2-log-60.py
@@ -12,1108 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 468
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-AJVDQL = "".join(chr(c) for c in [105, 110, 88, 77])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 55])
-AMJMAO = 350
-AOAWBS = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 332
-AWBSIR = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BBEKBD = 479
-BDFSRO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-BDJQRJ = 297
-BEKBDF = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-BIAMJM = 284
-BJEUTO = "".join(chr(c) for c in [75, 53])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-BQNRXC = 324
-BQSNQL = 315
-BSIRYX = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-BVWVUB = 291
-BWJYKL = 275
-BXIBHZ = 464
-BXYBQS = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BYGDSB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 458
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = 328
-DDPMXF = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-DFSROG = 372
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 53])
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-DNIBXT = "".join(chr(c) for c in [51, 50, 75])
-DNQGVU = 320
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-DSBDJQ = 296
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-DUBSSU = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-DZXNQT = 448
-EAKSTS = 454
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-EKBDFS = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = 288
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-ELWUEU = 256
-EMCGET = 457
-EOCTHB = 308
-ETIXQV = 459
-EUTOPH = "".join(chr(c) for c in [75, 49, 48, 48])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FCRTFM = "".join(chr(c) for c in [70, 117, 108, 108])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FIKJPU = 329
-FJBIAM = 377
-FMNHTB = "".join(chr(c) for c in [75, 50, 48, 48])
-FSROGM = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-FUBJLO = 375
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = 351
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 52])
-GDSBDJ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-GKEAKS = 453
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-GTYIYW = 358
-GVUNXN = "".join(chr(c) for c in [80, 49, 76])
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [75, 56])
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-HUOJRJ = 305
-HWDAFI = 327
-HXEKVK = 287
-HZVOAC = 466
-IACQFF = "".join(chr(c) for c in [67, 69])
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-IBHZVO = 465
-IBXTIA = "".join(chr(c) for c in [54, 52, 75])
-IBXYBQ = 311
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [49, 54, 75])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = 463
-IIDNIB = 290
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-ILXWAJ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-INEJNI = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 460
-IYWSKW = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JJVYFC = 301
-JLOINE = "".join(chr(c) for c in [76, 73])
-JMAOAW = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-JMCBFE = 260
-JPUNRJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-JQRJJJ = 299
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [75, 54, 48, 48])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 325
-KBDFSR = 371
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 54])
-KFWRKI = 354
-KHTZBB = 477
-KINEJN = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KJPUNR = 330
-KMLOIJ = "".join(chr(c) for c in [80, 52, 76])
-KPHUOJ = 304
-KQTDKH = 475
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 455
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KWIVDN = "".join(chr(c) for c in [45, 45, 45])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 323
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-LOIJUG = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 479
-LXWAJV = "".join(chr(c) for c in [77, 73, 65])
-MAOAWB = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-MCVDSS = 469
-MDDPMX = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-MFZDGK = 451
-MHXEKV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-MLOIJU = "".join(chr(c) for c in [66, 76, 79])
-MNHTBJ = "".join(chr(c) for c in [75, 52, 48, 48])
-MNZMJI = 313
-MOUNBL = 273
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = 309
-NELWUE = 60
-NHTBJE = "".join(chr(c) for c in [75, 56, 53])
-NIBXTI = "".join(chr(c) for c in [52, 56, 75])
-NIBXYB = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-NKMLOI = "".join(chr(c) for c in [80, 52, 72])
-NMHXEK = 285
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [78, 65])
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 50])
-NRJZTA = 333
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 326
-NXNKML = "".join(chr(c) for c in [80, 51, 72])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OAWBSI = 283
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = 374
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-OIJUGS = "".join(chr(c) for c in [65, 85, 88])
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [75, 51, 48, 48])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = 331
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 50, 50])
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-QGVUNX = "".join(chr(c) for c in [80, 49, 72])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [105, 110, 89, 84])
-QLNMHX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-QSNQLN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-QTMFZD = 450
-QVXOIH = 461
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 473
-RJHIUS = 362
-RJJJVY = 300
-RJZTAT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ROGMDD = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-RURAZM = 472
-RXCHWD = "".join(chr(c) for c in [72, 84, 82])
-RYXBQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-SELHBQ = 322
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 57])
-SIFJBI = 352
-SIRYXB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = 376
-SNQLNM = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = 373
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-SSRURA = 471
-SSUHBV = "".join(chr(c) for c in [50, 53, 65])
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 56])
-SUHBVW = "".join(chr(c) for c in [51, 48, 65])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-TBJEUT = "".join(chr(c) for c in [75, 52])
-TDKHTZ = 476
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 48])
-TFMNHT = 357
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [85, 76])
-TIDUBS = "".join(chr(c) for c in [51, 79, 80])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 51])
-TOPHUG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-TSEMCG = 456
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = "".join(chr(c) for c in [53, 79, 80])
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-TZBBEK = 478
-UBJLOI = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-UBSSUH = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-UBYGDS = 294
-UGSELH = 321
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-UNXNKM = "".join(chr(c) for c in [80, 50, 76])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [75, 56, 48, 48])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-VDQLAI = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-VDSSRU = 470
-VHFTHE = 6
-VKZILX = 289
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 467
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-VUNXNK = "".join(chr(c) for c in [80, 50, 72])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VYFCRT = 316
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-WIVDNQ = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-WSKWIV = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-WVUBYG = 293
-XBQFYL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-XEKVKZ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [80, 51, 76])
-XNQTMF = 449
-XOIHBX = 462
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-XSJWMN = 282
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [68, 74, 83, 52])
-XYBQSN = 314
-YBQSNQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-YGDSBD = 295
-YIYWSK = 360
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = 361
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 452
-ZILXWA = "".join(chr(c) for c in [105, 110, 88, 69])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = 474
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49])
-ACQFFT = [TIACQF, IACQFF]
-BJLOIN = []
-BXTIAC = [IDNIBX, DNIBXT, NIBXTI, IBXTIA]
-CRTFMN = [YFCRTF, FCRTFM]
-FFTTID = [CBFEGZ, QFFTTI]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-HUGTYI = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-]
-IDUBSS = [TTIDUB, TIDUBS]
-IJUGSE = [
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    SJMCBF,
-    MLOIJU,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LOIJUG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    OIJUGS,
-]
-INELWU = [
-    SNQLNM,
-    YLJUIK,
-    UIKFWR,
-    BSIRYX,
-    SPBWJY,
-    QSNQLN,
-    NQLNMH,
-    LGQPLS,
-    BLKXSJ,
-    BQFYLJ,
-    RYXBQF,
-    MJMAOA,
-    TSIFJB,
-    YBQSNQ,
-    IRYXBQ,
-    QFYLJU,
-    XBQFYL,
-    AWBSIR,
-    IKFWRK,
-    AOAWBS,
-    JMAOAW,
-    LJUIKF,
-    RKINEJ,
-    JUIKFW,
-    MAOAWB,
-    YXBQFY,
-    SIRYXB,
-    WBSIRY,
-]
-IVDNQG = [KWIVDN, WIVDNQ]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JNIBXY = [HECVYY, EJNIBX, EJNIBX, EJNIBX]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-LAIIDN = [
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-    DQLAII,
-    QLAIID,
-]
-LOINEL = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    JLOINE,
-]
-MCBFEG = [ASSAKQ, SOOQNR]
-MXFUBJ = [GMDDPM, MDDPMX, DDPMXF, DPMXFU, PMXFUB]
-OINELW = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UHBVWV = [SSUHBV, SUHBVW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XCHWDA = [
-    NQGVUN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RXCHWD,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-ZTATDZ = [
-    NQGVUN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1121,285 +19,870 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return NELWUE
+        return 60
 
     @property
     def begin(self):
-        return ELWUEU
+        return 256
 
     @property
     def end(self):
-        return LWUEUH
+        return 479
 
     @property
     def all_device_keys(self):
-        return LOINEL
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return OINELW
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return INELWU
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, BIAMJM, ICXQIE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, AMJMAO, ICXQIE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JVHFTH, EGZUQE, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, XSJWMN, ICXQIE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, XSJWMN, AHEOCT, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QIEFXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, EGZUQE, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BIAMJM, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, BIAMJM, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, BIAMJM, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, BIAMJM, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, AMJMAO, EGZUQE, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, AMJMAO, CXQIEF, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, AMJMAO, UQEXLS, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, AMJMAO, VHFTHE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, QIEFXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, EGZUQE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, SIFJBI, EGZUQE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, GYOUSP, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, GYOUSP, AHEOCT, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, KFWRKI, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, LSPFTS, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, OAWBSI, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, OAWBSI, AHEOCT, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, OAWBSI, CXQIEF, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, ICXQIE, None),
-            EJNIBX: GeckoEnumStructAccessor(
-                self.struct, EJNIBX, NEJNIB, AHEOCT, JNIBXY, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            NIBXYB: GeckoWordStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, XYBQSN, ICXQIE, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, ICXQIE, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, AHEOCT, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, FYLJUI, ICXQIE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, FYLJUI, AHEOCT, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, FYLJUI, CXQIEF, None),
-            LNMHXE: GeckoWordStructAccessor(self.struct, LNMHXE, NMHXEK, None),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, None),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, None),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, LAIIDN, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, IIDNIB, ICXQIE, BXTIAC, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, IIDNIB, QIEFXQ, ACQFFT, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, IIDNIB, EGZUQE, FFTTID, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, IIDNIB, CXQIEF, IDUBSS, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, IIDNIB, UQEXLS, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, IIDNIB, VHFTHE, None),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, IIDNIB, XLSXUJ, UHBVWV, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoWordStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, None),
-            JJJVYF: GeckoWordStructAccessor(self.struct, JJJVYF, JJVYFC, None),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, CRTFMN, None, QIEFXQ, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, HUGTYI, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, IVDNQG, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, IJUGSE, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, IJUGSE, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, IJUGSE, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, IJUGSE, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, IJUGSE, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            QNRXCH: GeckoEnumStructAccessor(
-                self.struct, QNRXCH, NRXCHW, None, XCHWDA, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, SAKQXP),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, SAKQXP),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, SAKQXP),
-            IKJPUN: GeckoByteStructAccessor(self.struct, IKJPUN, KJPUNR, SAKQXP),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, SAKQXP),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, None, ZTATDZ, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, SAKQXP),
-            BEKBDF: GeckoBoolStructAccessor(self.struct, BEKBDF, JVHFTH, UQEXLS, None),
-            EKBDFS: GeckoByteStructAccessor(self.struct, EKBDFS, KBDFSR, SAKQXP),
-            BDFSRO: GeckoByteStructAccessor(self.struct, BDFSRO, DFSROG, SAKQXP),
-            FSROGM: GeckoByteStructAccessor(self.struct, FSROGM, SROGMD, SAKQXP),
-            ROGMDD: GeckoEnumStructAccessor(
-                self.struct, ROGMDD, OGMDDP, None, MXFUBJ, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            XFUBJL: GeckoBoolStructAccessor(
-                self.struct, XFUBJL, FUBJLO, ICXQIE, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            UBJLOI: GeckoBoolStructAccessor(self.struct, UBJLOI, SKWIVD, ICXQIE, None),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-2.py
+++ b/src/geckolib/driver/packs/inxe-2.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inxe-64k-cfg-57.py
+++ b/src/geckolib/driver/packs/inxe-64k-cfg-57.py
@@ -12,791 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-ACQFFT = 8
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-AJVDQL = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 3
-AOAWBS = 6
-AONPYY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-AWBSIR = 23
-BDJQRJ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-BFEGZU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-BJEUTO = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-BLKXSJ = 31
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQSNQL = 34
-BSIRYX = 8
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BSSUHB = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-BVWVUB = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-BWJYKL = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-BXTIAC = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-BXYBQS = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-BYGDSB = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-CCPQIP = 29
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-CRTFMN = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DJQRJJ = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DNIBXT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-DNQGVU = 57
-DQLAII = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-DSBDJQ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-DUBSSU = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 28
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-EJNIBX = 73
-EKCWAO = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-EKVKZI = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EUTOPH = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-EXLSXU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FCRTFM = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-FEFJTA = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FFTTID = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-FJBIAM = 74
-FJTACC = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-FMNHTB = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 52
-FWRKIN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = 82
-GDSBDJ = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-GTYIYW = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-GYOUSP = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-GZUQEX = 27
-HBVWVU = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 56
-HTBJEU = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-HUGTYI = 45
-HUOJRJ = 80
-HXEKVK = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-IBXTIA = "".join(chr(c) for c in [66, 76, 85, 69])
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [82, 69, 68])
-IDUBSS = 44
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IGYOUS = 35
-IIDNIB = "".join(chr(c) for c in [79, 70, 70])
-IKFWRK = 1
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-IRYXBQ = 10
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IUXFEF = 78
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-JBIAMJ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JEUTOP = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JIGYOU = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-JJJVYF = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-JJVYFC = "".join(chr(c) for c in [80, 68, 67])
-JMAOAW = 4
-JMCBFE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-JQRJJJ = "".join(chr(c) for c in [76, 65])
-JRJHIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JTACCP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JUTYEK = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JVDQLA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-JYKLGQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JYMOUN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KCWAON = 58
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-KLGQPL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KVKZIL = 4
-KWIVDN = 47
-KXSJWM = 25
-KZILXW = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-LAIIDN = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 26
-LIUXFE = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-LJUIKF = 72
-LKXSJW = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-LNMHXE = 64
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67, 69])
-LSXUJU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-LXWAJV = 5
-MAOAWB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-MCBFEG = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-MHXEKV = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-MJIGYO = 3
-MJMAOA = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-MJVHFT = 12
-MNHTBJ = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-MNZMJI = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MOUNBL = "".join(chr(c) for c in [70])
-NBLKXS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NHTBJE = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-NIBXTI = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-NMHXEK = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQJYMO = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-NRSJMC = 2
-NZMJIG = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-OAWBSI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = 60
-OOQNRS = "".join(chr(c) for c in [79, 119, 110])
-OUNBLK = "".join(chr(c) for c in [67])
-OUSPBW = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PBWJYK = 70
-PFTSIF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-PHUGTY = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [85, 76])
-POUYNQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PYYLIU = 61
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QFFTTI = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-QFYLJU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 30
-QJYMOU = 1
-QLNMHX = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-QNRSJM = 0
-QPLSPF = 51
-QRJJJV = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-QSNQLN = "".join(chr(c) for c in [65, 109, 80, 109])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 55
-RJJJVY = "".join(chr(c) for c in [77, 65, 65, 88])
-RKINEJ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-RTFMNH = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SAKQXP = 13
-SBDJQR = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-SIFJBI = 53
-SIRYXB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SJMCBF = 32
-SJWMNZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-SKSOKP = 41
-SKWIVD = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-SNQLNM = "".join(chr(c) for c in [50, 52, 104])
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-SPBWJY = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-SUHBVW = "".join(chr(c) for c in [65, 108, 112, 115])
-SXUJUT = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-TBJEUT = "".join(chr(c) for c in [73, 100, 111, 108])
-TFMNHT = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TIDUBS = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-TOPHUG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-TSIFJB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-TTIDUB = 7
-TYEKCW = "".join(chr(c) for c in [72, 105])
-TYIYWS = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-UBSSUH = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UBYGDS = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-UGTYIY = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-UHBVWV = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-UIKFWR = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UQEXLS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-USOOQN = 81
-USPBWJ = 68
-UTOPHU = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-UTYEKC = "".join(chr(c) for c in [76, 111])
-UXFEFJ = "".join(chr(c) for c in [80, 49])
-UYNQJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-VDQLAI = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-VWVUBY = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-VYFCRT = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 43
-WAONPY = 59
-WBSIRY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-WMNZMJ = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WRKINE = 76
-WSKWIV = 46
-WVUBYG = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-XBQFYL = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-XLSXUJ = 57
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-XTIACQ = "".join(chr(c) for c in [67, 89, 65, 78])
-XUJUTY = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-XWAJVD = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XYBQSN = 75
-YBQSNQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-YFCRTF = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-YGDSBD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-YKLGQP = 77
-YLIUXF = 62
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-YMOUNB = 33
-YNQJYM = 63
-YOUSPB = 66
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-YXBQFY = 71
-YYLIUX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZUQEXL = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BIAMJM = [IPOUYN, JBIAMJ]
-BQFYLJ = [JVHFTH, ZUQEXL, XBQFYL]
-CPQIPO = [PIPIVL, UXFEFJ]
-FEGZUQ = [JMCBFE, MCBFEG, CBFEGZ, BFEGZU]
-FTTIDU = [QFFTTI, FFTTID]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IACQFF = [IIDNIB, IDNIBX, DNIBXT, NIBXTI, IBXTIA, BXTIAC, XTIACQ, TIACQF]
-IBXYBQ = [VLASSA, JNIBXY, NIBXYB]
-ILXWAJ = [KZILXW, ZILXWA]
-INEJNI = [RKINEJ, KINEJN]
-IVDNQG = [OKPHUO]
-JWMNZM = [XSJWMN, SJWMNZ]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-NQLNMH = [JVHFTH, QSNQLN, SNQLNM]
-OPHUGT = [
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-]
-OQNRSJ = [SOOQNR, OOQNRS]
-OUYNQJ = [IPOUYN, POUYNQ]
-QEXLSX = [ZUQEXL, UQEXLS]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QLAIID = [VDQLAI, DQLAII]
-SPFTSI = [PLSPFT, LSPFTS]
-TACCPQ = [FJTACC, JTACCP]
-UJUTYE = [LSXUJU, SXUJUT, XUJUTY]
-UNBLKX = [MOUNBL, OUNBLK]
-VDNQGV = []
-WIVDNQ = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-WJYKLG = [IPOUYN, BWJYKL]
-XEKVKZ = [MHXEKV, HXEKVK]
-XFEFJT = [JVHFTH, UXFEFJ, PIPIVL]
-YEKCWA = [UTYEKC, TYEKCW]
-YIYWSK = [GTYIYW, TYIYWS, VLASSA, VLASSA]
-ZMJIGY = [MNZMJI, NZMJIG]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -804,186 +19,530 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return DNQGVU
+        return 57
 
     @property
     def output_keys(self):
-        return WIVDNQ
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QNRSJM, OQNRSJ, None, NRSJMC, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, FEGZUQ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, QEXLSX, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, None, UJUTYE, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, USOOQN, NRSJMC, YEKCWA, None, NRSJMC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, XFEFJT, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, TACCPQ, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, CCPQIP, None, CPQIPO, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoTempStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, UNBLKX, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, None, CPQIPO, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, JWMNZM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, USOOQN, MJIGYO, ZMJIGY, None, NRSJMC, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoTempStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, WJYKLG, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, BIAMJM, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoTimeStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTimeStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoTimeStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTimeStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BQFYLJ, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            QFYLJU: GeckoBoolStructAccessor(
-                self.struct, QFYLJU, FYLJUI, QNRSJM, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, LJUIKF, NRSJMC, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            JUIKFW: GeckoBoolStructAccessor(
-                self.struct, JUIKFW, LJUIKF, QNRSJM, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            UIKFWR: GeckoBoolStructAccessor(
-                self.struct, UIKFWR, LJUIKF, IKFWRK, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
             ),
-            KFWRKI: GeckoBoolStructAccessor(
-                self.struct, KFWRKI, LJUIKF, MJIGYO, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, IBXYBQ, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, USOOQN, IKFWRK, XEKVKZ, None, NRSJMC, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, USOOQN, KVKZIL, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, USOOQN, LXWAJV, ILXWAJ, None, NRSJMC, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            XWAJVD: GeckoBoolStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, QNRSJM, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, WAJVDQ, IKFWRK, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, WAJVDQ, NRSJMC, QLAIID, None, NRSJMC, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, WAJVDQ, MJIGYO, QLAIID, None, NRSJMC, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, WAJVDQ, KVKZIL, IACQFF, None, ACQFFT, QBMJVH
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
             ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, WAJVDQ, TTIDUB, FTTIDU, None, NRSJMC, QBMJVH
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
             ),
-            PHUGTY: GeckoBoolStructAccessor(
-                self.struct, PHUGTY, HUGTYI, IKFWRK, QBMJVH
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, HUGTYI, NRSJMC, YIYWSK, None, KVKZIL, QBMJVH
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
             ),
-            IYWSKW: GeckoBoolStructAccessor(
-                self.struct, IYWSKW, HUGTYI, KVKZIL, QBMJVH
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
             ),
-            YWSKWI: GeckoByteStructAccessor(self.struct, YWSKWI, WSKWIV, QBMJVH),
-            SKWIVD: GeckoBoolStructAccessor(
-                self.struct, SKWIVD, KWIVDN, QNRSJM, QBMJVH
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 45, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxe-64k-log-56.py
+++ b/src/geckolib/driver/packs/inxe-64k-log-56.py
@@ -12,899 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 271
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-ACQFFT = 7
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 51])
-AHEOCT = 1
-AIIDNI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-AJVDQL = "".join(chr(c) for c in [85, 76])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 464
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AONPYY = "".join(chr(c) for c in [78, 69, 87])
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 57])
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-AZMKQT = 479
-BDJQRJ = 357
-BFEGZU = 310
-BHZVOA = 475
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BJEUTO = 361
-BLKXSJ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-BMJVHF = 256
-BQFYLJ = 309
-BQSNQL = "".join(chr(c) for c in [105, 110, 88, 69])
-BSIRYX = 354
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = 296
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-BWJYKL = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BXTIAC = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-BXYBQS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BYGDSB = 316
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 49])
-CMCVDS = 478
-CPQIPO = 272
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-CRTFMN = "".join(chr(c) for c in [75, 51, 48, 48])
-CTHBSK = 307
-CVDSSR = 479
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(chr(c) for c in [83, 84, 79, 80])
-CXQIEF = 4
-DAFIKJ = 450
-DGKEAK = 462
-DJQRJJ = "".join(chr(c) for c in [75, 50, 48, 48])
-DNQGVU = 323
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-DSSRUR = "".join(chr(c) for c in [76, 73])
-DUBSSU = 295
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = 268
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-EKCWAO = 263
-ELHBQN = 333
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EUTOPH = 320
-EXLSXU = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-FCRTFM = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-FEFJTA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-FIKJPU = 451
-FJBIAM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-FJTACC = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FMNHTB = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-FTHECV = 319
-FTSIFJ = 284
-FTTIDU = 293
-FWRKIN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FZDGKE = 461
-GDSBDJ = "".join(chr(c) for c in [70, 117, 108, 108])
-GETIXQ = 468
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-GSELHB = 331
-GTYIYW = "".join(chr(c) for c in [80, 51, 76])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = 325
-HBSKSO = 303
-HBVWVU = 299
-HBXIBH = 473
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = 360
-HUGTYI = "".join(chr(c) for c in [80, 50, 76])
-HUOJRJ = 261
-HWDAFI = 449
-HXEKVK = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-IAMJMA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-IBXTIA = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-IBXYBQ = 288
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [51, 79, 80])
-IDUBSS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-IGYOUS = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-IIDNIB = "".join(chr(c) for c in [53, 79, 80])
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 52])
-ILXWAJ = "".join(chr(c) for c in [52, 56, 75])
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-IVDNQG = 322
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IYWSKW = "".join(chr(c) for c in [66, 76, 79])
-JBIAMJ = 350
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = 277
-JJJVYF = "".join(chr(c) for c in [75, 52])
-JJVYFC = "".join(chr(c) for c in [75, 53])
-JMAOAW = 351
-JMCBFE = 5
-JNIBXY = 287
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 53])
-JQRJJJ = "".join(chr(c) for c in [75, 52, 48, 48])
-JTACCP = 270
-JUGSEL = 330
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JVDQLA = "".join(chr(c) for c in [67, 69])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-JYKLGQ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JYMOUN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JZTATD = 455
-KCWAON = "".join(chr(c) for c in [73, 68, 76, 69])
-KEAKST = 463
-KFWRKI = 315
-KINEJN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-KJPUNR = 452
-KLGQPL = 352
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KPHUOJ = 306
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-KWIVDN = 321
-KXSJWM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-KZILXW = "".join(chr(c) for c in [49, 54, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-LHBQNR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-LIUXFE = 266
-LJUIKF = 311
-LNMHXE = "".join(chr(c) for c in [105, 110, 88, 77])
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 283
-LSXUJU = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-LXWAJV = "".join(chr(c) for c in [54, 52, 75])
-MAOAWB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = 467
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-MHXEKV = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-MJIGYO = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-MJMAOA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = 328
-MNHTBJ = 358
-MNZMJI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-MOUNBL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-NBLKXS = "".join(chr(c) for c in [77, 69, 68])
-NEJNIB = 285
-NHTBJE = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-NIBXTI = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-NIBXYB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NKMLOI = 327
-NMHXEK = "".join(chr(c) for c in [75, 54, 48, 48])
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NQJYMO = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NQLNMH = "".join(chr(c) for c in [68, 74, 83, 52])
-NQTMFZ = 459
-NRJZTA = 454
-NRSJMC = 3
-NRXCHW = 332
-NZMJIG = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-OACMCV = 477
-OAWBSI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = 472
-OIJUGS = 329
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 49, 76])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = 313
-OUSPBW = 279
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-PBWJYK = 280
-PFTSIF = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-PHUGTY = "".join(chr(c) for c in [80, 50, 72])
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-POUYNQ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-PQIPOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PUNRJZ = 453
-PYYLIU = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 364
-QFFTTI = 291
-QFYLJU = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-QGVUNX = 324
-QIEFXQ = 2
-QIPOUY = 273
-QJYMOU = 282
-QLAIID = "".join(chr(c) for c in [80, 50, 50])
-QLNMHX = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QNRXCH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-QRJJJV = "".join(chr(c) for c in [75, 56, 53])
-QSNQLN = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 256
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [75, 56])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 55])
-RKINEJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 48])
-RYXBQF = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-SELHBQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-SEMCGE = 466
-SIFJBI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SIRYXB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-SKSOKP = 304
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-SNQLNM = "".join(chr(c) for c in [77, 73, 65])
-SOKPHU = 305
-SPBWJY = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-SPFTSI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-SSUHBV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-STSEMC = 465
-SUHBVW = 297
-SXUJUT = 367
-TACCPQ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-TATDZX = 456
-TBJEUT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-TDZXNQ = 457
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [51, 48, 65])
-TIDUBS = 294
-TIXQVX = 469
-TMFZDG = 460
-TOPHUG = "".join(chr(c) for c in [80, 49, 72])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-TSIFJB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TYIYWS = "".join(chr(c) for c in [80, 52, 72])
-UBSSUH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-UGSELH = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-UGTYIY = "".join(chr(c) for c in [80, 51, 72])
-UHBVWV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-UIKFWR = 314
-UJUTYE = 262
-UNBLKX = "".join(chr(c) for c in [78, 79])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 54])
-UNXNKM = "".join(chr(c) for c in [72, 84, 82])
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-URAZMK = 56
-USOOQN = 260
-USPBWJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-UTOPHU = "".join(chr(c) for c in [78, 65])
-UTYEKC = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-VHFTHE = 6
-VKZILX = 290
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-VUBYGD = 301
-VUNXNK = 326
-VWVUBY = 300
-VXOIHB = 471
-VYFCRT = "".join(chr(c) for c in [75, 49, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-WAONPY = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-WBSIRY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 50])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-WJYKLG = 281
-WMNZMJ = 355
-WRKINE = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-WVUBYG = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-XBQFYL = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-XCHWDA = 448
-XEKVKZ = "".join(chr(c) for c in [105, 110, 89, 84])
-XFEFJT = 267
-XIBHZV = 474
-XLSXUJ = 365
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 470
-XSJWMN = 353
-XTIACQ = "".join(chr(c) for c in [50, 53, 65])
-XUJUTY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XYBQSN = 289
-YBQSNQ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YFCRTF = "".join(chr(c) for c in [75, 56, 48, 48])
-YGDSBD = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-YIYWSK = "".join(chr(c) for c in [80, 52, 76])
-YKLGQP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-YLJUIK = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YMOUNB = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YNQJYM = "".join(chr(c) for c in [67, 80, 79, 84])
-YOUSPB = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-YXBQFY = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-YYLIUX = 264
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ZILXWA = "".join(chr(c) for c in [51, 50, 75])
-ZMJIGY = 275
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 56])
-ZVOACM = 476
-ZXNQTM = 458
-BQNRXC = [
-    UTOPHU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    OQNRSJ,
-]
-DNIBXT = [IIDNIB, IDNIBX]
-DSBDJQ = [YGDSBD, GDSBDJ]
-EKVKZI = [
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-]
-FYLJUI = [HECVYY, QFYLJU, QFYLJU, QFYLJU]
-GYOUSP = [HECVYY, IGYOUS, IGYOUS, IGYOUS]
-IACQFF = [XTIACQ, TIACQF]
-JRJHIU = [ASSAKQ, UOJRJH, OJRJHI]
-LAIIDN = [OOQNRS, QLAIID]
-LKXSJW = [UNBLKX, QXPICX, NBLKXS, XPICXQ, BLKXSJ]
-NPYYLI = [KCWAON, CWAONP, WAONPY, AONPYY, ONPYYL]
-NXNKML = [
-    UTOPHU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    UNXNKM,
-]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-RURAZM = [
-    WRKINE,
-    MAOAWB,
-    AWBSIR,
-    TSIFJB,
-    MNZMJI,
-    FWRKIN,
-    RKINEJ,
-    YOUSPB,
-    UYNQJY,
-    AMJMAO,
-    FJBIAM,
-    LGQPLS,
-    YKLGQP,
-    IKFWRK,
-    IFJBIA,
-    MJMAOA,
-    IAMJMA,
-    SPFTSI,
-    WBSIRY,
-    PLSPFT,
-    GQPLSP,
-    AOAWBS,
-    RYXBQF,
-    OAWBSI,
-    QPLSPF,
-    BIAMJM,
-    SIFJBI,
-    PFTSIF,
-]
-SOOQNR = [ASSAKQ, UOJRJH]
-SRURAZ = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-SSRURA = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    UQEXLS,
-    EXLSXU,
-    LSXUJU,
-    DSSRUR,
-]
-TFMNHT = [
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-]
-TYEKCW = [JUTYEK, UTYEKC]
-VDQLAI = [AJVDQL, JVDQLA]
-VDSSRU = []
-WSKWIV = [
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IUSOOQ,
-    IYWSKW,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YWSKWI,
-]
-XWAJVD = [KZILXW, ZILXWA, ILXWAJ, LXWAJV]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -912,257 +19,766 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return URAZMK
+        return 56
 
     @property
     def begin(self):
-        return RAZMKQ
+        return 256
 
     @property
     def end(self):
-        return AZMKQT
+        return 479
 
     @property
     def all_device_keys(self):
-        return SSRURA
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return SRURAZ
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return RURAZM
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, SAKQXP),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, ICXQIE, JRJHIU, None, CXQIEF, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, QIEFXQ, JRJHIU, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, CXQIEF, JRJHIU, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, VHFTHE, JRJHIU, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, SOOQNR, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, ZUQEXL, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EXLSXU: GeckoWordStructAccessor(self.struct, EXLSXU, XLSXUJ, None),
-            LSXUJU: GeckoWordStructAccessor(self.struct, LSXUJU, SXUJUT, SAKQXP),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, ICXQIE, TYEKCW, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, NPYYLI, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            PYYLIU: GeckoTimeStructAccessor(self.struct, PYYLIU, YYLIUX, SAKQXP),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, SAKQXP),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UJUTYE, QIEFXQ, TYEKCW, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, NPYYLI, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            FEFJTA: GeckoTimeStructAccessor(self.struct, FEFJTA, EFJTAC, SAKQXP),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, SAKQXP),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, ICXQIE, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, QIEFXQ, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, NRSJMC, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, QIPOUY, CXQIEF, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, QIPOUY, JMCBFE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, JVHFTH, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, QJYMOU, NRSJMC, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, QJYMOU, JMCBFE, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, QJYMOU, VHFTHE, None),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, JMCBFE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, VHFTHE, None),
-            JWMNZM: GeckoWordStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, JVHFTH, AHEOCT, None),
-            NZMJIG: GeckoTempStructAccessor(self.struct, NZMJIG, ZMJIGY, None),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, None),
-            IGYOUS: GeckoEnumStructAccessor(
-                self.struct, IGYOUS, USOOQN, JMCBFE, GYOUSP, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, QIEFXQ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, OUSPBW, VHFTHE, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, QIEFXQ, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, WJYKLG, AHEOCT, None),
-            JYKLGQ: GeckoBoolStructAccessor(
-                self.struct, JYKLGQ, WJYKLG, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, JVHFTH, NRSJMC, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QJYMOU, ICXQIE, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, QJYMOU, AHEOCT, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, LSPFTS, NRSJMC, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, NRSJMC, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, CXQIEF, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, FTSIFJ, JMCBFE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FTSIFJ, VHFTHE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, NRSJMC, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JBIAMJ, CXQIEF, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, JBIAMJ, JMCBFE, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, JBIAMJ, VHFTHE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, QIEFXQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, NRSJMC, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, KLGQPL, NRSJMC, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, XSJWMN, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, XSJWMN, AHEOCT, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, ICXQIE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, PBWJYK, ICXQIE, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, LSPFTS, ICXQIE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, LSPFTS, AHEOCT, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, LSPFTS, CXQIEF, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, ICXQIE, None),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, BQFYLJ, AHEOCT, FYLJUI, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            YLJUIK: GeckoWordStructAccessor(self.struct, YLJUIK, LJUIKF, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, KFWRKI, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, KFWRKI, AHEOCT, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, JMAOAW, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, JMAOAW, AHEOCT, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, JMAOAW, CXQIEF, None),
-            INEJNI: GeckoWordStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, None),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, EKVKZI, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, ICXQIE, XWAJVD, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, VKZILX, QIEFXQ, VDQLAI, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, VKZILX, NRSJMC, LAIIDN, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, VKZILX, CXQIEF, DNIBXT, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, VKZILX, JMCBFE, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, VKZILX, VHFTHE, None),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, VKZILX, ACQFFT, IACQFF, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            CQFFTT: GeckoWordStructAccessor(self.struct, CQFFTT, QFFTTI, None),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, None),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, None),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, None),
-            SSUHBV: GeckoWordStructAccessor(self.struct, SSUHBV, SUHBVW, None),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, None),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoWordStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, DSBDJQ, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, TFMNHT, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            FMNHTB: GeckoWordStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, WSKWIV, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, WSKWIV, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, WSKWIV, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, WSKWIV, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, WSKWIV, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, NXNKML, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, SAKQXP),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, SAKQXP),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, SAKQXP),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, SAKQXP),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, SAKQXP),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, SAKQXP),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, BQNRXC, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-64k.py
+++ b/src/geckolib/driver/packs/inxe-64k.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inxe-cfg-10.py
+++ b/src/geckolib/driver/packs/inxe-cfg-10.py
@@ -12,316 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 32
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AKQXPI = 11
-AONPYY = 21
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-BFEGZU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-BLKXSJ = 55
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BSKSOK = 34
-BWJYKL = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-CBFEGZ = 46
-CCPQIP = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-CPQIPO = 33
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 19
-CXQIEF = 14
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 54
-EFXQGL = 24
-EGZUQE = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-EKCWAO = 1
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [80, 49])
-FEFJTA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-FEGZUQ = 16
-FJTACC = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GLRAHE = 26
-GQPLSP = "".join(chr(c) for c in [50, 52, 104])
-GYOUSP = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GZUQEX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-HBSKSO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 28
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HUOJRJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IGYOUS = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-IUSOOQ = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IUXFEF = 50
-IVLASS = "".join(chr(c) for c in [])
-JHIUSO = 15
-JIGYOU = "".join(
-    chr(c) for c in [85, 110, 99, 111, 110, 102, 105, 103, 117, 114, 101, 100]
-)
-JMCBFE = 44
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JYMOUN = 3
-KCWAON = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-KLGQPL = 22
-KPHUOJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 35
-LGQPLS = "".join(chr(c) for c in [65, 109, 80, 109])
-LIUXFE = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LKXSJW = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = 48
-LSXUJU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-MCBFEG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-MJIGYO = 57
-MJVHFT = 9
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MOUNBL = 7
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-NPYYLI = "".join(chr(c) for c in [67])
-NQJYMO = 5
-NRSJMC = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-NZMJIG = 2
-OCTHBS = 29
-OJRJHI = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OKPHUO = 36
-ONPYYL = "".join(chr(c) for c in [70])
-OOQNRS = 39
-OQNRSJ = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-OUNBLK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-OUSPBW = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-OUYNQJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-PBWJYK = 60
-PFTSIF = "".join(chr(c) for c in [76, 73])
-PHUOJR = 20
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-PQIPOU = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 17
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 58
-QJYMOU = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-QNRSJM = 40
-QXPICX = 12
-RAHEOC = 27
-RJHIUS = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-RSJMCB = 42
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SIFJBI = 10
-SJMCBF = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-SJWMNZ = 56
-SKSOKP = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SOKPHU = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-SOOQNR = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SPBWJY = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-SSAKQX = 10
-SXUJUT = 18
-TACCPQ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-THBSKS = 30
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TYEKCW = 47
-UJUTYE = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-UNBLKX = 8
-UOJRJH = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-UQEXLS = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-USOOQN = 37
-USPBWJ = 59
-UTYEKC = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UXFEFJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-UYNQJY = 4
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-WJYKLG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WMNZMJ = 1
-XFEFJT = 52
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 25
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XUJUTY = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YEKCWA = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-YKLGQP = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-YLIUXF = 23
-YMOUNB = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-YNQJYM = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YYLIUX = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-FTSIFJ = [PFTSIF]
-JRJHIU = [HUOJRJ, UOJRJH, OJRJHI]
-JTACCP = [XUJUTY, FJTACC]
-JUTYEK = [XUJUTY, UJUTYE]
-JYKLGQ = [BWJYKL, WJYKLG]
-KXSJWM = [JVHFTH, LKXSJW]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-POUYNQ = [XUJUTY, IPOUYN]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QPLSPF = [JVHFTH, LGQPLS, GQPLSP]
-SPFTSI = [BMJVHF, ASSAKQ, SAKQXP, KQXPIC, XPICXQ, ICXQIE]
-TSIFJB = []
-XLSXUJ = [PIPIVL, EXLSXU]
-YOUSPB = [JIGYOU, IGYOUS, GYOUSP]
-ZUQEXL = [EGZUQE, GZUQEX]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -329,110 +19,352 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return SIFJBI
+        return 10
 
     @property
     def output_keys(self):
-        return SPFTSI
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                9,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                10,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                11,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoByteStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, JRJHIU, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                14,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoBoolStructAccessor(
-                self.struct, RJHIUS, JHIUSO, HIUSOO, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 24, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 25, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 26, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 27, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 28, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 29, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 30, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 34, "ALL"
             ),
-            IUSOOQ: GeckoTempStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoWordStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoWordStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoWordStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, ZUQEXL, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 35, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, XLSXUJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 36, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, JUTYEK, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                20,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoTempStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, XLSXUJ, None, None, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 15, 0, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, PYYLIU, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 37, "ALL"
             ),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoTempStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoTempStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, JTACCP, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 39, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 40, "ALL"
             ),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, POUYNQ, None, None, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 42, "ALL"
             ),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, QBMJVH),
-            QJYMOU: GeckoTimeStructAccessor(self.struct, QJYMOU, JYMOUN, QBMJVH),
-            YMOUNB: GeckoTimeStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoTimeStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, None, KXSJWM, None, None, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 44, "ALL"
             ),
-            XSJWMN: GeckoBoolStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, HIUSOO, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 46, "ALL"
             ),
-            JWMNZM: GeckoBoolStructAccessor(
-                self.struct, JWMNZM, SJWMNZ, WMNZMJ, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                16,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(
-                self.struct, MNZMJI, SJWMNZ, NZMJIG, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 17, None, ["CP", "P1"], None, None, "ALL"
             ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, None, YOUSPB, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                18,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, JYKLGQ, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 47, "ALL"
             ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 19, None, ["CP", "P1"], None, None, "ALL"
             ),
-            PLSPFT: GeckoWordStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 21, None, ["F", "C"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 23, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 50, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 52, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                54,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 32, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 33, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                58,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                55,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 56, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 56, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 56, 2, "ALL"
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                57,
+                None,
+                ["Unconfigured", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 59, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                60,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                22,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 48, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-11.py
+++ b/src/geckolib/driver/packs/inxe-cfg-11.py
@@ -12,320 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 61
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AKQXPI = 11
-AONPYY = 21
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-BFEGZU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-BLKXSJ = 8
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BSKSOK = 34
-BWJYKL = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-CBFEGZ = 46
-CCPQIP = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-CPQIPO = 32
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 19
-CXQIEF = 14
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 54
-EFXQGL = 24
-EGZUQE = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-EKCWAO = 1
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [80, 49])
-FEFJTA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-FEGZUQ = 16
-FJBIAM = 11
-FJTACC = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GLRAHE = 26
-GQPLSP = 22
-GYOUSP = "".join(
-    chr(c) for c in [85, 110, 99, 111, 110, 102, 105, 103, 117, 114, 101, 100]
-)
-GZUQEX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-HBSKSO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 28
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HUOJRJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IGYOUS = 57
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IUSOOQ = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IUXFEF = 50
-IVLASS = "".join(chr(c) for c in [])
-JHIUSO = 15
-JIGYOU = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JMCBFE = 44
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JYKLGQ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-JYMOUN = 5
-KCWAON = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-KPHUOJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 35
-KXSJWM = 55
-LGQPLS = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-LIUXFE = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LKXSJW = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSXUJU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-MCBFEG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-MJIGYO = 2
-MJVHFT = 9
-MNZMJI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-MOUNBL = 3
-NBLKXS = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-NPYYLI = "".join(chr(c) for c in [67])
-NQJYMO = 4
-NRSJMC = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-NZMJIG = 1
-OCTHBS = 29
-OJRJHI = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OKPHUO = 36
-ONPYYL = "".join(chr(c) for c in [70])
-OOQNRS = 39
-OQNRSJ = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-OUNBLK = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-OUSPBW = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-OUYNQJ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-PBWJYK = 59
-PFTSIF = 48
-PHUOJR = 20
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [50, 52, 104])
-POUYNQ = 58
-PQIPOU = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 17
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 33
-QJYMOU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-QNRSJM = 40
-QPLSPF = "".join(chr(c) for c in [65, 109, 80, 109])
-QXPICX = 12
-RAHEOC = 27
-RJHIUS = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-RSJMCB = 42
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SJMCBF = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-SKSOKP = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SOKPHU = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-SOOQNR = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SPBWJY = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-SPFTSI = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-SSAKQX = 10
-SXUJUT = 18
-TACCPQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-THBSKS = 30
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(chr(c) for c in [76, 73])
-TYEKCW = 47
-UJUTYE = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-UNBLKX = 7
-UOJRJH = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-UQEXLS = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-USOOQN = 37
-UTYEKC = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UXFEFJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-WJYKLG = 60
-WMNZMJ = 56
-XFEFJT = 52
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 25
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-XUJUTY = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YEKCWA = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-YKLGQP = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-YLIUXF = 23
-YMOUNB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-YNQJYM = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-YOUSPB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YYLIUX = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-FTSIFJ = [BMJVHF, ASSAKQ, SAKQXP, KQXPIC, XPICXQ, ICXQIE]
-IFJBIA = []
-JRJHIU = [HUOJRJ, UOJRJH, OJRJHI]
-JTACCP = [XUJUTY, FJTACC]
-JUTYEK = [XUJUTY, UJUTYE]
-KLGQPL = [JYKLGQ, YKLGQP]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LSPFTS = [JVHFTH, QPLSPF, PLSPFT]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-SIFJBI = [TSIFJB]
-SJWMNZ = [JVHFTH, XSJWMN]
-USPBWJ = [GYOUSP, YOUSPB, OUSPBW]
-UYNQJY = [XUJUTY, OUYNQJ]
-XLSXUJ = [PIPIVL, EXLSXU]
-ZUQEXL = [EGZUQE, GZUQEX]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -333,111 +19,355 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return FJBIAM
+        return 11
 
     @property
     def output_keys(self):
-        return FTSIFJ
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                9,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                10,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                11,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoByteStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, JRJHIU, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                14,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoBoolStructAccessor(
-                self.struct, RJHIUS, JHIUSO, HIUSOO, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 24, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 25, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 26, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 27, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 28, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 29, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 30, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 34, "ALL"
             ),
-            IUSOOQ: GeckoTempStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoWordStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoWordStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoWordStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, ZUQEXL, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 35, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, XLSXUJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 36, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, JUTYEK, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                20,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoTempStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, XLSXUJ, None, None, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 15, 0, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, PYYLIU, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 37, "ALL"
             ),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoTempStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoTempStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, JTACCP, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 39, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 40, "ALL"
             ),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, POUYNQ, None, UYNQJY, None, None, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 42, "ALL"
             ),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, QBMJVH),
-            QJYMOU: GeckoTimeStructAccessor(self.struct, QJYMOU, JYMOUN, QBMJVH),
-            YMOUNB: GeckoTimeStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoTimeStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoTimeStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, SJWMNZ, None, None, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 44, "ALL"
             ),
-            JWMNZM: GeckoBoolStructAccessor(
-                self.struct, JWMNZM, WMNZMJ, HIUSOO, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 46, "ALL"
             ),
-            MNZMJI: GeckoBoolStructAccessor(
-                self.struct, MNZMJI, WMNZMJ, NZMJIG, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                16,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            ZMJIGY: GeckoBoolStructAccessor(
-                self.struct, ZMJIGY, WMNZMJ, MJIGYO, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 17, None, ["CP", "P1"], None, None, "ALL"
             ),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                18,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, KLGQPL, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 47, "ALL"
             ),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, LSPFTS, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 19, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SPFTSI: GeckoWordStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 21, None, ["F", "C"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 23, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 50, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 52, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                54,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 61, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 32, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 33, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                58,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                55,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 56, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 56, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 56, 2, "ALL"
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                57,
+                None,
+                ["Unconfigured", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 59, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                60,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                22,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 48, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-12.py
+++ b/src/geckolib/driver/packs/inxe-cfg-12.py
@@ -12,336 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AKQXPI = 11
-AONPYY = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-BFEGZU = 45
-BLKXSJ = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-CBFEGZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-CPQIPO = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-CXQIEF = 14
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-EFXQGL = 25
-EGZUQE = 47
-EKCWAO = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-FEFJTA = 51
-FEGZUQ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJBIAM = "".join(chr(c) for c in [76, 73])
-FJTACC = 53
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GLRAHE = 27
-GQPLSP = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-GYOUSP = 2
-GZUQEX = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 29
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = 37
-IAMJMA = 12
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 33
-IUSOOQ = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-IUXFEF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-IVLASS = "".join(chr(c) for c in [])
-JHIUSO = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-JIGYOU = 1
-JMCBFE = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-JRJHIU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JTACCP = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-JUTYEK = 19
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 56
-JYKLGQ = 60
-JYMOUN = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-KCWAON = 48
-KLGQPL = 61
-KPHUOJ = 36
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KXSJWM = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-LGQPLS = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-LKXSJW = 7
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = 23
-LSXUJU = 18
-MCBFEG = 43
-MJIGYO = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-MJVHFT = 9
-MOUNBL = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-NBLKXS = 3
-NPYYLI = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-NQJYMO = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-NRSJMC = 40
-NZMJIG = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-OCTHBS = 30
-OJRJHI = 21
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 20
-OOQNRS = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-OQNRSJ = 38
-OUNBLK = 5
-OUSPBW = 58
-OUYNQJ = 34
-PBWJYK = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-PFTSIF = "".join(chr(c) for c in [50, 52, 104])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-POUYNQ = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-PQIPOU = 62
-PYYLIU = 22
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-QNRSJM = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-QXPICX = 12
-RAHEOC = 28
-RJHIUS = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-RSJMCB = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SIFJBI = 49
-SJMCBF = 41
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SKSOKP = 31
-SOKPHU = 35
-SOOQNR = 0
-SPBWJY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-SPFTSI = "".join(chr(c) for c in [65, 109, 80, 109])
-SSAKQX = 10
-SXUJUT = "".join(chr(c) for c in [80, 49])
-TACCPQ = 55
-THBSKS = 15
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-TYEKCW = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-UJUTYE = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-UNBLKX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-UOJRJH = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-UQEXLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-USOOQN = 16
-USPBWJ = "".join(
-    chr(c) for c in [85, 110, 99, 111, 110, 102, 105, 103, 117, 114, 101, 100]
-)
-UTYEKC = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-UXFEFJ = 24
-UYNQJY = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = 1
-WJYKLG = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-WMNZMJ = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-XFEFJT = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = 8
-YKLGQP = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-YLIUXF = "".join(chr(c) for c in [67])
-YMOUNB = 4
-YNQJYM = 59
-YOUSPB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YYLIUX = "".join(chr(c) for c in [70])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = 57
-ZUQEXL = 17
-BIAMJM = []
-BWJYKL = [USPBWJ, SPBWJY, PBWJYK]
-CCPQIP = [UTYEKC, ACCPQI]
-EXLSXU = [UQEXLS, QEXLSX]
-FTSIFJ = [JVHFTH, SPFTSI, PFTSIF]
-HBSKSO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-HIUSOO = [JRJHIU, RJHIUS, JHIUSO]
-IFJBIA = [BMJVHF, ASSAKQ, SAKQXP, KQXPIC, XPICXQ, ICXQIE, CTHBSK]
-JBIAMJ = [FJBIAM]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LIUXFE = [YYLIUX, YLIUXF]
-MNZMJI = [JVHFTH, WMNZMJ]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QJYMOU = [UTYEKC, NQJYMO]
-QPLSPF = [LGQPLS, GQPLSP]
-XUJUTY = [PIPIVL, SXUJUT]
-YEKCWA = [UTYEKC, TYEKCW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -349,114 +19,365 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return IAMJMA
+        return 12
 
     @property
     def output_keys(self):
-        return IFJBIA
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                9,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                10,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                11,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                14,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, HIUSOO, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 25, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 26, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 27, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 28, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 29, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 30, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoBoolStructAccessor(
-                self.struct, IUSOOQ, USOOQN, SOOQNR, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 31, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 35, "ALL"
             ),
-            OOQNRS: GeckoTempStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoWordStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoWordStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoWordStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, EXLSXU, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 36, "ALL"
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 37, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, YEKCWA, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                21,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoTempStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XUJUTY, None, None, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 16, 0, "ALL"
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, LIUXFE, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 38, "ALL"
             ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoTempStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoTempStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, CCPQIP, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 40, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 41, "ALL"
             ),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, QJYMOU, None, None, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 43, "ALL"
             ),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoTimeStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoTimeStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoTimeStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, MNZMJI, None, None, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 45, "ALL"
             ),
-            NZMJIG: GeckoBoolStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, SOOQNR, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 47, "ALL"
             ),
-            MJIGYO: GeckoBoolStructAccessor(
-                self.struct, MJIGYO, ZMJIGY, JIGYOU, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                17,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            IGYOUS: GeckoBoolStructAccessor(
-                self.struct, IGYOUS, ZMJIGY, GYOUSP, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 18, None, ["CP", "P1"], None, None, "ALL"
             ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, BWJYKL, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                19,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 48, "ALL"
             ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, FTSIFJ, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 20, None, ["CP", "P1"], None, None, "ALL"
             ),
-            TSIFJB: GeckoWordStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 22, None, ["F", "C"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 24, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 51, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 53, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                55,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 62, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 33, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 34, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                59,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                56,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 57, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 57, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 57, 2, "ALL"
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                58,
+                None,
+                ["Unconfigured", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 60, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                61,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                23,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 49, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-13.py
+++ b/src/geckolib/driver/packs/inxe-cfg-13.py
@@ -12,339 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 53
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AKQXPI = 11
-AONPYY = 48
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-BFEGZU = 45
-BLKXSJ = 5
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BWJYKL = "".join(
-    chr(c) for c in [85, 110, 99, 111, 110, 102, 105, 103, 117, 114, 101, 100]
-)
-CBFEGZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-CCPQIP = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-CPQIPO = 55
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 24
-EFXQGL = 25
-EGZUQE = 47
-EKCWAO = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FEFJTA = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-FEGZUQ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJBIAM = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-FJTACC = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 23
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GLRAHE = 27
-GQPLSP = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-GYOUSP = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GZUQEX = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 29
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = 37
-IAMJMA = "".join(chr(c) for c in [76, 73])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IGYOUS = 57
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IUSOOQ = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-IUXFEF = "".join(chr(c) for c in [70])
-IVLASS = "".join(chr(c) for c in [])
-JBIAMJ = 49
-JHIUSO = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-JIGYOU = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JMAOAW = 13
-JMCBFE = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-JRJHIU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JTACCP = 51
-JUTYEK = 18
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-JYKLGQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-JYMOUN = 59
-KCWAON = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-KLGQPL = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-KPHUOJ = 36
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KXSJWM = 3
-LGQPLS = 60
-LIUXFE = 22
-LKXSJW = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LSXUJU = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-MCBFEG = 43
-MJVHFT = 9
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-NBLKXS = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-NPYYLI = 1
-NQJYMO = 34
-NRSJMC = 40
-NZMJIG = 56
-OCTHBS = 30
-OJRJHI = 21
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-OOQNRS = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-OQNRSJ = 38
-OUNBLK = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-PBWJYK = 58
-PFTSIF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-POUYNQ = 62
-PQIPOU = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-PYYLIU = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QJYMOU = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-QNRSJM = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-QPLSPF = 61
-QXPICX = 12
-RAHEOC = 28
-RJHIUS = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-RSJMCB = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SIFJBI = "".join(chr(c) for c in [50, 52, 104])
-SJMCBF = 41
-SJWMNZ = 7
-SKSOKP = 31
-SOKPHU = 35
-SOOQNR = 0
-SPBWJY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-SSAKQX = 10
-SXUJUT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-TACCPQ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-THBSKS = 15
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(chr(c) for c in [65, 109, 80, 109])
-TYEKCW = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-UJUTYE = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-UNBLKX = 4
-UOJRJH = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-UQEXLS = "".join(chr(c) for c in [80, 49])
-USOOQN = 16
-USPBWJ = 2
-UXFEFJ = "".join(chr(c) for c in [67])
-UYNQJY = 33
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-WJYKLG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-WMNZMJ = 8
-XLSXUJ = 17
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-YEKCWA = 19
-YLIUXF = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YMOUNB = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-YNQJYM = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-YOUSPB = 1
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YYLIUX = 20
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-ZUQEXL = 63
-AMJMAO = [IAMJMA]
-BIAMJM = [BMJVHF, ASSAKQ, SAKQXP, KQXPIC, XPICXQ, ICXQIE, CTHBSK]
-CWAONP = [EKCWAO, KCWAON]
-HBSKSO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-HIUSOO = [JRJHIU, RJHIUS, JHIUSO]
-IFJBIA = [JVHFTH, TSIFJB, SIFJBI]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-MJIGYO = [JVHFTH, ZMJIGY]
-MJMAOA = []
-MOUNBL = [EKCWAO, YMOUNB]
-QEXLSX = [JVHFTH, UQEXLS, PIPIVL]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QIPOUY = [EKCWAO, PQIPOU]
-SPFTSI = [PLSPFT, LSPFTS]
-UTYEKC = [PIPIVL, UQEXLS]
-XFEFJT = [IUXFEF, UXFEFJ]
-XUJUTY = [LSXUJU, SXUJUT]
-YKLGQP = [BWJYKL, WJYKLG, JYKLGQ]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -352,117 +19,375 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JMAOAW
+        return 13
 
     @property
     def output_keys(self):
-        return BIAMJM
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                9,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                10,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                11,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                14,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, HIUSOO, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 25, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 26, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 27, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 28, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 29, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 30, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoBoolStructAccessor(
-                self.struct, IUSOOQ, USOOQN, SOOQNR, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 31, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 35, "ALL"
             ),
-            OOQNRS: GeckoTempStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoWordStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoWordStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoWordStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, QEXLSX, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 36, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, None, XUJUTY, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 37, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, UTYEKC, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                21,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, CWAONP, None, None, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 16, 0, "ALL"
             ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoTempStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, YYLIUX, None, UTYEKC, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 38, "ALL"
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, XFEFJT, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 40, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 41, "ALL"
             ),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoTempStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoTempStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, QIPOUY, None, None, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 43, "ALL"
             ),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, QBMJVH),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, MOUNBL, None, None, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 45, "ALL"
             ),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoTimeStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoTimeStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoTimeStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoTimeStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, MJIGYO, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 47, "ALL"
             ),
-            JIGYOU: GeckoBoolStructAccessor(
-                self.struct, JIGYOU, IGYOUS, SOOQNR, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                63,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoBoolStructAccessor(
-                self.struct, GYOUSP, IGYOUS, YOUSPB, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                17,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(
-                self.struct, OUSPBW, IGYOUS, USPBWJ, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 18, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, YKLGQP, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                19,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 48, "ALL"
             ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 20, None, ["CP", "P1"], None, None, "ALL"
             ),
-            FJBIAM: GeckoWordStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 22, None, ["F", "C"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 24, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 51, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 53, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                55,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 62, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 33, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 34, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                59,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                56,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 57, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 57, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 57, 2, "ALL"
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                58,
+                None,
+                ["Unconfigured", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 60, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                61,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                23,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 49, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-50.py
+++ b/src/geckolib/driver/packs/inxe-cfg-50.py
@@ -12,467 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = 50
-AKQXPI = 14
-AMJMAO = "".join(chr(c) for c in [67, 69])
-AOAWBS = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-AONPYY = 85
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-AWBSIR = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = 51
-BLKXSJ = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-BQSNQL = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-BSIRYX = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-BSKSOK = 19
-BWJYKL = "".join(chr(c) for c in [70])
-BXYBQS = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-CBFEGZ = 46
-CPQIPO = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = 17
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-EKCWAO = 55
-EKVKZI = 34
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = 50
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 47
-FJBIAM = 81
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 74
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GLRAHE = 38
-GQPLSP = 35
-GYOUSP = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-GZUQEX = 48
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = 79
-IAMJMA = "".join(chr(c) for c in [85, 76])
-IBXYBQ = 3
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IKFWRK = 75
-ILXWAJ = 68
-INEJNI = 76
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 59
-IRYXBQ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVLASS = "".join(chr(c) for c in [])
-JBIAMJ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-JHIUSO = 25
-JIGYOU = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-JMAOAW = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-JMCBFE = 45
-JNIBXY = 1
-JRJHIU = 24
-JTACCP = 27
-JUIKFW = 10
-JUTYEK = 84
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-JYMOUN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-KINEJN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-KLGQPL = 31
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 20
-KVKZIL = "".join(chr(c) for c in [65, 109, 80, 109])
-KXSJWM = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LGQPLS = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-LKXSJW = 28
-LNMHXE = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LSXUJU = 83
-MAOAWB = 52
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-MJIGYO = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-MJVHFT = 12
-MOUNBL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NIBXYB = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQJYMO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQLNMH = 77
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-OAWBSI = 53
-OCTHBS = 41
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 21
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 42
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 82
-OUSPBW = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-OUYNQJ = 60
-PBWJYK = 33
-PFTSIF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-PHUOJR = 22
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 70
-POUYNQ = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFYLJU = 6
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-QJYMOU = 64
-QLNMHX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-QNRSJM = 43
-QPLSPF = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-QXPICX = 15
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RKINEJ = 86
-RSJMCB = 44
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SNQLNM = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-SPFTSI = 72
-SSAKQX = 13
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-THBSKS = 18
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-TYEKCW = 54
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(chr(c) for c in [80, 49])
-UOJRJH = 23
-UQEXLS = 49
-USOOQN = 26
-USPBWJ = 1
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [50, 52, 104])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = 78
-WJYKLG = "".join(chr(c) for c in [67])
-WMNZMJ = 29
-WRKINE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-XBQFYL = 4
-XEKVKZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 37
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XYBQSN = 80
-YBQSNQ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YLIUXF = 2
-YLJUIK = 8
-YMOUNB = 66
-YNQJYM = 62
-YOUSPB = 67
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ZMJIGY = 30
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-CCPQIP = [TACCPQ, ACCPQI]
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-FWRKIN = [JVHFTH, KFWRKI]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-IGYOUS = [MJIGYO, JIGYOU]
-JYKLGQ = [BWJYKL, WJYKLG]
-KZILXW = [JVHFTH, KVKZIL, VKZILX]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LXWAJV = [
-    BMJVHF,
-    ASSAKQ,
-    SAKQXP,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-MJMAOA = [IAMJMA, AMJMAO]
-MNZMJI = [PIPIVL, UNBLKX]
-NBLKXS = [JVHFTH, UNBLKX, PIPIVL]
-NMHXEK = [IVLASS, QLNMHX, LNMHXE]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QSNQLN = [YBQSNQ, BQSNQL]
-SIFJBI = [MJIGYO, TSIFJB]
-SIRYXB = [MJIGYO, BSIRYX]
-SJWMNZ = [KXSJWM, XSJWMN]
-WAJVDQ = []
-XUJUTY = [
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    SXUJUT,
-]
-XWAJVD = [SXUJUT]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -480,165 +19,657 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return AJVDQL
+        return 50
 
     @property
     def output_keys(self):
-        return LXWAJV
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, LASSAK, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, LASSAK, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 41, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, LASSAK, None, None, QBMJVH
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, LASSAK, None, None, QBMJVH
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, LASSAK, None, None, QBMJVH
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, LASSAK, None, None, QBMJVH
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, LASSAK, None, None, QBMJVH
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                24,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 42, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 43, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 44, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 45, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 46, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 47, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 48, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 49, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 50, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                83,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 84, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CPQIPO: GeckoTempStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoWordStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoWordStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoWordStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, NBLKXS, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, SJWMNZ, None, None, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 85, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, WMNZMJ, None, MNZMJI, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, None, IGYOUS, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, JYKLGQ, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 57, "ALL"
             ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, MNZMJI, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 59, "ALL"),
+            "CpOnTimeDuringOT": GeckoWordStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 60, "ALL"
             ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoTempStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoTempStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, SIFJBI, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoWordStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 62, "ALL"
             ),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, MJMAOA, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoWordStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 64, "ALL"
             ),
-            JMAOAW: GeckoByteStructAccessor(self.struct, JMAOAW, MAOAWB, QBMJVH),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, QBMJVH),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, SIRYXB, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 66, "ALL"
             ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoTimeStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTimeStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTimeStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoTimeStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, FWRKIN, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                82,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(
-                self.struct, WRKINE, RKINEJ, YYLIUX, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            KINEJN: GeckoBoolStructAccessor(
-                self.struct, KINEJN, INEJNI, YLIUXF, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            NEJNIB: GeckoBoolStructAccessor(
-                self.struct, NEJNIB, INEJNI, YYLIUX, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            EJNIBX: GeckoBoolStructAccessor(
-                self.struct, EJNIBX, INEJNI, JNIBXY, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 67, "ALL"
             ),
-            NIBXYB: GeckoBoolStructAccessor(
-                self.struct, NIBXYB, INEJNI, IBXYBQ, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, QSNQLN, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, None, NMHXEK, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, KZILXW, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 70, "ALL"
             ),
-            ZILXWA: GeckoWordStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 72, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                74,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 81, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                78,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                75,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 86, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 76, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 76, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 76, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 76, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                80,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                77,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 79, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 68, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-51.py
+++ b/src/geckolib/driver/packs/inxe-cfg-51.py
@@ -12,473 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = 64
-AKQXPI = 14
-AMJMAO = 77
-AOAWBS = "".join(chr(c) for c in [67, 69])
-AONPYY = 81
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-AWBSIR = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BLKXSJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-BQSNQL = 3
-BSIRYX = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-BSKSOK = 18
-BWJYKL = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BXYBQS = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-CBFEGZ = 45
-CPQIPO = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = 26
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = 82
-EKCWAO = 55
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = 49
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 46
-FJBIAM = 70
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 66
-FWRKIN = 10
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-GLRAHE = 38
-GYOUSP = 30
-GZUQEX = 47
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IAMJMA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-IGYOUS = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-IKFWRK = 8
-ILXWAJ = "".join(chr(c) for c in [65, 109, 80, 109])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IRYXBQ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVLASS = "".join(chr(c) for c in [])
-JBIAMJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-JHIUSO = 24
-JMAOAW = 51
-JMCBFE = 44
-JNIBXY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-JRJHIU = 23
-JTACCP = 27
-JUIKFW = 6
-JUTYEK = 80
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 28
-JYKLGQ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-KINEJN = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-KLGQPL = "".join(chr(c) for c in [70])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 19
-KVKZIL = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-KXSJWM = "".join(chr(c) for c in [80, 49])
-KZILXW = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-LGQPLS = "".join(chr(c) for c in [67])
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LKXSJW = 78
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-LSXUJU = 79
-LXWAJV = "".join(chr(c) for c in [50, 52, 104])
-MAOAWB = "".join(chr(c) for c in [85, 76])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = 73
-MJIGYO = 29
-MJMAOA = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-MJVHFT = 12
-MNZMJI = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NBLKXS = 62
-NEJNIB = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NIBXYB = 72
-NMHXEK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQJYMO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-NQLNMH = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-OCTHBS = 50
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 41
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 61
-OUSPBW = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PBWJYK = 63
-PFTSIF = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PHUOJR = 21
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 31
-POUYNQ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFYLJU = 3
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-QJYMOU = 59
-QLAIID = 51
-QLNMHX = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-QNRSJM = 42
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QSNQLN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-QXPICX = 15
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RKINEJ = 71
-RSJMCB = 43
-RYXBQF = 74
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SIFJBI = 68
-SIRYXB = 53
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SNQLNM = 76
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SPFTSI = 35
-SSAKQX = 13
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-TYEKCW = 54
-UIKFWR = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 75
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = 52
-WJYKLG = 1
-WMNZMJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 37
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XYBQSN = 1
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YKLGQP = 33
-YLIUXF = 2
-YLJUIK = 4
-YMOUNB = 60
-YNQJYM = 58
-YOUSPB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 34
-ZMJIGY = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BIAMJM = [YOUSPB, JBIAMJ]
-CCPQIP = [TACCPQ, ACCPQI]
-DQLAII = []
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-EKVKZI = [IVLASS, HXEKVK, XEKVKZ]
-GQPLSP = [KLGQPL, LGQPLS]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-INEJNI = [JVHFTH, KINEJN]
-JIGYOU = [PIPIVL, KXSJWM]
-JVDQLA = [
-    BMJVHF,
-    ASSAKQ,
-    SAKQXP,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LNMHXE = [NQLNMH, QLNMHX]
-NZMJIG = [WMNZMJ, MNZMJI]
-OAWBSI = [MAOAWB, AOAWBS]
-OUYNQJ = [QIPOUY, IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-USPBWJ = [YOUSPB, OUSPBW]
-VDQLAI = [SXUJUT]
-XBQFYL = [YOUSPB, YXBQFY]
-XSJWMN = [JVHFTH, KXSJWM, PIPIVL]
-XUJUTY = [
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    SXUJUT,
-]
-XWAJVD = [JVHFTH, ILXWAJ, LXWAJV]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -486,167 +19,664 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return QLAIID
+        return 51
 
     @property
     def output_keys(self):
-        return JVDQLA
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, LASSAK, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, LASSAK, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, LASSAK, None, None, QBMJVH
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, LASSAK, None, None, QBMJVH
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, LASSAK, None, None, QBMJVH
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, LASSAK, None, None, QBMJVH
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, LASSAK, None, None, QBMJVH
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, OUYNQJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoByteStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, XSJWMN, None, None, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, NZMJIG, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, None, JIGYOU, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            IGYOUS: GeckoEnumStructAccessor(
-                self.struct, IGYOUS, GYOUSP, None, USPBWJ, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoTempStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, JIGYOU, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoTempStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoTempStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, BIAMJM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, OAWBSI, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, QBMJVH),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, XBQFYL, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTimeStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoTimeStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoTimeStructAccessor(self.struct, UIKFWR, IKFWRK, QBMJVH),
-            KFWRKI: GeckoTimeStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, INEJNI, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            NEJNIB: GeckoBoolStructAccessor(
-                self.struct, NEJNIB, EJNIBX, YYLIUX, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            JNIBXY: GeckoBoolStructAccessor(
-                self.struct, JNIBXY, NIBXYB, YLIUXF, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXYBQ: GeckoBoolStructAccessor(
-                self.struct, IBXYBQ, NIBXYB, YYLIUX, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            BXYBQS: GeckoBoolStructAccessor(
-                self.struct, BXYBQS, NIBXYB, XYBQSN, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            YBQSNQ: GeckoBoolStructAccessor(
-                self.struct, YBQSNQ, NIBXYB, BQSNQL, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, LNMHXE, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, EKVKZI, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            KVKZIL: GeckoByteStructAccessor(self.struct, KVKZIL, VKZILX, QBMJVH),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, XWAJVD, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            WAJVDQ: GeckoWordStructAccessor(self.struct, WAJVDQ, AJVDQL, QBMJVH),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-52.py
+++ b/src/geckolib/driver/packs/inxe-cfg-52.py
@@ -12,490 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-AJVDQL = "".join(chr(c) for c in [65, 109, 80, 109])
-AKQXPI = 14
-AMJMAO = 70
-AOAWBS = 77
-AONPYY = 81
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-AWBSIR = 51
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = 68
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BQSNQL = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-BSIRYX = "".join(chr(c) for c in [67, 69])
-BSKSOK = 18
-BWJYKL = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-BXYBQS = 82
-CBFEGZ = 45
-CPQIPO = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = 26
-DNIBXT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-DQLAII = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = 71
-EKCWAO = 55
-EKVKZI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = 49
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 46
-FJBIAM = 66
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 31
-FWRKIN = 6
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-GYOUSP = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-GZUQEX = 47
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-IAMJMA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-IBXYBQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IIDNIB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IKFWRK = 4
-ILXWAJ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-INEJNI = 10
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IRYXBQ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVLASS = "".join(chr(c) for c in [])
-JBIAMJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JHIUSO = 24
-JIGYOU = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JMCBFE = 44
-JNIBXY = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-JRJHIU = 23
-JTACCP = 27
-JUIKFW = 3
-JUTYEK = 80
-JVDQLA = "".join(chr(c) for c in [50, 52, 104])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 78
-JYKLGQ = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JYMOUN = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-KINEJN = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-KLGQPL = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 19
-KVKZIL = 73
-KXSJWM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KZILXW = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-LAIIDN = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-LGQPLS = 1
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-LKXSJW = 61
-LNMHXE = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67])
-LSXUJU = 79
-LXWAJV = 75
-MAOAWB = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MJIGYO = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-MJMAOA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-MJVHFT = 12
-MOUNBL = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-NBLKXS = 60
-NEJNIB = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-NIBXTI = 4
-NMHXEK = 76
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQJYMO = "".join(chr(c) for c in [72, 105])
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-OAWBSI = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-OCTHBS = 50
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 41
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 59
-PBWJYK = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-PFTSIF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-PHUOJR = 21
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70])
-POUYNQ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFYLJU = 74
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-QLAIID = 64
-QLNMHX = 3
-QNRSJM = 42
-QPLSPF = 33
-QSNQLN = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QXPICX = 15
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RKINEJ = 8
-RSJMCB = 43
-RYXBQF = 52
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SIFJBI = 35
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SNQLNM = 1
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = 30
-SSAKQX = 13
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 52
-TSIFJB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-TYEKCW = 54
-UIKFWR = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-USPBWJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 34
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = "".join(chr(c) for c in [85, 76])
-WMNZMJ = "".join(chr(c) for c in [80, 49])
-WRKINE = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-XBQFYL = 53
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 37
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = 62
-XWAJVD = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-YBQSNQ = 72
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YKLGQP = 63
-YLIUXF = 2
-YMOUNB = 58
-YNQJYM = "".join(chr(c) for c in [76, 111])
-YOUSPB = 29
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = 28
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BXTIAC = [SXUJUT]
-CCPQIP = [TACCPQ, ACCPQI]
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-IBXTIA = [
-    BMJVHF,
-    ASSAKQ,
-    SAKQXP,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-IDNIBX = [AIIDNI, IIDNIB]
-IGYOUS = [MJIGYO, JIGYOU]
-JMAOAW = [PBWJYK, MJMAOA]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-MNZMJI = [JVHFTH, WMNZMJ, PIPIVL]
-NIBXYB = [JVHFTH, JNIBXY]
-OUSPBW = [PIPIVL, WMNZMJ]
-OUYNQJ = [QIPOUY, IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QJYMOU = [YNQJYM, NQJYMO]
-SIRYXB = [WBSIRY, BSIRYX]
-SPFTSI = [PLSPFT, LSPFTS]
-VDQLAI = [JVHFTH, AJVDQL, JVDQLA]
-WJYKLG = [PBWJYK, BWJYKL]
-XEKVKZ = [MHXEKV, HXEKVK]
-XTIACQ = []
-XUJUTY = [
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    SXUJUT,
-]
-YLJUIK = [PBWJYK, FYLJUI]
-ZILXWA = [IVLASS, VKZILX, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -503,176 +19,680 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return TIACQF
+        return 52
 
     @property
     def output_keys(self):
-        return IBXTIA
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, LASSAK, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, LASSAK, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, LASSAK, None, None, QBMJVH
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, LASSAK, None, None, QBMJVH
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, LASSAK, None, None, QBMJVH
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, LASSAK, None, None, QBMJVH
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, LASSAK, None, None, QBMJVH
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, OUYNQJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, AONPYY, YLIUXF, QJYMOU, None, YLIUXF, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, MNZMJI, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, None, IGYOUS, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, OUSPBW, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, None, WJYKLG, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, OUSPBW, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, JMAOAW, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SIRYXB, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            LJUIKF: GeckoByteStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoTimeStructAccessor(self.struct, UIKFWR, IKFWRK, QBMJVH),
-            KFWRKI: GeckoTimeStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoTimeStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoTimeStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, NIBXYB, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXYBQ: GeckoBoolStructAccessor(
-                self.struct, IBXYBQ, BXYBQS, YYLIUX, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            XYBQSN: GeckoBoolStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, YLIUXF, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            BQSNQL: GeckoBoolStructAccessor(
-                self.struct, BQSNQL, YBQSNQ, YYLIUX, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            QSNQLN: GeckoBoolStructAccessor(
-                self.struct, QSNQLN, YBQSNQ, SNQLNM, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            NQLNMH: GeckoBoolStructAccessor(
-                self.struct, NQLNMH, YBQSNQ, QLNMHX, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, NMHXEK, None, XEKVKZ, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, ZILXWA, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            ILXWAJ: GeckoByteStructAccessor(self.struct, ILXWAJ, LXWAJV, QBMJVH),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, None, VDQLAI, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            DQLAII: GeckoWordStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AONPYY, SNQLNM, IDNIBX, None, YLIUXF, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            DNIBXT: GeckoBoolStructAccessor(
-                self.struct, DNIBXT, AONPYY, NIBXTI, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-53.py
+++ b/src/geckolib/driver/packs/inxe-cfg-53.py
@@ -12,465 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 29
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-AOAWBS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AONPYY = 60
-AWBSIR = 1
-BIAMJM = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-BLKXSJ = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-BQSNQL = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BSIRYX = 3
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BWJYKL = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-BXYBQS = 4
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-CPQIPO = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 59
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-EFXQGL = 36
-EGZUQE = 27
-EJNIBX = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-EKCWAO = 58
-EKVKZI = 46
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = 57
-FEFJTA = 28
-FEGZUQ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-FWRKIN = "".join(chr(c) for c in [65, 109, 80, 109])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-GYOUSP = 51
-GZUQEX = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 56
-HUOJRJ = 80
-HXEKVK = 45
-IBXYBQ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-ICXQIE = 16
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = 10
-IGYOUS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-IKFWRK = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-INEJNI = 64
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-IRYXBQ = 76
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IUXFEF = "".join(chr(c) for c in [80, 49])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = 71
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JIGYOU = 77
-JMAOAW = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-JMCBFE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JNIBXY = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-JRJHIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JUIKFW = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-JUTYEK = "".join(chr(c) for c in [76, 111])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 68
-JYKLGQ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-JYMOUN = 33
-KCWAON = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-KFWRKI = 34
-KINEJN = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-KLGQPL = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KXSJWM = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LIUXFE = 78
-LKXSJW = 35
-LNMHXE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = 4
-LSXUJU = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-MAOAWB = 72
-MCBFEG = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-MHXEKV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-MJIGYO = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-MJMAOA = 82
-MJVHFT = 12
-MNZMJI = 70
-MOUNBL = "".join(chr(c) for c in [67])
-NBLKXS = 31
-NEJNIB = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NMHXEK = 44
-NPYYLI = 61
-NQJYMO = 1
-NQLNMH = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-NRSJMC = 2
-NZMJIG = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-OAWBSI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-OOQNRS = "".join(chr(c) for c in [79, 119, 110])
-OUSPBW = "".join(chr(c) for c in [67, 69])
-OUYNQJ = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-PBWJYK = 52
-PFTSIF = 6
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-PQIPOU = 30
-PYYLIU = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-QFYLJU = 73
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-QJYMOU = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QLNMHX = 43
-QNRSJM = 0
-QPLSPF = 3
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 55
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-RYXBQF = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-SAKQXP = 13
-SIFJBI = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SIRYXB = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-SJMCBF = 32
-SJWMNZ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SKSOKP = 41
-SNQLNM = 5
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-SPBWJY = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-SPFTSI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SXUJUT = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-TACCPQ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = 8
-UIKFWR = 75
-UJUTYE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-UNBLKX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-USOOQN = 81
-UTYEKC = "".join(chr(c) for c in [72, 105])
-UYNQJY = 63
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-WJYKLG = 53
-WMNZMJ = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-WRKINE = "".join(chr(c) for c in [50, 52, 104])
-XEKVKZ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-XFEFJT = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-XLSXUJ = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = 66
-XYBQSN = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-YBQSNQ = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-YEKCWA = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-YKLGQP = 74
-YLIUXF = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-YLJUIK = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-YMOUNB = "".join(chr(c) for c in [70])
-YNQJYM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-YOUSPB = "".join(chr(c) for c in [85, 76])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-YYLIUX = 62
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 53
-ZUQEXL = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BFEGZU = [JMCBFE, MCBFEG, CBFEGZ]
-CCPQIP = [PIPIVL, IUXFEF]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IAMJMA = [JVHFTH, BIAMJM]
-JTACCP = [EFJTAC, FJTACC]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-KVKZIL = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-KZILXW = []
-LGQPLS = [QIPOUY, KLGQPL]
-LJUIKF = [VLASSA, FYLJUI, YLJUIK]
-NIBXYB = [EJNIBX, JNIBXY]
-OQNRSJ = [SOOQNR, OOQNRS]
-OUNBLK = [YMOUNB, MOUNBL]
-POUYNQ = [QIPOUY, IPOUYN]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QSNQLN = [YBQSNQ, BQSNQL]
-RKINEJ = [JVHFTH, FWRKIN, WRKINE]
-TYEKCW = [JUTYEK, UTYEKC]
-UQEXLS = [GZUQEX, ZUQEXL]
-USPBWJ = [YOUSPB, OUSPBW]
-UXFEFJ = [JVHFTH, IUXFEF, PIPIVL]
-VKZILX = [OKPHUO]
-XBQFYL = [RYXBQF, YXBQFY]
-XUJUTY = [XLSXUJ, LSXUJU, SXUJUT]
-ZMJIGY = [QIPOUY, NZMJIG]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -478,151 +19,450 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return ZILXWA
+        return 53
 
     @property
     def output_keys(self):
-        return KVKZIL
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QNRSJM, OQNRSJ, None, NRSJMC, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, BFEGZU, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, EGZUQE, None, UQEXLS, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, EXLSXU, None, XUJUTY, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, USOOQN, NRSJMC, TYEKCW, None, NRSJMC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, UXFEFJ, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            XFEFJT: GeckoEnumStructAccessor(
-                self.struct, XFEFJT, FEFJTA, None, JTACCP, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, CCPQIP, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, POUYNQ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoTempStructAccessor(self.struct, YNQJYM, NQJYMO, QBMJVH),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, OUNBLK, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, NBLKXS, None, CCPQIP, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoTempStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoTempStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, ZMJIGY, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoEnumStructAccessor(
-                self.struct, IGYOUS, GYOUSP, None, USPBWJ, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoByteStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, LGQPLS, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            GQPLSP: GeckoByteStructAccessor(self.struct, GQPLSP, QPLSPF, QBMJVH),
-            PLSPFT: GeckoTimeStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoTimeStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoTimeStructAccessor(self.struct, FTSIFJ, TSIFJB, QBMJVH),
-            SIFJBI: GeckoTimeStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, IAMJMA, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            AMJMAO: GeckoBoolStructAccessor(
-                self.struct, AMJMAO, MJMAOA, QNRSJM, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            JMAOAW: GeckoBoolStructAccessor(
-                self.struct, JMAOAW, MAOAWB, NRSJMC, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            AOAWBS: GeckoBoolStructAccessor(
-                self.struct, AOAWBS, MAOAWB, QNRSJM, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            OAWBSI: GeckoBoolStructAccessor(
-                self.struct, OAWBSI, MAOAWB, AWBSIR, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            WBSIRY: GeckoBoolStructAccessor(
-                self.struct, WBSIRY, MAOAWB, BSIRYX, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, XBQFYL, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, LJUIKF, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            JUIKFW: GeckoByteStructAccessor(self.struct, JUIKFW, UIKFWR, QBMJVH),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, RKINEJ, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            KINEJN: GeckoWordStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, USOOQN, AWBSIR, NIBXYB, None, NRSJMC, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXYBQ: GeckoBoolStructAccessor(
-                self.struct, IBXYBQ, USOOQN, BXYBQS, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, USOOQN, SNQLNM, QSNQLN, None, NRSJMC, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            NQLNMH: GeckoByteStructAccessor(self.struct, NQLNMH, QLNMHX, QBMJVH),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-54.py
+++ b/src/geckolib/driver/packs/inxe-cfg-54.py
@@ -12,510 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 3
-AOAWBS = 6
-AONPYY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-AWBSIR = 23
-BFEGZU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-BLKXSJ = 31
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQSNQL = 34
-BSIRYX = 8
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BWJYKL = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-BXYBQS = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-CCPQIP = 29
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DNIBXT = 54
-DQLAII = 45
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 28
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-EJNIBX = 73
-EKCWAO = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-EKVKZI = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FEFJTA = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FJBIAM = 74
-FJTACC = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 52
-FWRKIN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = 82
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-GYOUSP = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-GZUQEX = 27
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 56
-HUOJRJ = 80
-HXEKVK = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-ICXQIE = 16
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IGYOUS = 35
-IKFWRK = 1
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-IRYXBQ = 10
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IUXFEF = 78
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JIGYOU = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-JMAOAW = 4
-JMCBFE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-JRJHIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JTACCP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JUTYEK = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JVDQLA = 44
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JYKLGQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JYMOUN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KCWAON = 58
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-KLGQPL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KVKZIL = 4
-KXSJWM = 25
-KZILXW = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-LAIIDN = 46
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 26
-LIUXFE = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-LJUIKF = 72
-LKXSJW = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-LNMHXE = 64
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67, 69])
-LSXUJU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-LXWAJV = 5
-MAOAWB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-MCBFEG = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-MHXEKV = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-MJIGYO = 3
-MJMAOA = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-MJVHFT = 12
-MNZMJI = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MOUNBL = "".join(chr(c) for c in [70])
-NBLKXS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-NMHXEK = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQJYMO = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-NRSJMC = 2
-NZMJIG = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-OAWBSI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = 60
-OOQNRS = "".join(chr(c) for c in [79, 119, 110])
-OUNBLK = "".join(chr(c) for c in [67])
-OUSPBW = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PBWJYK = 70
-PFTSIF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [85, 76])
-POUYNQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PYYLIU = 61
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QFYLJU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 30
-QJYMOU = 1
-QLAIID = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-QNRSJM = 0
-QPLSPF = 51
-QSNQLN = "".join(chr(c) for c in [65, 109, 80, 109])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 55
-RKINEJ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SAKQXP = 13
-SIFJBI = 53
-SIRYXB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SJMCBF = 32
-SJWMNZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-SKSOKP = 41
-SNQLNM = "".join(chr(c) for c in [50, 52, 104])
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-SPBWJY = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SXUJUT = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-TYEKCW = "".join(chr(c) for c in [72, 105])
-UIKFWR = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UQEXLS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-USOOQN = 81
-USPBWJ = 68
-UTYEKC = "".join(chr(c) for c in [76, 111])
-UXFEFJ = "".join(chr(c) for c in [80, 49])
-UYNQJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-VDQLAI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 43
-WAONPY = 59
-WBSIRY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-WMNZMJ = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WRKINE = 76
-XBQFYL = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-XLSXUJ = 57
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-XUJUTY = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-XWAJVD = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-XYBQSN = 75
-YBQSNQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-YKLGQP = 77
-YLIUXF = 62
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-YMOUNB = 33
-YNQJYM = 63
-YOUSPB = 66
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 71
-YYLIUX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZUQEXL = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-AIIDNI = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BIAMJM = [IPOUYN, JBIAMJ]
-BQFYLJ = [JVHFTH, ZUQEXL, XBQFYL]
-CPQIPO = [PIPIVL, UXFEFJ]
-FEGZUQ = [JMCBFE, MCBFEG, CBFEGZ, BFEGZU]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IBXYBQ = [VLASSA, JNIBXY, NIBXYB]
-IDNIBX = []
-IIDNIB = [OKPHUO]
-ILXWAJ = [KZILXW, ZILXWA]
-INEJNI = [RKINEJ, KINEJN]
-JWMNZM = [XSJWMN, SJWMNZ]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-NQLNMH = [JVHFTH, QSNQLN, SNQLNM]
-OQNRSJ = [SOOQNR, OOQNRS]
-OUYNQJ = [IPOUYN, POUYNQ]
-QEXLSX = [ZUQEXL, UQEXLS]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-SPFTSI = [PLSPFT, LSPFTS]
-TACCPQ = [FJTACC, JTACCP]
-UJUTYE = [LSXUJU, SXUJUT, XUJUTY]
-UNBLKX = [MOUNBL, OUNBLK]
-WJYKLG = [IPOUYN, BWJYKL]
-XEKVKZ = [MHXEKV, HXEKVK]
-XFEFJT = [JVHFTH, UXFEFJ, PIPIVL]
-YEKCWA = [UTYEKC, TYEKCW]
-ZMJIGY = [MNZMJI, NZMJIG]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -523,159 +19,474 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return DNIBXT
+        return 54
 
     @property
     def output_keys(self):
-        return AIIDNI
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QNRSJM, OQNRSJ, None, NRSJMC, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, FEGZUQ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, QEXLSX, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, None, UJUTYE, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, USOOQN, NRSJMC, YEKCWA, None, NRSJMC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, XFEFJT, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, TACCPQ, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, CCPQIP, None, CPQIPO, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoTempStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, UNBLKX, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, None, CPQIPO, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, JWMNZM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, USOOQN, MJIGYO, ZMJIGY, None, NRSJMC, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoTempStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, WJYKLG, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, BIAMJM, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoTimeStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTimeStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoTimeStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTimeStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BQFYLJ, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            QFYLJU: GeckoBoolStructAccessor(
-                self.struct, QFYLJU, FYLJUI, QNRSJM, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, LJUIKF, NRSJMC, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            JUIKFW: GeckoBoolStructAccessor(
-                self.struct, JUIKFW, LJUIKF, QNRSJM, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            UIKFWR: GeckoBoolStructAccessor(
-                self.struct, UIKFWR, LJUIKF, IKFWRK, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
             ),
-            KFWRKI: GeckoBoolStructAccessor(
-                self.struct, KFWRKI, LJUIKF, MJIGYO, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, IBXYBQ, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, USOOQN, IKFWRK, XEKVKZ, None, NRSJMC, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, USOOQN, KVKZIL, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, USOOQN, LXWAJV, ILXWAJ, None, NRSJMC, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, QBMJVH),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoByteStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoByteStructAccessor(self.struct, QLAIID, LAIIDN, QBMJVH),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-55.py
+++ b/src/geckolib/driver/packs/inxe-cfg-55.py
@@ -12,512 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-AJVDQL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AOAWBS = 4
-AONPYY = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-AWBSIR = 6
-BFEGZU = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-BIAMJM = 74
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 71
-BQSNQL = 75
-BSIRYX = 23
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BWJYKL = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-BXYBQS = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-CBFEGZ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-CPQIPO = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DQLAII = 44
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-EKCWAO = "".join(chr(c) for c in [72, 105])
-EKVKZI = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FEFJTA = "".join(chr(c) for c in [80, 49])
-FEGZUQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FJBIAM = 53
-FJTACC = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FWRKIN = 1
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GLRAHE = 38
-GQPLSP = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-GYOUSP = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 55
-HUOJRJ = 80
-HXEKVK = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-IAMJMA = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-IBXTIA = 55
-IBXYBQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-ICXQIE = 16
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-IGYOUS = 3
-IIDNIB = 46
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ILXWAJ = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-INEJNI = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-IRYXBQ = 8
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IUXFEF = 62
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-JHIUSO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JMAOAW = 3
-JMCBFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JRJHIU = "".join(chr(c) for c in [80, 49, 76, 84, 105, 109, 101, 79, 117, 116])
-JTACCP = 28
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-JUTYEK = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-JVDQLA = 43
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-JYKLGQ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-JYMOUN = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-KFWRKI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-KINEJN = 76
-KLGQPL = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KXSJWM = 31
-KZILXW = 4
-LAIIDN = 45
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 77
-LIUXFE = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-LJUIKF = 82
-LKXSJW = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = 51
-LSXUJU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-LXWAJV = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-MAOAWB = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-MCBFEG = 32
-MHXEKV = 64
-MJIGYO = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-MJMAOA = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-MJVHFT = 12
-MOUNBL = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-NBLKXS = "".join(chr(c) for c in [67])
-NEJNIB = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-NIBXYB = 73
-NMHXEK = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQJYMO = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NQLNMH = "".join(chr(c) for c in [65, 109, 80, 109])
-NZMJIG = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-OAWBSI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = 59
-OOQNRS = 81
-OQNRSJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OUNBLK = 33
-OUSPBW = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-PBWJYK = 68
-PFTSIF = "".join(chr(c) for c in [67, 69])
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-POUYNQ = 30
-PQIPOU = 29
-PYYLIU = 60
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QFYLJU = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QJYMOU = 63
-QLAIID = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-QLNMHX = "".join(chr(c) for c in [50, 52, 104])
-QNRSJM = "".join(chr(c) for c in [79, 119, 110])
-QPLSPF = 26
-QSNQLN = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 22
-RKINEJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-RSJMCB = 0
-RYXBQF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SAKQXP = 13
-SIFJBI = 52
-SIRYXB = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-SJMCBF = 2
-SJWMNZ = 25
-SKSOKP = 41
-SNQLNM = 34
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-SPBWJY = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SPFTSI = "".join(chr(c) for c in [85, 76])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SXUJUT = 57
-TACCPQ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-TYEKCW = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-UIKFWR = 72
-UJUTYE = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-UNBLKX = "".join(chr(c) for c in [70])
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UQEXLS = 27
-USOOQN = 56
-USPBWJ = 66
-UXFEFJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-UYNQJY = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-VDQLAI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-VLASSA = "".join(chr(c) for c in [])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 5
-WAONPY = 58
-WBSIRY = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-WJYKLG = 70
-WMNZMJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-XFEFJT = 78
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-XUJUTY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-YBQSNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-YEKCWA = "".join(chr(c) for c in [76, 111])
-YLIUXF = 61
-YLJUIK = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-YMOUNB = 1
-YOUSPB = 35
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 10
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-ZMJIGY = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-ZUQEXL = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-AMJMAO = [OUYNQJ, IAMJMA]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BLKXSJ = [UNBLKX, NBLKXS]
-CCPQIP = [TACCPQ, ACCPQI]
-DNIBXT = [OKPHUO]
-EFJTAC = [JVHFTH, FEFJTA, PIPIVL]
-EJNIBX = [INEJNI, NEJNIB]
-FTSIFJ = [SPFTSI, PFTSIF]
-FYLJUI = [JVHFTH, QEXLSX, QFYLJU]
-GZUQEX = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IDNIBX = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-JIGYOU = [ZMJIGY, MJIGYO]
-KCWAON = [YEKCWA, EKCWAO]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-KVKZIL = [XEKVKZ, EKVKZI]
-LNMHXE = [JVHFTH, NQLNMH, QLNMHX]
-MNZMJI = [JWMNZM, WMNZMJ]
-NIBXTI = []
-NRSJMC = [OQNRSJ, QNRSJM]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QIPOUY = [PIPIVL, FEFJTA]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XLSXUJ = [QEXLSX, EXLSXU]
-XWAJVD = [ILXWAJ, LXWAJV]
-XYBQSN = [VLASSA, IBXYBQ, BXYBQS]
-YKLGQP = [OUYNQJ, JYKLGQ]
-YNQJYM = [OUYNQJ, UYNQJY]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -525,160 +19,475 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return IBXTIA
+        return 55
 
     @property
     def output_keys(self):
-        return IDNIBX
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, RSJMCB, NRSJMC, None, SJMCBF, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, GZUQEX, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, UQEXLS, None, XLSXUJ, None, None, QBMJVH
+            "P1LTimeOut": GeckoByteStructAccessor(self.struct, "P1LTimeOut", 22, "ALL"),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, OOQNRS, SJMCBF, KCWAON, None, SJMCBF, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, EFJTAC, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, QIPOUY, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, POUYNQ, None, YNQJYM, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            NQJYMO: GeckoByteStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoTempStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, BLKXSJ, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, QIPOUY, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MNZMJI, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, OOQNRS, IGYOUS, JIGYOU, None, SJMCBF, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoTempStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, YKLGQP, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoByteStructAccessor(self.struct, GQPLSP, QPLSPF, QBMJVH),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, FTSIFJ, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, AMJMAO, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            MJMAOA: GeckoByteStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTimeStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoTimeStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTimeStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoTimeStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FYLJUI, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, LJUIKF, RSJMCB, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            JUIKFW: GeckoBoolStructAccessor(
-                self.struct, JUIKFW, UIKFWR, SJMCBF, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            IKFWRK: GeckoBoolStructAccessor(
-                self.struct, IKFWRK, UIKFWR, RSJMCB, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            KFWRKI: GeckoBoolStructAccessor(
-                self.struct, KFWRKI, UIKFWR, FWRKIN, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(
-                self.struct, WRKINE, UIKFWR, IGYOUS, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, NIBXYB, None, XYBQSN, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            YBQSNQ: GeckoByteStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, LNMHXE, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            NMHXEK: GeckoWordStructAccessor(self.struct, NMHXEK, MHXEKV, QBMJVH),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, OOQNRS, FWRKIN, KVKZIL, None, SJMCBF, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, OOQNRS, KZILXW, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, OOQNRS, WAJVDQ, XWAJVD, None, SJMCBF, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoByteStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoByteStructAccessor(self.struct, QLAIID, LAIIDN, QBMJVH),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-56.py
+++ b/src/geckolib/driver/packs/inxe-cfg-56.py
@@ -12,510 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 3
-AOAWBS = 6
-AONPYY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-AWBSIR = 23
-BFEGZU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-BLKXSJ = 31
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQSNQL = 34
-BSIRYX = 8
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BWJYKL = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-BXYBQS = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-CCPQIP = 29
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DNIBXT = 56
-DQLAII = 45
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 28
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-EJNIBX = 73
-EKCWAO = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-EKVKZI = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FEFJTA = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FJBIAM = 74
-FJTACC = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 52
-FWRKIN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = 82
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-GYOUSP = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-GZUQEX = 27
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 56
-HUOJRJ = 80
-HXEKVK = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-ICXQIE = 16
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IGYOUS = 35
-IKFWRK = 1
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-IRYXBQ = 10
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IUXFEF = 78
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JIGYOU = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-JMAOAW = 4
-JMCBFE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-JRJHIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JTACCP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JUTYEK = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JVDQLA = 44
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JYKLGQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JYMOUN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KCWAON = 58
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-KLGQPL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KVKZIL = 4
-KXSJWM = 25
-KZILXW = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-LAIIDN = 46
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 26
-LIUXFE = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-LJUIKF = 72
-LKXSJW = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-LNMHXE = 64
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67, 69])
-LSXUJU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-LXWAJV = 5
-MAOAWB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-MCBFEG = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-MHXEKV = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-MJIGYO = 3
-MJMAOA = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-MJVHFT = 12
-MNZMJI = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MOUNBL = "".join(chr(c) for c in [70])
-NBLKXS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-NMHXEK = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQJYMO = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-NRSJMC = 2
-NZMJIG = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-OAWBSI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = 60
-OOQNRS = "".join(chr(c) for c in [79, 119, 110])
-OUNBLK = "".join(chr(c) for c in [67])
-OUSPBW = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PBWJYK = 70
-PFTSIF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [85, 76])
-POUYNQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PYYLIU = 61
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QFYLJU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 30
-QJYMOU = 1
-QLAIID = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-QNRSJM = 0
-QPLSPF = 51
-QSNQLN = "".join(chr(c) for c in [65, 109, 80, 109])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 55
-RKINEJ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SAKQXP = 13
-SIFJBI = 53
-SIRYXB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SJMCBF = 32
-SJWMNZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-SKSOKP = 41
-SNQLNM = "".join(chr(c) for c in [50, 52, 104])
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-SPBWJY = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SXUJUT = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-TYEKCW = "".join(chr(c) for c in [72, 105])
-UIKFWR = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UQEXLS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-USOOQN = 81
-USPBWJ = 68
-UTYEKC = "".join(chr(c) for c in [76, 111])
-UXFEFJ = "".join(chr(c) for c in [80, 49])
-UYNQJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-VDQLAI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 43
-WAONPY = 59
-WBSIRY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-WMNZMJ = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WRKINE = 76
-XBQFYL = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-XLSXUJ = 57
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-XUJUTY = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-XWAJVD = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-XYBQSN = 75
-YBQSNQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-YKLGQP = 77
-YLIUXF = 62
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-YMOUNB = 33
-YNQJYM = 63
-YOUSPB = 66
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 71
-YYLIUX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZUQEXL = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-AIIDNI = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BIAMJM = [IPOUYN, JBIAMJ]
-BQFYLJ = [JVHFTH, ZUQEXL, XBQFYL]
-CPQIPO = [PIPIVL, UXFEFJ]
-FEGZUQ = [JMCBFE, MCBFEG, CBFEGZ, BFEGZU]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IBXYBQ = [VLASSA, JNIBXY, NIBXYB]
-IDNIBX = []
-IIDNIB = [OKPHUO]
-ILXWAJ = [KZILXW, ZILXWA]
-INEJNI = [RKINEJ, KINEJN]
-JWMNZM = [XSJWMN, SJWMNZ]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-NQLNMH = [JVHFTH, QSNQLN, SNQLNM]
-OQNRSJ = [SOOQNR, OOQNRS]
-OUYNQJ = [IPOUYN, POUYNQ]
-QEXLSX = [ZUQEXL, UQEXLS]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-SPFTSI = [PLSPFT, LSPFTS]
-TACCPQ = [FJTACC, JTACCP]
-UJUTYE = [LSXUJU, SXUJUT, XUJUTY]
-UNBLKX = [MOUNBL, OUNBLK]
-WJYKLG = [IPOUYN, BWJYKL]
-XEKVKZ = [MHXEKV, HXEKVK]
-XFEFJT = [JVHFTH, UXFEFJ, PIPIVL]
-YEKCWA = [UTYEKC, TYEKCW]
-ZMJIGY = [MNZMJI, NZMJIG]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -523,159 +19,474 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return DNIBXT
+        return 56
 
     @property
     def output_keys(self):
-        return AIIDNI
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QNRSJM, OQNRSJ, None, NRSJMC, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, FEGZUQ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, QEXLSX, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, None, UJUTYE, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, USOOQN, NRSJMC, YEKCWA, None, NRSJMC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, XFEFJT, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, TACCPQ, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, CCPQIP, None, CPQIPO, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoTempStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, UNBLKX, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, None, CPQIPO, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, JWMNZM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, USOOQN, MJIGYO, ZMJIGY, None, NRSJMC, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoTempStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, WJYKLG, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, BIAMJM, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoTimeStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTimeStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoTimeStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTimeStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BQFYLJ, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            QFYLJU: GeckoBoolStructAccessor(
-                self.struct, QFYLJU, FYLJUI, QNRSJM, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, LJUIKF, NRSJMC, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            JUIKFW: GeckoBoolStructAccessor(
-                self.struct, JUIKFW, LJUIKF, QNRSJM, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            UIKFWR: GeckoBoolStructAccessor(
-                self.struct, UIKFWR, LJUIKF, IKFWRK, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
             ),
-            KFWRKI: GeckoBoolStructAccessor(
-                self.struct, KFWRKI, LJUIKF, MJIGYO, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, IBXYBQ, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, USOOQN, IKFWRK, XEKVKZ, None, NRSJMC, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, USOOQN, KVKZIL, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, USOOQN, LXWAJV, ILXWAJ, None, NRSJMC, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, QBMJVH),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoByteStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoByteStructAccessor(self.struct, QLAIID, LAIIDN, QBMJVH),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-57.py
+++ b/src/geckolib/driver/packs/inxe-cfg-57.py
@@ -12,761 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-ACQFFT = 8
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-AJVDQL = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 3
-AOAWBS = 6
-AONPYY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-AWBSIR = 23
-BDJQRJ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-BFEGZU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-BJEUTO = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-BLKXSJ = 31
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQSNQL = 34
-BSIRYX = 8
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BSSUHB = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-BVWVUB = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-BWJYKL = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-BXTIAC = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-BXYBQS = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-BYGDSB = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-CCPQIP = 29
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-CRTFMN = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DJQRJJ = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DNIBXT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-DQLAII = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-DSBDJQ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-DUBSSU = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 28
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-EJNIBX = 73
-EKCWAO = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-EKVKZI = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EUTOPH = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-EXLSXU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FCRTFM = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-FEFJTA = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FFTTID = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-FJBIAM = 74
-FJTACC = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-FMNHTB = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 52
-FWRKIN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = 82
-GDSBDJ = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-GTYIYW = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-GYOUSP = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-GZUQEX = 27
-HBVWVU = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 56
-HTBJEU = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-HUGTYI = 45
-HUOJRJ = 80
-HXEKVK = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-IBXTIA = "".join(chr(c) for c in [66, 76, 85, 69])
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [82, 69, 68])
-IDUBSS = 44
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IGYOUS = 35
-IIDNIB = "".join(chr(c) for c in [79, 70, 70])
-IKFWRK = 1
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-IRYXBQ = 10
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IUXFEF = 78
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-JBIAMJ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JEUTOP = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JIGYOU = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-JJJVYF = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-JJVYFC = "".join(chr(c) for c in [80, 68, 67])
-JMAOAW = 4
-JMCBFE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-JQRJJJ = "".join(chr(c) for c in [76, 65])
-JRJHIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JTACCP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JUTYEK = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JVDQLA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-JYKLGQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JYMOUN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KCWAON = 58
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-KLGQPL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KVKZIL = 4
-KXSJWM = 25
-KZILXW = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-LAIIDN = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 26
-LIUXFE = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-LJUIKF = 72
-LKXSJW = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-LNMHXE = 64
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67, 69])
-LSXUJU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-LXWAJV = 5
-MAOAWB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-MCBFEG = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-MHXEKV = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-MJIGYO = 3
-MJMAOA = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-MJVHFT = 12
-MNHTBJ = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-MNZMJI = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MOUNBL = "".join(chr(c) for c in [70])
-NBLKXS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NHTBJE = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-NIBXTI = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-NMHXEK = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQJYMO = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-NRSJMC = 2
-NZMJIG = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-OAWBSI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = 60
-OOQNRS = "".join(chr(c) for c in [79, 119, 110])
-OUNBLK = "".join(chr(c) for c in [67])
-OUSPBW = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PBWJYK = 70
-PFTSIF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-PHUGTY = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [85, 76])
-POUYNQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PYYLIU = 61
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QFFTTI = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-QFYLJU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 30
-QJYMOU = 1
-QLNMHX = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-QNRSJM = 0
-QPLSPF = 51
-QRJJJV = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-QSNQLN = "".join(chr(c) for c in [65, 109, 80, 109])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 55
-RJJJVY = "".join(chr(c) for c in [77, 65, 65, 88])
-RKINEJ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-RTFMNH = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SAKQXP = 13
-SBDJQR = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-SIFJBI = 53
-SIRYXB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SJMCBF = 32
-SJWMNZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-SKSOKP = 41
-SKWIVD = 47
-SNQLNM = "".join(chr(c) for c in [50, 52, 104])
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-SPBWJY = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-SUHBVW = "".join(chr(c) for c in [65, 108, 112, 115])
-SXUJUT = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-TBJEUT = "".join(chr(c) for c in [73, 100, 111, 108])
-TFMNHT = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TIDUBS = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-TOPHUG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-TSIFJB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-TTIDUB = 7
-TYEKCW = "".join(chr(c) for c in [72, 105])
-UBSSUH = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UBYGDS = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-UGTYIY = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-UHBVWV = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-UIKFWR = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UQEXLS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-USOOQN = 81
-USPBWJ = 68
-UTOPHU = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-UTYEKC = "".join(chr(c) for c in [76, 111])
-UXFEFJ = "".join(chr(c) for c in [80, 49])
-UYNQJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-VDNQGV = 57
-VDQLAI = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-VWVUBY = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-VYFCRT = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 43
-WAONPY = 59
-WBSIRY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-WMNZMJ = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WRKINE = 76
-WSKWIV = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-WVUBYG = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-XBQFYL = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-XLSXUJ = 57
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-XTIACQ = "".join(chr(c) for c in [67, 89, 65, 78])
-XUJUTY = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-XWAJVD = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XYBQSN = 75
-YBQSNQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-YFCRTF = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-YGDSBD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-YIYWSK = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-YKLGQP = 77
-YLIUXF = 62
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-YMOUNB = 33
-YNQJYM = 63
-YOUSPB = 66
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = 46
-YXBQFY = 71
-YYLIUX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZUQEXL = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BIAMJM = [IPOUYN, JBIAMJ]
-BQFYLJ = [JVHFTH, ZUQEXL, XBQFYL]
-CPQIPO = [PIPIVL, UXFEFJ]
-FEGZUQ = [JMCBFE, MCBFEG, CBFEGZ, BFEGZU]
-FTTIDU = [QFFTTI, FFTTID]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IACQFF = [IIDNIB, IDNIBX, DNIBXT, NIBXTI, IBXTIA, BXTIAC, XTIACQ, TIACQF]
-IBXYBQ = [VLASSA, JNIBXY, NIBXYB]
-ILXWAJ = [KZILXW, ZILXWA]
-INEJNI = [RKINEJ, KINEJN]
-IVDNQG = []
-JWMNZM = [XSJWMN, SJWMNZ]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-KWIVDN = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-NQLNMH = [JVHFTH, QSNQLN, SNQLNM]
-OPHUGT = [
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-]
-OQNRSJ = [SOOQNR, OOQNRS]
-OUYNQJ = [IPOUYN, POUYNQ]
-QEXLSX = [ZUQEXL, UQEXLS]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QLAIID = [VDQLAI, DQLAII]
-SPFTSI = [PLSPFT, LSPFTS]
-TACCPQ = [FJTACC, JTACCP]
-TYIYWS = [UGTYIY, GTYIYW, VLASSA, VLASSA]
-UJUTYE = [LSXUJU, SXUJUT, XUJUTY]
-UNBLKX = [MOUNBL, OUNBLK]
-WIVDNQ = [OKPHUO]
-WJYKLG = [IPOUYN, BWJYKL]
-XEKVKZ = [MHXEKV, HXEKVK]
-XFEFJT = [JVHFTH, UXFEFJ, PIPIVL]
-YEKCWA = [UTYEKC, TYEKCW]
-ZMJIGY = [MNZMJI, NZMJIG]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -774,183 +19,527 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return VDNQGV
+        return 57
 
     @property
     def output_keys(self):
-        return KWIVDN
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QNRSJM, OQNRSJ, None, NRSJMC, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, FEGZUQ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, QEXLSX, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, None, UJUTYE, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, USOOQN, NRSJMC, YEKCWA, None, NRSJMC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, XFEFJT, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, TACCPQ, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, CCPQIP, None, CPQIPO, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoTempStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, UNBLKX, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, None, CPQIPO, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, JWMNZM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, USOOQN, MJIGYO, ZMJIGY, None, NRSJMC, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoTempStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, WJYKLG, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, BIAMJM, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoTimeStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTimeStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoTimeStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTimeStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BQFYLJ, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            QFYLJU: GeckoBoolStructAccessor(
-                self.struct, QFYLJU, FYLJUI, QNRSJM, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, LJUIKF, NRSJMC, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            JUIKFW: GeckoBoolStructAccessor(
-                self.struct, JUIKFW, LJUIKF, QNRSJM, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            UIKFWR: GeckoBoolStructAccessor(
-                self.struct, UIKFWR, LJUIKF, IKFWRK, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
             ),
-            KFWRKI: GeckoBoolStructAccessor(
-                self.struct, KFWRKI, LJUIKF, MJIGYO, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, IBXYBQ, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, USOOQN, IKFWRK, XEKVKZ, None, NRSJMC, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, USOOQN, KVKZIL, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, USOOQN, LXWAJV, ILXWAJ, None, NRSJMC, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            XWAJVD: GeckoBoolStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, QNRSJM, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, WAJVDQ, IKFWRK, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, WAJVDQ, NRSJMC, QLAIID, None, NRSJMC, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, WAJVDQ, MJIGYO, QLAIID, None, NRSJMC, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, WAJVDQ, KVKZIL, IACQFF, None, ACQFFT, QBMJVH
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
             ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, WAJVDQ, TTIDUB, FTTIDU, None, NRSJMC, QBMJVH
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
             ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, NRSJMC, TYIYWS, None, KVKZIL, QBMJVH
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
             ),
-            YIYWSK: GeckoBoolStructAccessor(
-                self.struct, YIYWSK, HUGTYI, KVKZIL, QBMJVH
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
             ),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, QBMJVH),
-            WSKWIV: GeckoBoolStructAccessor(
-                self.struct, WSKWIV, SKWIVD, QNRSJM, QBMJVH
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 45, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-58.py
+++ b/src/geckolib/driver/packs/inxe-cfg-58.py
@@ -12,723 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-ACQFFT = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 10
-AONPYY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-AWBSIR = 82
-BDJQRJ = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-BFEGZU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-BIAMJM = 8
-BJEUTO = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-BLKXSJ = 31
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-BSIRYX = 72
-BSKSOK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-BVWVUB = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-BXTIAC = 7
-BXYBQS = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-BYGDSB = "".join(chr(c) for c in [77, 65, 65, 88])
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-CCPQIP = 29
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-CRTFMN = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DJQRJJ = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DNIBXT = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-DQLAII = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-DSBDJQ = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-DUBSSU = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 28
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-EJNIBX = "".join(chr(c) for c in [50, 52, 104])
-EKCWAO = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-EKVKZI = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FCRTFM = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-FEFJTA = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FFTTID = "".join(chr(c) for c in [65, 108, 112, 115])
-FJBIAM = 23
-FJTACC = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-FMNHTB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 4
-FTTIDU = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-GDSBDJ = "".join(chr(c) for c in [80, 68, 67])
-GLRAHE = 38
-GQPLSP = 74
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-GZUQEX = 27
-HBVWVU = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 56
-HTBJEU = 45
-HUOJRJ = 80
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-IACQFF = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-IAMJMA = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-IBXYBQ = 64
-ICXQIE = 16
-IDNIBX = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IDUBSS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-IGYOUS = 77
-IIDNIB = 8
-IKFWRK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-ILXWAJ = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-INEJNI = 34
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-IRYXBQ = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IUXFEF = 78
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-JEUTOP = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JIGYOU = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JJJVYF = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-JJVYFC = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-JMAOAW = 71
-JMCBFE = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JQRJJJ = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-JRJHIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JTACCP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JUIKFW = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JUTYEK = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JVDQLA = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-JWMNZM = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JYKLGQ = 52
-JYMOUN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KCWAON = 58
-KFWRKI = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-KINEJN = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KLGQPL = 53
-KQXPIC = 14
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-KVKZIL = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-KXSJWM = 35
-KZILXW = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-LAIIDN = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-LIUXFE = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-LKXSJW = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-LNMHXE = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-LSXUJU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-LXWAJV = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-MAOAWB = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-MCBFEG = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-MHXEKV = 5
-MJMAOA = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-MJVHFT = 12
-MNZMJI = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-MOUNBL = "".join(chr(c) for c in [70])
-NBLKXS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NEJNIB = "".join(chr(c) for c in [65, 109, 80, 109])
-NHTBJE = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-NIBXTI = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-NIBXYB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQJYMO = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-NQLNMH = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NRSJMC = 2
-NZMJIG = 70
-OAWBSI = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-OCTHBS = 42
-OJRJHI = 54
-OKPHUO = "".join(chr(c) for c in [76, 73])
-ONPYYL = 60
-OOQNRS = "".join(chr(c) for c in [79, 119, 110])
-OUNBLK = "".join(chr(c) for c in [67])
-OUSPBW = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-PBWJYK = "".join(chr(c) for c in [67, 69])
-PFTSIF = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-PHUOJR = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-POUYNQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PYYLIU = 61
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QFFTTI = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-QFYLJU = 76
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 30
-QJYMOU = 1
-QLAIID = "".join(chr(c) for c in [67, 89, 65, 78])
-QLNMHX = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-QNRSJM = 0
-QPLSPF = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-QRJJJV = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-QSNQLN = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = 55
-RJJJVY = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-RKINEJ = 75
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-RTFMNH = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-RYXBQF = 1
-SAKQXP = 13
-SBDJQR = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-SIFJBI = 6
-SIRYXB = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-SJMCBF = 32
-SJWMNZ = 66
-SKSOKP = 41
-SNQLNM = 4
-SOKPHU = 79
-SOOQNR = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-SPBWJY = "".join(chr(c) for c in [85, 76])
-SPFTSI = 3
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-SUHBVW = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SXUJUT = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-TBJEUT = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-TFMNHT = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 44
-TIDUBS = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-TOPHUG = 46
-TSIFJB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-TTIDUB = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-TYEKCW = "".join(chr(c) for c in [72, 105])
-UBSSUH = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-UBYGDS = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-UGTYIY = 58
-UHBVWV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-UIKFWR = 73
-UOJRJH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UQEXLS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-USOOQN = 81
-USPBWJ = 51
-UTOPHU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-UTYEKC = "".join(chr(c) for c in [76, 111])
-UXFEFJ = "".join(chr(c) for c in [80, 49])
-UYNQJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-VDQLAI = "".join(chr(c) for c in [66, 76, 85, 69])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [76, 65])
-VWVUBY = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VYFCRT = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [82, 69, 68])
-WAONPY = 59
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-WJYKLG = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-WMNZMJ = 68
-WRKINE = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-WVUBYG = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-XBQFYL = 3
-XEKVKZ = 43
-XLSXUJ = 57
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 18
-XSJWMN = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-XTIACQ = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-XUJUTY = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-XWAJVD = "".join(chr(c) for c in [79, 70, 70])
-XYBQSN = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-YBQSNQ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-YFCRTF = "".join(chr(c) for c in [73, 100, 111, 108])
-YGDSBD = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-YKLGQP = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-YLIUXF = 62
-YLJUIK = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-YMOUNB = 33
-YNQJYM = 63
-YOUSPB = 26
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-ZUQEXL = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-AIIDNI = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN]
-AOAWBS = [JVHFTH, ZUQEXL, MAOAWB]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BQSNQL = [XYBQSN, YBQSNQ]
-BWJYKL = [SPBWJY, PBWJYK]
-CPQIPO = [PIPIVL, UXFEFJ]
-EUTOPH = [BJEUTO, JEUTOP, VLASSA, VLASSA]
-FEGZUQ = [JMCBFE, MCBFEG, CBFEGZ, BFEGZU]
-FWRKIN = [VLASSA, IKFWRK, KFWRKI]
-HBSKSO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-HUGTYI = []
-IBXTIA = [DNIBXT, NIBXTI]
-JNIBXY = [JVHFTH, NEJNIB, EJNIBX]
-KPHUOJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OKPHUO,
-]
-LJUIKF = [FYLJUI, YLJUIK]
-MJIGYO = [IPOUYN, ZMJIGY]
-MNHTBJ = [
-    IACQFF,
-    ACQFFT,
-    CQFFTT,
-    QFFTTI,
-    FFTTID,
-    FTTIDU,
-    TTIDUB,
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-]
-NMHXEK = [QLNMHX, LNMHXE]
-OPHUGT = [BMJVHF, SSAKQX, AKQXPI, QXPICX, PICXQI, CXQIEF, CTHBSK, KSOKPH]
-OQNRSJ = [SOOQNR, OOQNRS]
-OUYNQJ = [IPOUYN, POUYNQ]
-PHUGTY = [OKPHUO]
-PLSPFT = [IPOUYN, QPLSPF]
-QEXLSX = [ZUQEXL, UQEXLS]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-TACCPQ = [FJTACC, JTACCP]
-UJUTYE = [LSXUJU, SXUJUT, XUJUTY]
-UNBLKX = [MOUNBL, OUNBLK]
-XFEFJT = [JVHFTH, UXFEFJ, PIPIVL]
-YEKCWA = [UTYEKC, TYEKCW]
-ZILXWA = [VKZILX, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -736,174 +19,504 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return UGTYIY
+        return 58
 
     @property
     def output_keys(self):
-        return OPHUGT
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, HBSKSO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KPHUOJ, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, None),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QNRSJM, OQNRSJ, None, NRSJMC, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, FEGZUQ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, QEXLSX, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, None, UJUTYE, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, USOOQN, NRSJMC, YEKCWA, None, NRSJMC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, XFEFJT, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, TACCPQ, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, CCPQIP, None, CPQIPO, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoTempStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, UNBLKX, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, None, CPQIPO, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoTempStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, MJIGYO, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, BWJYKL, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, PLSPFT, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoTimeStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoTimeStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoTimeStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTimeStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoTimeStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, AOAWBS, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            OAWBSI: GeckoBoolStructAccessor(
-                self.struct, OAWBSI, AWBSIR, QNRSJM, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            WBSIRY: GeckoBoolStructAccessor(
-                self.struct, WBSIRY, BSIRYX, NRSJMC, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(
-                self.struct, SIRYXB, BSIRYX, QNRSJM, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            IRYXBQ: GeckoBoolStructAccessor(
-                self.struct, IRYXBQ, BSIRYX, RYXBQF, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            YXBQFY: GeckoBoolStructAccessor(
-                self.struct, YXBQFY, BSIRYX, XBQFYL, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, LJUIKF, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, FWRKIN, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            NIBXYB: GeckoWordStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, USOOQN, RYXBQF, BQSNQL, None, NRSJMC, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            QSNQLN: GeckoBoolStructAccessor(
-                self.struct, QSNQLN, USOOQN, SNQLNM, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            NQLNMH: GeckoEnumStructAccessor(
-                self.struct, NQLNMH, USOOQN, MHXEKV, NMHXEK, None, NRSJMC, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, QNRSJM, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, XEKVKZ, RYXBQF, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, XEKVKZ, NRSJMC, ZILXWA, None, NRSJMC, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, XEKVKZ, XBQFYL, ZILXWA, None, NRSJMC, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XEKVKZ, SNQLNM, AIIDNI, None, IIDNIB, QBMJVH
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, XEKVKZ, BXTIAC, IBXTIA, None, NRSJMC, QBMJVH
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
             ),
-            NHTBJE: GeckoBoolStructAccessor(
-                self.struct, NHTBJE, HTBJEU, QNRSJM, QBMJVH
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
             ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, HTBJEU, NRSJMC, EUTOPH, None, SNQLNM, QBMJVH
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
             ),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-60.py
+++ b/src/geckolib/driver/packs/inxe-cfg-60.py
@@ -12,911 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACQFFT = "".join(chr(c) for c in [65, 109, 80, 109])
-AFIKJP = 46
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(chr(c) for c in [52])
-AMJMAO = "".join(chr(c) for c in [70, 50])
-AONPYY = "".join(chr(c) for c in [72, 105])
-ASSAKQ = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AWBSIR = 84
-BFEGZU = 48
-BIAMJM = 83
-BJEUTO = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-BLKXSJ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 88
-BQSNQL = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-BSIRYX = 85
-BSKSOK = 17
-BSSUHB = 4
-BVWVUB = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BWJYKL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-BXTIAC = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-BXYBQS = 4
-BYGDSB = 43
-CBFEGZ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-CCPQIP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-CHWDAF = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-CPQIPO = 28
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [50, 52, 104])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 53])
-DAFIKJ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-DGKEAK = 127
-DJQRJJ = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DNIBXT = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DNQGVU = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-DQLAII = 76
-DSBDJQ = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DZXNQT = 124
-EAKSTS = "".join(chr(c) for c in [51])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 62
-EGZUQE = 32
-EJNIBX = 106
-EKCWAO = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-EKVKZI = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ELHBQN = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-EMCGET = 60
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-EUTOPH = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-FCRTFM = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-FEFJTA = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FEGZUQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-FFTTID = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-FMNHTB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 122
-FTTIDU = 64
-FWRKIN = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-FYLJUI = 89
-FZDGKE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-GDSBDJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-GKEAKS = "".join(chr(c) for c in [49])
-GLRAHE = 37
-GSELHB = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-GTYIYW = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-GVUNXN = "".join(chr(c) for c in [80, 68, 67])
-GYOUSP = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-GZUQEX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-HBQNRX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-HBSKSO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 55
-HTBJEU = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-HUGTYI = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-HWDAFI = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-HXEKVK = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-IACQFF = 34
-IAMJMA = "".join(chr(c) for c in [70, 49])
-IBXYBQ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-ICXQIE = 15
-IDNIBX = 73
-IDUBSS = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IEFXQG = 18
-IFJBIA = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-IGYOUS = 68
-IIDNIB = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IJUGSE = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-IKFWRK = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-IKJPUN = 47
-ILXWAJ = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-INEJNI = 105
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IRYXBQ = 86
-IUSOOQ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IUXFEF = 60
-IVDNQG = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-JBIAMJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JEUTOP = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-JHIUSO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JIGYOU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JJJVYF = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JJVYFC = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-JMCBFE = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JNIBXY = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JPUNRJ = 121
-JQRJJJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-JRJHIU = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-JTACCP = 78
-JUGSEL = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-JUIKFW = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-JUTYEK = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-JVDQLA = 5
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [66, 76, 85, 69])
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-JYKLGQ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-JYMOUN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-JZTATD = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-KEAKST = "".join(chr(c) for c in [50])
-KFWRKI = 100
-KINEJN = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-KJPUNR = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-KLGQPL = "".join(chr(c) for c in [85, 76])
-KMLOIJ = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-KPHUOJ = 79
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-KVKZIL = 82
-KWIVDN = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-KXSJWM = "".join(chr(c) for c in [70])
-KZILXW = 72
-LAIIDN = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [67, 69])
-LHBQNR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-LIUXFE = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-LJUIKF = 98
-LKXSJW = 33
-LNMHXE = 10
-LOIJUG = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-LSXUJU = 27
-LXWAJV = 1
-MAOAWB = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-MCBFEG = 118
-MFZDGK = 126
-MHXEKV = 71
-MJIGYO = 66
-MJMAOA = "".join(chr(c) for c in [70, 51])
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-MNHTBJ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-MNZMJI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-MOUNBL = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NBLKXS = 1
-NEJNIB = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-NIBXYB = 3
-NKMLOI = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-NPYYLI = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-NQGVUN = "".join(chr(c) for c in [77, 65, 65, 88])
-NQJYMO = 30
-NQLNMH = 8
-NQTMFZ = 125
-NRJZTA = "".join(chr(c) for c in [82, 71, 66])
-NRXCHW = 45
-NXNKML = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NZMJIG = 35
-OAWBSI = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-OCTHBS = 40
-OIJUGS = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-OJRJHI = 80
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OOQNRS = 81
-OPHUGT = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-OQNRSJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OUNBLK = 63
-OUSPBW = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-OUYNQJ = 29
-PBWJYK = 77
-PFTSIF = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-PHUGTY = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-PHUOJR = "".join(chr(c) for c in [76, 73])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 52])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 52
-POUYNQ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PQIPOU = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-PUNRJZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-PYYLIU = 58
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-QFYLJU = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-QIPOUY = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-QJYMOU = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-QLAIID = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-QLNMHX = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-QNRSJM = "".join(chr(c) for c in [79, 119, 110])
-QNRXCH = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QPLSPF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-QRJJJV = "".join(chr(c) for c in [79, 70, 70])
-QSNQLN = 23
-QTMFZD = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 38
-RJHIUS = 54
-RJJJVY = "".join(chr(c) for c in [82, 69, 68])
-RSJMCB = 0
-RTFMNH = 8
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-RYXBQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-SBDJQR = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-SELHBQ = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-SIFJBI = 74
-SIRYXB = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-SJMCBF = 2
-SKWIVD = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-SNQLNM = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-SOKPHU = 41
-SOOQNR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-SPBWJY = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-SPFTSI = 53
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-SUHBVW = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-SXUJUT = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-TACCPQ = "".join(chr(c) for c in [80, 49])
-TATDZX = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-TBJEUT = 44
-TDZXNQ = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-TFMNHT = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-THBSKS = 42
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-TIDUBS = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TMFZDG = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-TOPHUG = "".join(chr(c) for c in [65, 108, 112, 115])
-TSIFJB = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-TTIDUB = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-TYEKCW = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TYIYWS = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-UBSSUH = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-UBYGDS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UGSELH = "".join(chr(c) for c in [73, 100, 111, 108])
-UGTYIY = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-UHBVWV = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-UIKFWR = 99
-UNBLKX = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-UNRJZT = 123
-UNXNKM = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-UOJRJH = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UQEXLS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-USOOQN = 56
-UTOPHU = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-UTYEKC = 57
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [76, 65])
-VDQLAI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = 7
-VUNXNK = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-VWVUBY = 6
-VYFCRT = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 3
-WAONPY = "".join(chr(c) for c in [76, 111])
-WBSIRY = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-WIVDNQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-WJYKLG = 26
-WMNZMJ = 31
-WRKINE = 104
-WSKWIV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-WVUBYG = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-XBQFYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 70, 117, 115, 101])
-XCHWDA = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-XFEFJT = 61
-XLSXUJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-XNKMLO = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-XPICXQ = 14
-XQGLRA = 36
-XQIEFX = 16
-XSJWMN = "".join(chr(c) for c in [67])
-XTIACQ = 75
-XUJUTY = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-XWAJVD = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-XYBQSN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-YBQSNQ = 6
-YEKCWA = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-YFCRTF = "".join(chr(c) for c in [67, 89, 65, 78])
-YGDSBD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-YIYWSK = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-YKLGQP = 51
-YLIUXF = 59
-YLJUIK = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YNQJYM = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-YOUSPB = 70
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-YXBQFY = 87
-YYLIUX = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-ZILXWA = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZTATDZ = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-ZUQEXL = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-ZXNQTM = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-ACCPQI = [JVHFTH, TACCPQ, PIPIVL]
-AIIDNI = [QLAIID, LAIIDN]
-AOAWBS = [IAMJMA, AMJMAO, MJMAOA, VLASSA, VLASSA, VLASSA, JMAOAW, MAOAWB]
-ATDZXN = [ZTATDZ, TATDZX]
-BDJQRJ = [DSBDJQ, SBDJQR]
-BQNRXC = [
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-]
-CRTFMN = [QRJJJV, RJJJVY, JJJVYF, JJVYFC, JVYFCR, VYFCRT, YFCRTF, FCRTFM]
-DUBSSU = [TIDUBS, IDUBSS]
-EFXQGL = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-EXLSXU = [GZUQEX, ZUQEXL, UQEXLS, QEXLSX]
-FJBIAM = [QJYMOU, IFJBIA]
-GQPLSP = [KLGQPL, LGQPLS]
-HBVWVU = [SUHBVW, UHBVWV]
-HUOJRJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PHUOJR,
-]
-IBXTIA = [VLASSA, DNIBXT, NIBXTI]
-IPOUYN = [PQIPOU, QIPOUY]
-KCWAON = [TYEKCW, YEKCWA, EKCWAO]
-KSTSEM = [VLASSA, GKEAKS, KEAKST, EAKSTS, AKSTSE]
-NHTBJE = [FMNHTB, MNHTBJ]
-NRSJMC = [OQNRSJ, QNRSJM]
-ONPYYL = [WAONPY, AONPYY]
-QFFTTI = [JVHFTH, ACQFFT, CQFFTT]
-RJZTAT = [NRJZTA, FCRTFM]
-RKINEJ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, JMAOAW, MAOAWB]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    SSAKQX,
-]
-SEMCGE = []
-SJWMNZ = [KXSJWM, XSJWMN]
-SKSOKP = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-STSEMC = [BMJVHF, AKQXPI, QXPICX, PICXQI, CXQIEF, QIEFXQ, HBSKSO, OKPHUO]
-TSEMCG = [PHUOJR]
-UJUTYE = [SXUJUT, XUJUTY]
-USPBWJ = [QJYMOU, OUSPBW]
-UYNQJY = [PIPIVL, TACCPQ]
-WDAFIK = [CHWDAF, HWDAFI, VLASSA, VLASSA]
-XEKVKZ = [JVHFTH, SXUJUT, HXEKVK]
-YMOUNB = [QJYMOU, JYMOUN]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -924,253 +19,706 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return EMCGET
+        return 60
 
     @property
     def output_keys(self):
-        return STSEMC
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, SAKQXP, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, SAKQXP, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, EFXQGL, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, SKSOKP, None, None, QBMJVH
-            ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, HUOJRJ, None, None, None
-            ),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, None),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, RSJMCB, NRSJMC, None, SJMCBF, QBMJVH
-            ),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, EGZUQE, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, UJUTYE, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, KCWAON, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, OOQNRS, SJMCBF, ONPYYL, None, SJMCBF, QBMJVH
-            ),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, ACCPQI, None, None, QBMJVH
-            ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, IPOUYN, None, None, QBMJVH
-            ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, OUYNQJ, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoTempStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, SJWMNZ, None, None, QBMJVH
-            ),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, WMNZMJ, None, UYNQJY, None, None, QBMJVH
-            ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoTempStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoTempStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, USPBWJ, None, None, QBMJVH
-            ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoByteStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoEnumStructAccessor(
-                self.struct, TSIFJB, SIFJBI, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, AOAWBS, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, BSIRYX, None, AOAWBS, None, None, QBMJVH
-            ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, AOAWBS, None, None, QBMJVH
-            ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, AOAWBS, None, None, QBMJVH
-            ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, AOAWBS, None, None, QBMJVH
-            ),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, None, AOAWBS, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoByteStructAccessor(self.struct, JUIKFW, UIKFWR, QBMJVH),
-            IKFWRK: GeckoByteStructAccessor(self.struct, IKFWRK, KFWRKI, QBMJVH),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, RKINEJ, None, None, QBMJVH
-            ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, RKINEJ, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoTimeStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoTimeStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoTimeStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoTimeStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, XEKVKZ, None, None, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, KVKZIL, RSJMCB, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, KZILXW, SJMCBF, QBMJVH
-            ),
-            ZILXWA: GeckoBoolStructAccessor(
-                self.struct, ZILXWA, KZILXW, RSJMCB, QBMJVH
-            ),
-            ILXWAJ: GeckoBoolStructAccessor(
-                self.struct, ILXWAJ, KZILXW, LXWAJV, QBMJVH
-            ),
-            XWAJVD: GeckoBoolStructAccessor(
-                self.struct, XWAJVD, KZILXW, WAJVDQ, QBMJVH
-            ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, KZILXW, JVDQLA, QBMJVH
-            ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, None, AIIDNI, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, IBXTIA, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, QBMJVH),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, QFFTTI, None, None, QBMJVH
-            ),
-            FFTTID: GeckoWordStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, OOQNRS, LXWAJV, DUBSSU, None, SJMCBF, QBMJVH
-            ),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, OOQNRS, BSSUHB, QBMJVH
-            ),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, OOQNRS, JVDQLA, HBVWVU, None, SJMCBF, QBMJVH
-            ),
-            BVWVUB: GeckoBoolStructAccessor(
-                self.struct, BVWVUB, OOQNRS, VWVUBY, QBMJVH
-            ),
-            WVUBYG: GeckoBoolStructAccessor(
-                self.struct, WVUBYG, OOQNRS, VUBYGD, QBMJVH
-            ),
-            UBYGDS: GeckoBoolStructAccessor(
-                self.struct, UBYGDS, BYGDSB, RSJMCB, QBMJVH
-            ),
-            YGDSBD: GeckoBoolStructAccessor(
-                self.struct, YGDSBD, BYGDSB, LXWAJV, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, BYGDSB, SJMCBF, BDJQRJ, None, SJMCBF, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, BYGDSB, WAJVDQ, BDJQRJ, None, SJMCBF, QBMJVH
-            ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, BYGDSB, BSSUHB, CRTFMN, None, RTFMNH, QBMJVH
-            ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, BYGDSB, VUBYGD, NHTBJE, None, SJMCBF, QBMJVH
-            ),
-            QNRXCH: GeckoBoolStructAccessor(
-                self.struct, QNRXCH, NRXCHW, RSJMCB, QBMJVH
-            ),
-            RXCHWD: GeckoBoolStructAccessor(
-                self.struct, RXCHWD, NRXCHW, LXWAJV, QBMJVH
-            ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, NRXCHW, SJMCBF, WDAFIK, None, BSSUHB, QBMJVH
-            ),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, QBMJVH),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, IKJPUN, RSJMCB, QBMJVH
-            ),
-            KJPUNR: GeckoByteStructAccessor(self.struct, KJPUNR, JPUNRJ, QBMJVH),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            JZTATD: GeckoEnumStructAccessor(
-                self.struct, JZTATD, UNRJZT, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, DZXNQT, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, NQTMFZ, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, NQTMFZ, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, MFZDGK, RSJMCB, RJZTAT, None, SJMCBF, None
-            ),
-            FZDGKE: GeckoEnumStructAccessor(
-                self.struct, FZDGKE, MFZDGK, LXWAJV, ATDZXN, None, SJMCBF, None
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, RSJMCB, KSTSEM, None, RTFMNH, None
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "DirectFuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-61.py
+++ b/src/geckolib/driver/packs/inxe-cfg-61.py
@@ -12,970 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 78
-ACQFFT = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-AFIKJP = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-AMJMAO = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-AONPYY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-ASSAKQ = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-ATDZXN = "".join(chr(c) for c in [82, 71, 66])
-AWBSIR = "".join(chr(c) for c in [70, 49])
-BDJQRJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-BFEGZU = 118
-BHZVOA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BJEUTO = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-BLKXSJ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BQNRXC = "".join(chr(c) for c in [73, 100, 111, 108])
-BQSNQL = 106
-BSIRYX = "".join(chr(c) for c in [70, 51])
-BSKSOK = 17
-BSSUHB = 64
-BVWVUB = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BWJYKL = 68
-BXIBHZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-BXYBQS = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-CBFEGZ = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-CCPQIP = "".join(chr(c) for c in [80, 49])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-CHWDAF = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-CQBMJV = 0
-CRTFMN = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 53])
-DAFIKJ = 45
-DGKEAK = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-DJQRJJ = 43
-DNIBXT = 76
-DNQGVU = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-DQLAII = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-DSBDJQ = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-EAKSTS = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 61
-EGZUQE = 48
-EJNIBX = 100
-EKCWAO = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-EKVKZI = 8
-ELHBQN = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-EUTOPH = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-EXLSXU = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FCRTFM = "".join(chr(c) for c in [82, 69, 68])
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-FFTTID = 75
-FIKJPU = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-FJBIAM = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-FJTACC = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FMNHTB = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 69])
-FTTIDU = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-FWRKIN = 89
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-FZDGKE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-GDSBDJ = 6
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-GKEAKS = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-GLRAHE = 37
-GQPLSP = 77
-GSELHB = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-GTYIYW = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-GVUNXN = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-GYOUSP = 3
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-HBQNRX = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-HBSKSO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-HBXIBH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HUGTYI = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-HXEKVK = 23
-IACQFF = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IAMJMA = 122
-IBHZVO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-IBXTIA = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-ICXQIE = 15
-IDNIBX = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-IDUBSS = "".join(chr(c) for c in [50, 52, 104])
-IEFXQG = 18
-IFJBIA = 52
-IHBXIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-IIDNIB = 5
-IJUGSE = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-IKFWRK = 88
-IKJPUN = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-ILXWAJ = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-INEJNI = 99
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-IRYXBQ = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-IUSOOQ = 54
-IUXFEF = 59
-IVDNQG = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-IYWSKW = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-JBIAMJ = 53
-JEUTOP = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JHIUSO = 80
-JIGYOU = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JJJVYF = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JMAOAW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JNIBXY = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JPUNRJ = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-JQRJJJ = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-JTACCP = 62
-JUGSEL = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-JUIKFW = 87
-JUTYEK = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JVDQLA = 72
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-JWMNZM = "".join(chr(c) for c in [67])
-JYKLGQ = 70
-JYMOUN = 30
-JZTATD = 121
-KCWAON = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-KEAKST = 126
-KFWRKI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-KINEJN = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-KMLOIJ = "".join(chr(c) for c in [80, 68, 67])
-KPHUOJ = 47
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-KSTSEM = 127
-KVKZIL = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-KWIVDN = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-KXSJWM = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-LHBQNR = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-LIUXFE = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-LJUIKF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-LKXSJW = 1
-LNMHXE = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LOIJUG = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-MCBFEG = 0
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-MFZDGK = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-MHXEKV = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-MJIGYO = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MJMAOA = 74
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-MNHTBJ = "".join(chr(c) for c in [67, 89, 65, 78])
-MNZMJI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-MOUNBL = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-NBLKXS = 63
-NEJNIB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-NHTBJE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-NIBXTI = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-NIBXYB = 104
-NKMLOI = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-NMHXEK = 6
-NPYYLI = "".join(chr(c) for c in [72, 105])
-NQGVUN = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-NQLNMH = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-NRJZTA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-NRSJMC = 81
-NRXCHW = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-NXNKML = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-NZMJIG = 31
-OACMCV = 61
-OAWBSI = 83
-OCTHBS = 40
-OIHBXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-OIJUGS = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-OJRJHI = "".join(chr(c) for c in [76, 73])
-OKPHUO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-ONPYYL = "".join(chr(c) for c in [76, 111])
-OOQNRS = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-OPHUGT = 44
-OQNRSJ = 56
-OUSPBW = 35
-PBWJYK = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PFTSIF = "".join(chr(c) for c in [85, 76])
-PHUGTY = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-PHUOJR = 2
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 52])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 26
-POUYNQ = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-PQIPOU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-PUNRJZ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-QFFTTI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-QFYLJU = 85
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-QIPOUY = 28
-QJYMOU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-QLAIID = 1
-QLNMHX = 4
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-QNRXCH = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-QRJJJV = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-QSNQLN = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-QTMFZD = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 38
-RJHIUS = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-RJJJVY = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-RJZTAT = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-RKINEJ = 98
-RSJMCB = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-RTFMNH = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-RXCHWD = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-SBDJQR = 7
-SELHBQ = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-SEMCGE = "".join(chr(c) for c in [51])
-SIFJBI = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-SIRYXB = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-SJMCBF = "".join(chr(c) for c in [79, 119, 110])
-SJWMNZ = "".join(chr(c) for c in [70])
-SKWIVD = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-SNQLNM = 3
-SOKPHU = 41
-SOOQNR = 55
-SPBWJY = 66
-SPFTSI = 51
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-STSEMC = "".join(chr(c) for c in [49])
-SUHBVW = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-SXUJUT = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-TACCPQ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-TATDZX = 123
-TBJEUT = 8
-TFMNHT = "".join(chr(c) for c in [66, 76, 85, 69])
-THBSKS = 42
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 73
-TIDUBS = "".join(chr(c) for c in [65, 109, 80, 109])
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-TMFZDG = 124
-TOPHUG = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-TSEMCG = "".join(chr(c) for c in [50])
-TTIDUB = 34
-TYEKCW = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-TYIYWS = "".join(chr(c) for c in [65, 108, 112, 115])
-UBSSUH = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-UBYGDS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-UGSELH = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-UGTYIY = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-UHBVWV = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-UIKFWR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 70, 117, 115, 101])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-UNBLKX = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UNRJZT = 46
-UNXNKM = "".join(chr(c) for c in [76, 65])
-UOJRJH = 79
-UQEXLS = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-USOOQN = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-USPBWJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UYNQJY = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-VDNQGV = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-VDQLAI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 10
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-VUNXNK = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-VWVUBY = 4
-VXOIHB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-VYFCRT = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 82
-WBSIRY = "".join(chr(c) for c in [70, 50])
-WDAFIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-WIVDNQ = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-WJYKLG = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-WRKINE = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-WSKWIV = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-WVUBYG = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XBQFYL = 84
-XCHWDA = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-XEKVKZ = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-XFEFJT = 60
-XIBHZV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-XLSXUJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-XNKMLO = "".join(chr(c) for c in [77, 65, 65, 88])
-XNQTMF = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-XOIHBX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XPICXQ = 14
-XQGLRA = 36
-XQIEFX = 16
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-XSJWMN = 33
-XTIACQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-XUJUTY = 27
-XWAJVD = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-XYBQSN = 105
-YBQSNQ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-YEKCWA = 57
-YFCRTF = "".join(chr(c) for c in [79, 70, 70])
-YGDSBD = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-YIYWSK = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-YKLGQP = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-YLIUXF = 58
-YLJUIK = 86
-YMOUNB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YNQJYM = 29
-YOUSPB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-YXBQFY = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-YYLIUX = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = 125
-ZILXWA = 71
-ZMJIGY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-ZUQEXL = 32
-ZXNQTM = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-BXTIAC = [NIBXTI, IBXTIA]
-BYGDSB = [VUBYGD, UBYGDS]
-CPQIPO = [JVHFTH, CCPQIP, PIPIVL]
-CQFFTT = [VLASSA, IACQFF, ACQFFT]
-DUBSSU = [JVHFTH, TIDUBS, IDUBSS]
-EFXQGL = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-EMCGET = [VLASSA, STSEMC, TSEMCG, SEMCGE]
-HBVWVU = [SUHBVW, UHBVWV]
-HTBJEU = [YFCRTF, FCRTFM, CRTFMN, RTFMNH, TFMNHT, FMNHTB, MNHTBJ, NHTBJE]
-HWDAFI = [
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-]
-HZVOAC = [BMJVHF, AKQXPI, QXPICX, PICXQI, CXQIEF, QIEFXQ, HBSKSO, HUOJRJ]
-IBXYBQ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, SIRYXB, IRYXBQ]
-IGYOUS = [MJIGYO, JIGYOU]
-JJVYFC = [RJJJVY, JJJVYF]
-JMCBFE = [RSJMCB, SJMCBF]
-JRJHIU = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OJRJHI,
-]
-KJPUNR = [FIKJPU, IKJPUN, VLASSA, VLASSA]
-KLGQPL = [YMOUNB, YKLGQP]
-LSXUJU = [UQEXLS, QEXLSX, EXLSXU, XLSXUJ]
-LXWAJV = [JVHFTH, UJUTYE, ILXWAJ]
-MAOAWB = [YMOUNB, JMAOAW]
-NQJYMO = [PIPIVL, CCPQIP]
-NQTMFZ = [ZXNQTM, XNQTMF]
-OUNBLK = [YMOUNB, MOUNBL]
-OUYNQJ = [IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-RYXBQF = [AWBSIR, WBSIRY, BSIRYX, VLASSA, VLASSA, VLASSA, SIRYXB, IRYXBQ]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    SSAKQX,
-]
-SKSOKP = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-TDZXNQ = [ATDZXN, NHTBJE]
-TSIFJB = [PFTSIF, FTSIFJ]
-UTOPHU = [JEUTOP, EUTOPH]
-UTYEKC = [UJUTYE, JUTYEK]
-VOACMC = []
-WAONPY = [EKCWAO, KCWAON, CWAONP]
-WMNZMJ = [SJWMNZ, JWMNZM]
-ZVOACM = [OJRJHI]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -983,276 +19,763 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return OACMCV
+        return 61
 
     @property
     def output_keys(self):
-        return HZVOAC
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, SAKQXP, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, SAKQXP, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, EFXQGL, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, SKSOKP, None, None, QBMJVH
-            ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoBoolStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, PHUOJR, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                18,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 42, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 41, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 47, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "DirectFuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 45, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct, "NumberOfZones", 127, 0, ["", "1", "2", "3"], None, 8, None
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, JRJHIU, None, None, None
-            ),
-            RJHIUS: GeckoByteStructAccessor(self.struct, RJHIUS, JHIUSO, None),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, QBMJVH),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, MCBFEG, JMCBFE, None, PHUOJR, QBMJVH
-            ),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, LSXUJU, None, None, QBMJVH
-            ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, UTYEKC, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, WAONPY, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, NRSJMC, PHUOJR, PYYLIU, None, PHUOJR, QBMJVH
-            ),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, NQJYMO, None, None, QBMJVH
-            ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, OUNBLK, None, None, QBMJVH
-            ),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoTempStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, XSJWMN, None, WMNZMJ, None, None, QBMJVH
-            ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, NQJYMO, None, None, QBMJVH
-            ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, NRSJMC, GYOUSP, IGYOUS, None, PHUOJR, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoTempStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoEnumStructAccessor(
-                self.struct, WJYKLG, JYKLGQ, None, KLGQPL, None, None, QBMJVH
-            ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, TSIFJB, None, None, QBMJVH
-            ),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoByteStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, RYXBQF, None, None, QBMJVH
-            ),
-            YXBQFY: GeckoEnumStructAccessor(
-                self.struct, YXBQFY, XBQFYL, None, RYXBQF, None, None, QBMJVH
-            ),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, RYXBQF, None, None, QBMJVH
-            ),
-            FYLJUI: GeckoEnumStructAccessor(
-                self.struct, FYLJUI, YLJUIK, None, RYXBQF, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, RYXBQF, None, None, QBMJVH
-            ),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, RYXBQF, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, RYXBQF, None, None, QBMJVH
-            ),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoByteStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, NIBXYB, None, IBXYBQ, None, None, QBMJVH
-            ),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, IBXYBQ, None, None, QBMJVH
-            ),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, IBXYBQ, None, None, QBMJVH
-            ),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, QBMJVH),
-            NQLNMH: GeckoTimeStructAccessor(self.struct, NQLNMH, QLNMHX, QBMJVH),
-            LNMHXE: GeckoTimeStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoTimeStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoTimeStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoTimeStructAccessor(self.struct, KVKZIL, VKZILX, QBMJVH),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, LXWAJV, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoBoolStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, MCBFEG, QBMJVH
-            ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, JVDQLA, PHUOJR, QBMJVH
-            ),
-            VDQLAI: GeckoBoolStructAccessor(
-                self.struct, VDQLAI, JVDQLA, MCBFEG, QBMJVH
-            ),
-            DQLAII: GeckoBoolStructAccessor(
-                self.struct, DQLAII, JVDQLA, QLAIID, QBMJVH
-            ),
-            LAIIDN: GeckoBoolStructAccessor(
-                self.struct, LAIIDN, JVDQLA, GYOUSP, QBMJVH
-            ),
-            AIIDNI: GeckoBoolStructAccessor(
-                self.struct, AIIDNI, JVDQLA, IIDNIB, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, CQFFTT, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, QBMJVH),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, DUBSSU, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoWordStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, NRSJMC, QLAIID, HBVWVU, None, PHUOJR, QBMJVH
-            ),
-            BVWVUB: GeckoBoolStructAccessor(
-                self.struct, BVWVUB, NRSJMC, VWVUBY, QBMJVH
-            ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, NRSJMC, IIDNIB, BYGDSB, None, PHUOJR, QBMJVH
-            ),
-            YGDSBD: GeckoBoolStructAccessor(
-                self.struct, YGDSBD, NRSJMC, GDSBDJ, QBMJVH
-            ),
-            DSBDJQ: GeckoBoolStructAccessor(
-                self.struct, DSBDJQ, NRSJMC, SBDJQR, QBMJVH
-            ),
-            BDJQRJ: GeckoBoolStructAccessor(
-                self.struct, BDJQRJ, DJQRJJ, MCBFEG, QBMJVH
-            ),
-            JQRJJJ: GeckoBoolStructAccessor(
-                self.struct, JQRJJJ, DJQRJJ, QLAIID, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, DJQRJJ, PHUOJR, JJVYFC, None, PHUOJR, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, DJQRJJ, GYOUSP, JJVYFC, None, PHUOJR, QBMJVH
-            ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, DJQRJJ, VWVUBY, HTBJEU, None, TBJEUT, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, DJQRJJ, SBDJQR, UTOPHU, None, PHUOJR, QBMJVH
-            ),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, QLAIID, QBMJVH
-            ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, DAFIKJ, PHUOJR, KJPUNR, None, VWVUBY, QBMJVH
-            ),
-            JPUNRJ: GeckoBoolStructAccessor(
-                self.struct, JPUNRJ, DAFIKJ, VWVUBY, QBMJVH
-            ),
-            PUNRJZ: GeckoByteStructAccessor(self.struct, PUNRJZ, UNRJZT, QBMJVH),
-            NRJZTA: GeckoBoolStructAccessor(
-                self.struct, NRJZTA, KPHUOJ, MCBFEG, QBMJVH
-            ),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, TATDZX, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, TATDZX, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, TMFZDG, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            FZDGKE: GeckoEnumStructAccessor(
-                self.struct, FZDGKE, ZDGKEA, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, ZDGKEA, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, KEAKST, MCBFEG, TDZXNQ, None, PHUOJR, None
-            ),
-            EAKSTS: GeckoEnumStructAccessor(
-                self.struct, EAKSTS, KEAKST, QLAIID, NQTMFZ, None, PHUOJR, None
-            ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, MCBFEG, EMCGET, None, TBJEUT, None
-            ),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, KSTSEM, SBDJQR, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, TATDZX, VWVUBY, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, TATDZX, IIDNIB, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, TATDZX, GDSBDJ, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, TATDZX, SBDJQR, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, TMFZDG, VWVUBY, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, TMFZDG, IIDNIB, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, TMFZDG, GDSBDJ, None),
-            VXOIHB: GeckoBoolStructAccessor(self.struct, VXOIHB, TMFZDG, SBDJQR, None),
-            XOIHBX: GeckoBoolStructAccessor(self.struct, XOIHBX, ZDGKEA, VWVUBY, None),
-            OIHBXI: GeckoBoolStructAccessor(self.struct, OIHBXI, ZDGKEA, IIDNIB, None),
-            IHBXIB: GeckoBoolStructAccessor(self.struct, IHBXIB, ZDGKEA, GDSBDJ, None),
-            HBXIBH: GeckoBoolStructAccessor(self.struct, HBXIBH, ZDGKEA, SBDJQR, None),
-            BXIBHZ: GeckoBoolStructAccessor(self.struct, BXIBHZ, KEAKST, VWVUBY, None),
-            XIBHZV: GeckoBoolStructAccessor(self.struct, XIBHZV, KEAKST, IIDNIB, None),
-            IBHZVO: GeckoBoolStructAccessor(self.struct, IBHZVO, KEAKST, GDSBDJ, None),
-            BHZVOA: GeckoBoolStructAccessor(self.struct, BHZVOA, KEAKST, SBDJQR, None),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-7.py
+++ b/src/geckolib/driver/packs/inxe-cfg-7.py
@@ -12,199 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-AHEOCT = 1
-AKQXPI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-ASSAKQ = 36
-BFEGZU = 0
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-CBFEGZ = 51
-CQBMJV = 0
-CTHBSK = 18
-CVYYPI = 17
-CXQIEF = "".join(chr(c) for c in [67, 80])
-ECVYYP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-EFXQGL = 15
-EGZUQE = 1
-EOCTHB = 16
-EXLSXU = "".join(chr(c) for c in [65, 109, 80, 109])
-FEGZUQ = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-FTHECV = 31
-FXQGLR = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-GLRAHE = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-GZUQEX = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-HBSKSO = "".join(chr(c) for c in [67])
-HECVYY = 32
-HEOCTH = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-HFTHEC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HIUSOO = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-HUOJRJ = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-ICXQIE = 14
-IEFXQG = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-IPIVLA = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IUSOOQ = 3
-IVLASS = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JHIUSO = 5
-JRJHIU = 4
-JUTYEK = "".join(chr(c) for c in [76, 73])
-JVHFTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-KPHUOJ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-KQXPIC = 40
-KSOKPH = 46
-LASSAK = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-LRAHEO = 43
-MCBFEG = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-MJVHFT = 27
-NRSJMC = 50
-OCTHBS = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-OJRJHI = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-OKPHUO = 48
-OOQNRS = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-OQNRSJ = 8
-PHUOJR = 29
-PICXQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PIVLAS = 33
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 19
-QNRSJM = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QXPICX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-RAHEOC = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-RJHIUS = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-RSJMCB = "".join(chr(c) for c in [78, 65])
-SAKQXP = 38
-SJMCBF = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-SKSOKP = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SOKPHU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SOOQNR = 7
-SSAKQX = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-SXUJUT = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-THBSKS = "".join(chr(c) for c in [70])
-THECVY = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-TYEKCW = 7
-UOJRJH = 30
-UQEXLS = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-USOOQN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-VHFTHE = 26
-VLASSA = 35
-VYYPIP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-XLSXUJ = "".join(chr(c) for c in [50, 52, 104])
-XPICXQ = 42
-XQGLRA = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-XQIEFX = "".join(chr(c) for c in [80, 49])
-XUJUTY = 44
-YPIPIV = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-YYPIPI = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZUQEXL = 2
-BSKSOK = [THBSKS, HBSKSO]
-JMCBFE = [RSJMCB, SJMCBF]
-LSXUJU = [RSJMCB, EXLSXU, XLSXUJ]
-PIPIVL = [VYYPIP, YYPIPI, YPIPIV]
-QGLRAH = [FXQGLR, XQGLRA]
-QIEFXQ = [CXQIEF, XQIEFX]
-UJUTYE = []
-UTYEKC = [JUTYEK]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -212,66 +19,120 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return TYEKCW
+        return 7
 
     @property
     def output_keys(self):
-        return UJUTYE
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoByteStructAccessor(self.struct, BMJVHF, MJVHFT, QBMJVH),
-            JVHFTH: GeckoByteStructAccessor(self.struct, JVHFTH, VHFTHE, QBMJVH),
-            HFTHEC: GeckoByteStructAccessor(self.struct, HFTHEC, FTHECV, QBMJVH),
-            THECVY: GeckoByteStructAccessor(self.struct, THECVY, HECVYY, QBMJVH),
-            ECVYYP: GeckoEnumStructAccessor(
-                self.struct, ECVYYP, CVYYPI, None, PIPIVL, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            IPIVLA: GeckoTempStructAccessor(self.struct, IPIVLA, PIVLAS, QBMJVH),
-            IVLASS: GeckoByteStructAccessor(self.struct, IVLASS, VLASSA, QBMJVH),
-            LASSAK: GeckoWordStructAccessor(self.struct, LASSAK, ASSAKQ, QBMJVH),
-            SSAKQX: GeckoWordStructAccessor(self.struct, SSAKQX, SAKQXP, QBMJVH),
-            AKQXPI: GeckoWordStructAccessor(self.struct, AKQXPI, KQXPIC, QBMJVH),
-            QXPICX: GeckoByteStructAccessor(self.struct, QXPICX, XPICXQ, QBMJVH),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, QIEFXQ, None, None, QBMJVH
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 27, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 26, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 31, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QGLRAH, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 32, "ALL"
             ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoTempStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, QIEFXQ, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                17,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, BSKSOK, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 33, "ALL"
             ),
-            SKSOKP: GeckoTempStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoTempStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoByteStructAccessor(self.struct, KPHUOJ, PHUOJR, QBMJVH),
-            HUOJRJ: GeckoByteStructAccessor(self.struct, HUOJRJ, UOJRJH, QBMJVH),
-            OJRJHI: GeckoByteStructAccessor(self.struct, OJRJHI, JRJHIU, QBMJVH),
-            RJHIUS: GeckoTimeStructAccessor(self.struct, RJHIUS, JHIUSO, QBMJVH),
-            HIUSOO: GeckoTimeStructAccessor(self.struct, HIUSOO, IUSOOQ, QBMJVH),
-            USOOQN: GeckoTimeStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoTimeStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, JMCBFE, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 35, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 36, "ALL"
             ),
-            MCBFEG: GeckoBoolStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, BFEGZU, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 38, "ALL"
             ),
-            FEGZUQ: GeckoBoolStructAccessor(
-                self.struct, FEGZUQ, CBFEGZ, EGZUQE, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 40, "ALL"
             ),
-            GZUQEX: GeckoBoolStructAccessor(
-                self.struct, GZUQEX, CBFEGZ, ZUQEXL, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 42, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, LSXUJU, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 14, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SXUJUT: GeckoWordStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                15,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 43, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 16, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 18, None, ["F", "C"], None, None, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 46, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 48, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 29, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 30, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                50,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 51, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 51, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 51, 2, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                19,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 44, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-8.py
+++ b/src/geckolib/driver/packs/inxe-cfg-8.py
@@ -12,203 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-AHEOCT = 1
-AKQXPI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-ASSAKQ = 36
-BFEGZU = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-CBFEGZ = "".join(chr(c) for c in [78, 65])
-CQBMJV = 0
-CTHBSK = 18
-CVYYPI = 17
-CWAONP = 8
-CXQIEF = "".join(chr(c) for c in [67, 80])
-ECVYYP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-EFXQGL = 15
-EGZUQE = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-EKCWAO = "".join(chr(c) for c in [76, 73])
-EOCTHB = 16
-EXLSXU = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-FTHECV = 31
-FXQGLR = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-GLRAHE = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-GZUQEX = 52
-HBSKSO = "".join(chr(c) for c in [67])
-HECVYY = 32
-HEOCTH = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-HFTHEC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HIUSOO = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-HUOJRJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-ICXQIE = 14
-IEFXQG = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-IPIVLA = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IUSOOQ = 4
-IVLASS = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JHIUSO = 30
-JMCBFE = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-JRJHIU = 29
-JVHFTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-KPHUOJ = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-KQXPIC = 40
-KSOKPH = 46
-LASSAK = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-LRAHEO = 43
-LSXUJU = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-MCBFEG = 51
-MJVHFT = 27
-NRSJMC = 7
-OCTHBS = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-OJRJHI = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-OKPHUO = 48
-OOQNRS = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OQNRSJ = 3
-PHUOJR = 50
-PICXQI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PIVLAS = 33
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 1
-QNRSJM = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-QXPICX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-RAHEOC = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-RJHIUS = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-RSJMCB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SAKQXP = 38
-SJMCBF = 8
-SKSOKP = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SOKPHU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SOOQNR = 5
-SSAKQX = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-SXUJUT = 19
-THBSKS = "".join(chr(c) for c in [70])
-THECVY = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-TYEKCW = 44
-UJUTYE = "".join(chr(c) for c in [50, 52, 104])
-UQEXLS = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-USOOQN = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-VHFTHE = 26
-VLASSA = 35
-VYYPIP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-XLSXUJ = 2
-XPICXQ = 42
-XQGLRA = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-XQIEFX = "".join(chr(c) for c in [80, 49])
-XUJUTY = "".join(chr(c) for c in [65, 109, 80, 109])
-YPIPIV = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-YYPIPI = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZUQEXL = 0
-BSKSOK = [THBSKS, HBSKSO]
-FEGZUQ = [CBFEGZ, BFEGZU]
-JUTYEK = [CBFEGZ, XUJUTY, UJUTYE]
-KCWAON = [EKCWAO]
-PIPIVL = [VYYPIP, YYPIPI, YPIPIV]
-QGLRAH = [FXQGLR, XQGLRA]
-QIEFXQ = [CXQIEF, XQIEFX]
-UOJRJH = [FXQGLR, HUOJRJ]
-YEKCWA = []
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -216,69 +19,130 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return CWAONP
+        return 8
 
     @property
     def output_keys(self):
-        return YEKCWA
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoByteStructAccessor(self.struct, BMJVHF, MJVHFT, QBMJVH),
-            JVHFTH: GeckoByteStructAccessor(self.struct, JVHFTH, VHFTHE, QBMJVH),
-            HFTHEC: GeckoByteStructAccessor(self.struct, HFTHEC, FTHECV, QBMJVH),
-            THECVY: GeckoByteStructAccessor(self.struct, THECVY, HECVYY, QBMJVH),
-            ECVYYP: GeckoEnumStructAccessor(
-                self.struct, ECVYYP, CVYYPI, None, PIPIVL, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            IPIVLA: GeckoTempStructAccessor(self.struct, IPIVLA, PIVLAS, QBMJVH),
-            IVLASS: GeckoByteStructAccessor(self.struct, IVLASS, VLASSA, QBMJVH),
-            LASSAK: GeckoWordStructAccessor(self.struct, LASSAK, ASSAKQ, QBMJVH),
-            SSAKQX: GeckoWordStructAccessor(self.struct, SSAKQX, SAKQXP, QBMJVH),
-            AKQXPI: GeckoWordStructAccessor(self.struct, AKQXPI, KQXPIC, QBMJVH),
-            QXPICX: GeckoByteStructAccessor(self.struct, QXPICX, XPICXQ, QBMJVH),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, QIEFXQ, None, None, QBMJVH
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 27, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 26, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 31, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QGLRAH, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 32, "ALL"
             ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoTempStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, QIEFXQ, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                17,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, BSKSOK, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 33, "ALL"
             ),
-            SKSOKP: GeckoTempStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoTempStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, UOJRJH, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 35, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 36, "ALL"
             ),
-            OJRJHI: GeckoByteStructAccessor(self.struct, OJRJHI, JRJHIU, QBMJVH),
-            RJHIUS: GeckoByteStructAccessor(self.struct, RJHIUS, JHIUSO, QBMJVH),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, QBMJVH),
-            USOOQN: GeckoTimeStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoTimeStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoTimeStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoTimeStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, FEGZUQ, None, None, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 38, "ALL"
             ),
-            EGZUQE: GeckoBoolStructAccessor(
-                self.struct, EGZUQE, GZUQEX, ZUQEXL, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 40, "ALL"
             ),
-            UQEXLS: GeckoBoolStructAccessor(
-                self.struct, UQEXLS, GZUQEX, QEXLSX, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 42, "ALL"
             ),
-            EXLSXU: GeckoBoolStructAccessor(
-                self.struct, EXLSXU, GZUQEX, XLSXUJ, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 14, None, ["CP", "P1"], None, None, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, JUTYEK, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                15,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            UTYEKC: GeckoWordStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 43, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 16, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 18, None, ["F", "C"], None, None, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 46, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 48, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                50,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 29, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 30, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                51,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 52, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 52, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 52, 2, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                19,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 44, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-cfg-9.py
+++ b/src/geckolib/driver/packs/inxe-cfg-9.py
@@ -12,312 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 32
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AKQXPI = 11
-AONPYY = 21
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-BFEGZU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BSKSOK = 33
-CBFEGZ = 45
-CCPQIP = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CPQIPO = 57
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 19
-CXQIEF = 14
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 23
-EGZUQE = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-EKCWAO = 1
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = "".join(chr(c) for c in [80, 49])
-FEFJTA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-FEGZUQ = 16
-FJTACC = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 9
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GLRAHE = 25
-GQPLSP = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-GYOUSP = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-GZUQEX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-HBSKSO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 27
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HUOJRJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-IUSOOQ = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IUXFEF = 51
-IVLASS = "".join(chr(c) for c in [])
-JHIUSO = 15
-JIGYOU = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-JMCBFE = 43
-JTACCP = 31
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-JYKLGQ = 22
-JYMOUN = 7
-KCWAON = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-KLGQPL = "".join(chr(c) for c in [50, 52, 104])
-KPHUOJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 34
-KXSJWM = 55
-LIUXFE = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LKXSJW = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [76, 73])
-LSXUJU = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-MCBFEG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-MJIGYO = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-MJVHFT = 9
-MNZMJI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-MOUNBL = 8
-NBLKXS = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-NPYYLI = "".join(chr(c) for c in [67])
-NQJYMO = 3
-NRSJMC = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 102, 102, 84, 105, 109, 101]
-)
-NZMJIG = 56
-OCTHBS = 28
-OJRJHI = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OKPHUO = 35
-ONPYYL = "".join(chr(c) for c in [70])
-OOQNRS = 38
-OQNRSJ = "".join(
-    chr(c) for c in [67, 80, 79, 84, 77, 97, 120, 79, 110, 84, 105, 109, 101]
-)
-OUNBLK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-OUSPBW = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-OUYNQJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-PBWJYK = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-PHUOJR = 20
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-POUYNQ = 4
-PQIPOU = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 17
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QJYMOU = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-QNRSJM = 39
-QPLSPF = 47
-QXPICX = 12
-RAHEOC = 26
-RJHIUS = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-RSJMCB = 41
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SJMCBF = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        84,
-        68,
-        117,
-        114,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-        52,
-        72,
-    ]
-)
-SJWMNZ = 1
-SKSOKP = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SOKPHU = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-SOOQNR = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SPBWJY = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-SSAKQX = 10
-SXUJUT = 18
-TACCPQ = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-THBSKS = 29
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TYEKCW = 46
-UJUTYE = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-UNBLKX = 54
-UOJRJH = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-UQEXLS = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-USOOQN = 36
-USPBWJ = 59
-UTYEKC = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UXFEFJ = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-UYNQJY = 5
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-WJYKLG = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-WMNZMJ = 2
-XFEFJT = 53
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 24
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XUJUTY = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YEKCWA = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-YKLGQP = "".join(chr(c) for c in [65, 109, 80, 109])
-YLIUXF = 49
-YMOUNB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YNQJYM = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-YOUSPB = 58
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YYLIUX = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [85, 110, 99, 111, 110, 102, 105, 103, 117, 114, 101, 100]
-)
-BLKXSJ = [JVHFTH, NBLKXS]
-BWJYKL = [SPBWJY, PBWJYK]
-EFJTAC = [XUJUTY, FEFJTA]
-IGYOUS = [ZMJIGY, MJIGYO, JIGYOU]
-JRJHIU = [HUOJRJ, UOJRJH, OJRJHI]
-JUTYEK = [XUJUTY, UJUTYE]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LGQPLS = [JVHFTH, YKLGQP, KLGQPL]
-PFTSIF = []
-PLSPFT = [BMJVHF, ASSAKQ, SAKQXP, KQXPIC, XPICXQ, ICXQIE]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QIPOUY = [XUJUTY, PQIPOU]
-SPFTSI = [LSPFTS]
-XLSXUJ = [PIPIVL, EXLSXU]
-ZUQEXL = [EGZUQE, GZUQEX]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -325,109 +19,349 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return FTSIFJ
+        return 9
 
     @property
     def output_keys(self):
-        return PLSPFT
+        return ["Out1", "Out2", "Out3", "Out4", "Out5", "OutHtr"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                9,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                10,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                11,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoByteStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, JRJHIU, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                14,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoBoolStructAccessor(
-                self.struct, RJHIUS, JHIUSO, HIUSOO, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 23, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 24, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 25, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 26, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 27, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 28, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 29, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 33, "ALL"
             ),
-            IUSOOQ: GeckoTempStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoWordStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoWordStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoWordStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, ZUQEXL, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 34, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, XLSXUJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 35, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, JUTYEK, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                20,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoTempStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, XLSXUJ, None, None, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 15, 0, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, PYYLIU, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 36, "ALL"
             ),
-            YYLIUX: GeckoTempStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoTempStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, EFJTAC, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 38, "ALL"),
+            "CPOTMaxOnTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOnTime", 39, "ALL"
             ),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, QIPOUY, None, None, QBMJVH
+            "CPOTMaxOffTime": GeckoWordStructAccessor(
+                self.struct, "CPOTMaxOffTime", 41, "ALL"
             ),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoTimeStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, QBMJVH),
-            QJYMOU: GeckoTimeStructAccessor(self.struct, QJYMOU, JYMOUN, QBMJVH),
-            YMOUNB: GeckoTimeStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, QBMJVH
+            "FiltOTDuration24H": GeckoWordStructAccessor(
+                self.struct, "FiltOTDuration24H", 43, "ALL"
             ),
-            LKXSJW: GeckoBoolStructAccessor(
-                self.struct, LKXSJW, KXSJWM, HIUSOO, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 45, "ALL"
             ),
-            XSJWMN: GeckoBoolStructAccessor(
-                self.struct, XSJWMN, KXSJWM, SJWMNZ, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                16,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            JWMNZM: GeckoBoolStructAccessor(
-                self.struct, JWMNZM, KXSJWM, WMNZMJ, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 17, None, ["CP", "P1"], None, None, "ALL"
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, IGYOUS, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                18,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, BWJYKL, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 46, "ALL"
             ),
-            WJYKLG: GeckoEnumStructAccessor(
-                self.struct, WJYKLG, JYKLGQ, None, LGQPLS, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 19, None, ["CP", "P1"], None, None, "ALL"
             ),
-            GQPLSP: GeckoWordStructAccessor(self.struct, GQPLSP, QPLSPF, QBMJVH),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 21, None, ["F", "C"], None, None, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 49, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 51, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                53,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 31, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 32, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                57,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 4, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 5, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 3, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 7, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 8, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                54,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 55, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 55, 1, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 55, 2, "ALL"
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                56,
+                None,
+                ["Unconfigured", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 58, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                59,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                22,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 47, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-50.py
+++ b/src/geckolib/driver/packs/inxe-log-50.py
@@ -12,873 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 50])
-AHEOCT = 308
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 463
-AMJMAO = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 56])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-AZMKQT = 50
-BDJQRJ = "".join(chr(c) for c in [80, 52, 76])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = 474
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-BJEUTO = 336
-BLKXSJ = 274
-BMJVHF = 284
-BQFYLJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 347
-BQSNQL = "".join(chr(c) for c in [105, 110, 89, 84])
-BSIRYX = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-BVWVUB = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-BWJYKL = 282
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-BXYBQS = "".join(chr(c) for c in [75, 54, 48, 48])
-BYGDSB = "".join(chr(c) for c in [80, 50, 72])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 48])
-CMCVDS = 477
-CPQIPO = 273
-CQBMJV = 317
-CQFFTT = 296
-CRTFMN = 324
-CTHBSK = 303
-CVDSSR = 478
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 265
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 449
-DGKEAK = 461
-DJQRJJ = "".join(chr(c) for c in [66, 76, 79])
-DNIBXT = 291
-DNQGVU = 331
-DQLAII = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-DSBDJQ = "".join(chr(c) for c in [80, 51, 76])
-DSSRUR = 479
-DUBSSU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 57])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 272
-EFXQGL = 257
-EJNIBX = "".join(chr(c) for c in [77, 73, 65])
-EKCWAO = 263
-EKVKZI = "".join(chr(c) for c in [85, 76])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-EUTOPH = 337
-FCRTFM = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 297
-FIKJPU = 450
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [72, 84, 82])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-FWRKIN = 288
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-FZDGKE = 460
-GDSBDJ = "".join(chr(c) for c in [80, 51, 72])
-GETIXQ = 467
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-GQPLSP = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-GVUNXN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-GYOUSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-HBSKSO = 304
-HBXIBH = 472
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 259
-HTBJEU = 335
-HUGTYI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 448
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-IACQFF = 295
-IAMJMA = 354
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-IBXTIA = 293
-IBXYBQ = "".join(chr(c) for c in [105, 110, 88, 77])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-IDUBSS = 300
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IGYOUS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-IIDNIB = 7
-IJUGSE = 343
-IKFWRK = 287
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 51])
-INEJNI = "".join(chr(c) for c in [105, 110, 88, 69])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IUXFEF = 270
-IVDNQG = 330
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IYWSKW = 327
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = 321
-JJVYFC = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [68, 74, 83, 52])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 52])
-JQRJJJ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-JUIKFW = 285
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-JVHFTH = 319
-JVYFCR = 322
-JWMNZM = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-JZTATD = 454
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 462
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-KINEJN = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-KJPUNR = 451
-KLGQPL = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 341
-KPHUOJ = 260
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-KVKZIL = "".join(chr(c) for c in [67, 69])
-KWIVDN = 329
-KXSJWM = 276
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-LAIIDN = "".join(chr(c) for c in [51, 48, 65])
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LHBQNR = 346
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-LKXSJW = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-LNMHXE = "".join(chr(c) for c in [51, 50, 75])
-LOIJUG = 342
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 262
-LXWAJV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-MAOAWB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-MCBFEG = 310
-MCGETI = 466
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-MHXEKV = "".join(chr(c) for c in [54, 52, 75])
-MJIGYO = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-MJMAOA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MKQTDK = 479
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-MNZMJI = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MOUNBL = 353
-NBLKXS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NHTBJE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-NIBXYB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [52, 56, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = 290
-NQTMFZ = 458
-NRJZTA = 453
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 348
-NXNKML = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-NZMJIG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-OACMCV = 476
-OAWBSI = 309
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 471
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 266
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PFTSIF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-PHUGTY = 339
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = 350
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 452
-PYYLIU = 267
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-QFYLJU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 332
-QIEFXQ = 6
-QIPOUY = 281
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [50, 53, 65])
-QLNMHX = "".join(chr(c) for c in [49, 54, 75])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 54])
-RKINEJ = 289
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-RXCHWD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-RYXBQF = 314
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [80, 52, 72])
-SELHBQ = 345
-SEMCGE = 465
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-SIRYXB = 311
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SKSOKP = 305
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SRURAZ = "".join(chr(c) for c in [76, 73])
-SSAKQX = 258
-SSUHBV = 316
-STSEMC = 464
-SUHBVW = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 455
-TBJEUT = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-TDZXNQ = 456
-TFMNHT = 325
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-TIXQVX = 468
-TMFZDG = 459
-TOPHUG = 338
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-TSIFJB = 351
-TTIDUB = 299
-TYIYWS = 326
-UBSSUH = 301
-UBYGDS = "".join(chr(c) for c in [80, 49, 76])
-UGSELH = 344
-UGTYIY = 340
-UHBVWV = "".join(chr(c) for c in [70, 117, 108, 108])
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 53])
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-VDQLAI = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VUBYGD = "".join(chr(c) for c in [80, 49, 72])
-VUNXNK = 333
-VWVUBY = 320
-VXOIHB = 470
-VYFCRT = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-WAJVDQ = "".join(chr(c) for c in [51, 79, 80])
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 49])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-WJYKLG = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-WMNZMJ = 278
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-WSKWIV = 328
-WVUBYG = "".join(chr(c) for c in [78, 65])
-XBQFYL = 315
-XCHWDA = 349
-XEKVKZ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-XFEFJT = 271
-XIBHZV = 473
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 334
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 469
-XSJWMN = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-XTIACQ = 294
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = "".join(chr(c) for c in [53, 79, 80])
-XYBQSN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 323
-YGDSBD = "".join(chr(c) for c in [80, 50, 76])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-YKLGQP = 283
-YLIUXF = 269
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = 352
-YPIPIV = 256
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ZILXWA = "".join(chr(c) for c in [80, 50, 50])
-ZMJIGY = 279
-ZMKQTD = 256
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 55])
-ZUQEXL = 261
-ZVOACM = 475
-ZXNQTM = 457
-AIIDNI = [QLAIID, LAIIDN]
-AJVDQL = [XWAJVD, WAJVDQ]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HBVWVU = [SUHBVW, UHBVWV]
-HXEKVK = [QLNMHX, LNMHXE, NMHXEK, MHXEKV]
-ILXWAJ = [USOOQN, ZILXWA]
-IUSOOQ = [IVLASS, PHUOJR]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-MNHTBJ = [
-    WVUBYG,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FMNHTB,
-]
-QRJJJV = [
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    JHIUSO,
-    DJQRJJ,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    JQRJJJ,
-]
-QSNQLN = [
-    KINEJN,
-    INEJNI,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-]
-RAZMKQ = [
-    QFYLJU,
-    SIFJBI,
-    JBIAMJ,
-    KLGQPL,
-    UNBLKX,
-    BQFYLJ,
-    FYLJUI,
-    JWMNZM,
-    ACCPQI,
-    PFTSIF,
-    QPLSPF,
-    OUSPBW,
-    GYOUSP,
-    YXBQFY,
-    GQPLSP,
-    FTSIFJ,
-    SPFTSI,
-    WJYKLG,
-    BIAMJM,
-    PBWJYK,
-    USPBWJ,
-    IFJBIA,
-    JMAOAW,
-    FJBIAM,
-    SPBWJY,
-    LSPFTS,
-    LGQPLS,
-    JYKLGQ,
-]
-RURAZM = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    SRURAZ,
-]
-SJWMNZ = [HFTHEC, XSJWMN, XSJWMN, XSJWMN]
-SSRURA = []
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UNXNKM = [
-    WVUBYG,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-URAZMK = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-VKZILX = [EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WBSIRY = [HFTHEC, AWBSIR, AWBSIR, AWBSIR]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -886,276 +19,951 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return AZMKQT
+        return 50
 
     @property
     def begin(self):
-        return ZMKQTD
+        return 256
 
     @property
     def end(self):
-        return MKQTDK
+        return 479
 
     @property
     def all_device_keys(self):
-        return RURAZM
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return URAZMK
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return RAZMKQ
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 284, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                256,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 258, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 258, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 258, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 258, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 257, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 257, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 260, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 260, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 260, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 260, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 259, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 259, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 259, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 259, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 259, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 259, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 259, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, CPQIPO, LRAHEO, None),
-            NBLKXS: GeckoTempStructAccessor(self.struct, NBLKXS, BLKXSJ, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, HIUSOO, RSJMCB, SJWMNZ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                261,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, WMNZMJ, ICXQIE, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, WMNZMJ, QIEFXQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, ICXQIE, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, LRAHEO, None),
-            IGYOUS: GeckoBoolStructAccessor(
-                self.struct, IGYOUS, JIGYOU, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                262,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, YOUSPB, LRAHEO, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, CPQIPO, OQNRSJ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, QIPOUY, QXPICX, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, QIPOUY, LRAHEO, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, ICXQIE, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, OQNRSJ, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, YKLGQP, XPICXQ, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, YKLGQP, RSJMCB, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, YKLGQP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, OQNRSJ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, PLSPFT, XPICXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PLSPFT, RSJMCB, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, PLSPFT, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, ICXQIE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, TSIFJB, OQNRSJ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, YOUSPB, OQNRSJ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, MOUNBL, QXPICX, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, MOUNBL, LRAHEO, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QXPICX, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, ZMJIGY, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, BWJYKL, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, BWJYKL, LRAHEO, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, BWJYKL, XPICXQ, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QXPICX, None),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, OAWBSI, LRAHEO, WBSIRY, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 263, "ALL"
             ),
-            BSIRYX: GeckoWordStructAccessor(self.struct, BSIRYX, SIRYXB, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, QXPICX, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, XBQFYL, LRAHEO, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, TSIFJB, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, TSIFJB, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, TSIFJB, XPICXQ, None),
-            LJUIKF: GeckoWordStructAccessor(self.struct, LJUIKF, JUIKFW, None),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, QSNQLN, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 265, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, QXPICX, HXEKVK, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                261,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, NQLNMH, ICXQIE, VKZILX, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                266,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, NQLNMH, OQNRSJ, ILXWAJ, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 267, "ALL"
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, NQLNMH, XPICXQ, AJVDQL, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 269, "ALL"
             ),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, NQLNMH, RSJMCB, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, NQLNMH, QIEFXQ, None),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, NQLNMH, IIDNIB, AIIDNI, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 270, "ALL"
             ),
-            IDNIBX: GeckoWordStructAccessor(self.struct, IDNIBX, DNIBXT, None),
-            NIBXTI: GeckoByteStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoWordStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoWordStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, HBVWVU, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 271, "ALL"
             ),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, VWVUBY, None, QRJJJV, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 272, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 272, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 272, 3, None
             ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, JJJVYF, None, QRJJJV, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 272, 4, None
             ),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, JVYFCR, None, QRJJJV, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 272, 5, None
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, QRJJJV, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 273, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 281, 3, None
             ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, QRJJJV, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 281, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 281, 6, None
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, MNHTBJ, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, LASSAK),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, LASSAK),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, LASSAK),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, LASSAK),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, LASSAK),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, LASSAK),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, QRJJJV, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, QRJJJV, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, QRJJJV, None, None, LASSAK
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 273, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 274, None
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, QRJJJV, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 276, None
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, QRJJJV, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                259,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, QRJJJV, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 278, 2, None
             ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, QRJJJV, None, None, LASSAK
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 278, 6, None
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, UNXNKM, None, None, LASSAK
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 279, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 280, 1, None
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, UNXNKM, None, None, LASSAK
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 280, 2, "ALL"
             ),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, LASSAK),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, LASSAK),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, LASSAK),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, LASSAK),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, LASSAK),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, LASSAK),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, LASSAK),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 273, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 281, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 281, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 282, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 282, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 283, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 283, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 283, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 283, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 279, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 282, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 282, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 282, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 340, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                332,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 341, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 342, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 343, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 344, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 345, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 346, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 347, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 348, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 349, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-51.py
+++ b/src/geckolib/driver/packs/inxe-log-51.py
@@ -12,873 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 50])
-AHEOCT = 308
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 463
-AMJMAO = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 56])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-AZMKQT = 51
-BDJQRJ = "".join(chr(c) for c in [80, 52, 76])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = 474
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-BJEUTO = 336
-BLKXSJ = 275
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 346
-BQSNQL = "".join(chr(c) for c in [105, 110, 89, 84])
-BSIRYX = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-BVWVUB = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-BWJYKL = 283
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-BXYBQS = "".join(chr(c) for c in [75, 54, 48, 48])
-BYGDSB = "".join(chr(c) for c in [80, 50, 72])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 48])
-CMCVDS = 477
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = 296
-CRTFMN = 324
-CTHBSK = 303
-CVDSSR = 478
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 449
-DGKEAK = 461
-DJQRJJ = "".join(chr(c) for c in [66, 76, 79])
-DNIBXT = 291
-DNQGVU = 330
-DQLAII = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-DSBDJQ = "".join(chr(c) for c in [80, 51, 76])
-DSSRUR = 479
-DUBSSU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 57])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [77, 73, 65])
-EKCWAO = 264
-EKVKZI = "".join(chr(c) for c in [85, 76])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-EUTOPH = 337
-FCRTFM = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 297
-FIKJPU = 450
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [72, 84, 82])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-FWRKIN = 288
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-FZDGKE = 460
-GDSBDJ = "".join(chr(c) for c in [80, 51, 72])
-GETIXQ = 467
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-GQPLSP = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-GVUNXN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-GYOUSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-HBSKSO = 304
-HBXIBH = 472
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = 335
-HUGTYI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 448
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-IACQFF = 295
-IAMJMA = 354
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-IBXTIA = 293
-IBXYBQ = "".join(chr(c) for c in [105, 110, 88, 77])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-IDUBSS = 300
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IGYOUS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-IIDNIB = 7
-IJUGSE = 342
-IKFWRK = 287
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 51])
-INEJNI = "".join(chr(c) for c in [105, 110, 88, 69])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IUXFEF = 271
-IVDNQG = 329
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IYWSKW = 326
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 281
-JJJVYF = 321
-JJVYFC = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [68, 74, 83, 52])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 52])
-JQRJJJ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-JUIKFW = 285
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-JVHFTH = 319
-JVYFCR = 322
-JWMNZM = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-JZTATD = 454
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 462
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-KINEJN = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-KJPUNR = 451
-KLGQPL = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 340
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-KVKZIL = "".join(chr(c) for c in [67, 69])
-KWIVDN = 328
-KXSJWM = 277
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-LAIIDN = "".join(chr(c) for c in [51, 48, 65])
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LHBQNR = 345
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-LKXSJW = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-LNMHXE = "".join(chr(c) for c in [51, 50, 75])
-LOIJUG = 341
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-MAOAWB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-MCBFEG = 310
-MCGETI = 466
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-MHXEKV = "".join(chr(c) for c in [54, 52, 75])
-MJIGYO = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-MJMAOA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MKQTDK = 479
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-MNZMJI = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MOUNBL = 353
-NBLKXS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NHTBJE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-NIBXYB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [52, 56, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = 290
-NQTMFZ = 458
-NRJZTA = 453
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 347
-NXNKML = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-NZMJIG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-OACMCV = 476
-OAWBSI = 309
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 471
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PFTSIF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-PHUGTY = 339
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = 350
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 452
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-QFYLJU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 331
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [50, 53, 65])
-QLNMHX = "".join(chr(c) for c in [49, 54, 75])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 54])
-RKINEJ = 289
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-RXCHWD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-RYXBQF = 314
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [80, 52, 72])
-SELHBQ = 344
-SEMCGE = 465
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-SIRYXB = 311
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SKSOKP = 305
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SRURAZ = "".join(chr(c) for c in [76, 73])
-SSAKQX = 259
-SSUHBV = 316
-STSEMC = 464
-SUHBVW = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 455
-TBJEUT = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-TDZXNQ = 456
-TFMNHT = 334
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-TIXQVX = 468
-TMFZDG = 459
-TOPHUG = 338
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-TSIFJB = 351
-TTIDUB = 299
-TYIYWS = 325
-UBSSUH = 301
-UBYGDS = "".join(chr(c) for c in [80, 49, 76])
-UGSELH = 343
-UGTYIY = 349
-UHBVWV = "".join(chr(c) for c in [70, 117, 108, 108])
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 53])
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-VDQLAI = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VUBYGD = "".join(chr(c) for c in [80, 49, 72])
-VUNXNK = 332
-VWVUBY = 320
-VXOIHB = 470
-VYFCRT = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-WAJVDQ = "".join(chr(c) for c in [51, 79, 80])
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 49])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-WJYKLG = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-WMNZMJ = 279
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-WSKWIV = 327
-WVUBYG = "".join(chr(c) for c in [78, 65])
-XBQFYL = 315
-XCHWDA = 348
-XEKVKZ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-XFEFJT = 272
-XIBHZV = 473
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 333
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 469
-XSJWMN = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-XTIACQ = 294
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = "".join(chr(c) for c in [53, 79, 80])
-XYBQSN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 323
-YGDSBD = "".join(chr(c) for c in [80, 50, 76])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-YKLGQP = 284
-YLIUXF = 270
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = 352
-YPIPIV = 257
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ZILXWA = "".join(chr(c) for c in [80, 50, 50])
-ZMJIGY = 280
-ZMKQTD = 256
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 55])
-ZUQEXL = 262
-ZVOACM = 475
-ZXNQTM = 457
-AIIDNI = [QLAIID, LAIIDN]
-AJVDQL = [XWAJVD, WAJVDQ]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HBVWVU = [SUHBVW, UHBVWV]
-HXEKVK = [QLNMHX, LNMHXE, NMHXEK, MHXEKV]
-ILXWAJ = [USOOQN, ZILXWA]
-IUSOOQ = [IVLASS, PHUOJR]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-MNHTBJ = [
-    WVUBYG,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FMNHTB,
-]
-QRJJJV = [
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    JHIUSO,
-    DJQRJJ,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    JQRJJJ,
-]
-QSNQLN = [
-    KINEJN,
-    INEJNI,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-]
-RAZMKQ = [
-    QFYLJU,
-    SIFJBI,
-    JBIAMJ,
-    KLGQPL,
-    UNBLKX,
-    BQFYLJ,
-    FYLJUI,
-    JWMNZM,
-    ACCPQI,
-    PFTSIF,
-    QPLSPF,
-    OUSPBW,
-    GYOUSP,
-    YXBQFY,
-    GQPLSP,
-    FTSIFJ,
-    SPFTSI,
-    WJYKLG,
-    BIAMJM,
-    PBWJYK,
-    USPBWJ,
-    IFJBIA,
-    JMAOAW,
-    FJBIAM,
-    SPBWJY,
-    LSPFTS,
-    LGQPLS,
-    JYKLGQ,
-]
-RURAZM = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    SRURAZ,
-]
-SJWMNZ = [HFTHEC, XSJWMN, XSJWMN, XSJWMN]
-SSRURA = []
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UNXNKM = [
-    WVUBYG,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-URAZMK = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-VKZILX = [EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WBSIRY = [HFTHEC, AWBSIR, AWBSIR, AWBSIR]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -886,276 +19,951 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return AZMKQT
+        return 51
 
     @property
     def begin(self):
-        return ZMKQTD
+        return 256
 
     @property
     def end(self):
-        return MKQTDK
+        return 479
 
     @property
     def all_device_keys(self):
-        return RURAZM
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return URAZMK
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return RAZMKQ
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, CPQIPO, LRAHEO, None),
-            NBLKXS: GeckoTempStructAccessor(self.struct, NBLKXS, BLKXSJ, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, HIUSOO, RSJMCB, SJWMNZ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, WMNZMJ, ICXQIE, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, WMNZMJ, QIEFXQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, ICXQIE, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, LRAHEO, None),
-            IGYOUS: GeckoBoolStructAccessor(
-                self.struct, IGYOUS, JIGYOU, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, YOUSPB, LRAHEO, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, CPQIPO, OQNRSJ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, QIPOUY, QXPICX, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, QIPOUY, LRAHEO, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, ICXQIE, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, OQNRSJ, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, YKLGQP, XPICXQ, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, YKLGQP, RSJMCB, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, YKLGQP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, OQNRSJ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, PLSPFT, XPICXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PLSPFT, RSJMCB, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, PLSPFT, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, ICXQIE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, TSIFJB, OQNRSJ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, YOUSPB, OQNRSJ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, MOUNBL, QXPICX, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, MOUNBL, LRAHEO, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QXPICX, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, ZMJIGY, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, BWJYKL, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, BWJYKL, LRAHEO, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, BWJYKL, XPICXQ, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QXPICX, None),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, OAWBSI, LRAHEO, WBSIRY, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            BSIRYX: GeckoWordStructAccessor(self.struct, BSIRYX, SIRYXB, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, QXPICX, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, XBQFYL, LRAHEO, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, TSIFJB, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, TSIFJB, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, TSIFJB, XPICXQ, None),
-            LJUIKF: GeckoWordStructAccessor(self.struct, LJUIKF, JUIKFW, None),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, QSNQLN, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, QXPICX, HXEKVK, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, NQLNMH, ICXQIE, VKZILX, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, NQLNMH, OQNRSJ, ILXWAJ, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, NQLNMH, XPICXQ, AJVDQL, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, NQLNMH, RSJMCB, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, NQLNMH, QIEFXQ, None),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, NQLNMH, IIDNIB, AIIDNI, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            IDNIBX: GeckoWordStructAccessor(self.struct, IDNIBX, DNIBXT, None),
-            NIBXTI: GeckoByteStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoWordStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoWordStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, HBVWVU, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, VWVUBY, None, QRJJJV, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, JJJVYF, None, QRJJJV, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, JVYFCR, None, QRJJJV, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, QRJJJV, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, QRJJJV, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, MNHTBJ, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, LASSAK),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, LASSAK),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, LASSAK),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, LASSAK),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, LASSAK),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, LASSAK),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, QRJJJV, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, QRJJJV, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, QRJJJV, None, None, LASSAK
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, QRJJJV, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, QRJJJV, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, QRJJJV, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, QRJJJV, None, None, LASSAK
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, UNXNKM, None, None, LASSAK
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, UNXNKM, None, None, LASSAK
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
             ),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, LASSAK),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, LASSAK),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, LASSAK),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, LASSAK),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, LASSAK),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, LASSAK),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, LASSAK),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-52.py
+++ b/src/geckolib/driver/packs/inxe-log-52.py
@@ -12,875 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 49])
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [50, 53, 65])
-AJVDQL = "".join(chr(c) for c in [53, 79, 80])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 462
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 55])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BDJQRJ = "".join(chr(c) for c in [80, 51, 76])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = 473
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = 335
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 345
-BQSNQL = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-BVWVUB = "".join(chr(c) for c in [70, 117, 108, 108])
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-BXYBQS = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BYGDSB = "".join(chr(c) for c in [80, 49, 72])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-CHWDAF = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-CMCVDS = 476
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = 295
-CRTFMN = 323
-CTHBSK = 303
-CVDSSR = 477
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 448
-DGKEAK = 460
-DJQRJJ = "".join(chr(c) for c in [80, 52, 72])
-DNIBXT = 7
-DNQGVU = 329
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-DSBDJQ = "".join(chr(c) for c in [80, 50, 76])
-DSSRUR = 478
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 56])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [105, 110, 88, 69])
-EKCWAO = 264
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-EUTOPH = 336
-FCRTFM = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 296
-FIKJPU = 449
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-FWRKIN = 287
-FYLJUI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = 459
-GDSBDJ = "".join(chr(c) for c in [80, 50, 72])
-GETIXQ = 466
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HBXIBH = 471
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HUGTYI = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 348
-HXEKVK = "".join(chr(c) for c in [52, 56, 75])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-IACQFF = 294
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-IBXTIA = 291
-IBXYBQ = "".join(chr(c) for c in [68, 74, 83, 52])
-ICXQIE = 2
-IDUBSS = 299
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-IIDNIB = "".join(chr(c) for c in [51, 48, 65])
-IJUGSE = 341
-IKFWRK = 285
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 50])
-ILXWAJ = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-INEJNI = 289
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IUXFEF = 271
-IVDNQG = 328
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IYWSKW = 325
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJVYFC = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 51])
-JQRJJJ = "".join(chr(c) for c in [80, 52, 76])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(chr(c) for c in [51, 79, 80])
-JVHFTH = 319
-JVYFCR = 321
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = 453
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 461
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KJPUNR = 450
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 333
-KPHUOJ = 261
-KQTDKH = 256
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-KWIVDN = 327
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [67, 69])
-LAIIDN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = 344
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LNMHXE = 290
-LOIJUG = 340
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = "".join(chr(c) for c in [80, 50, 50])
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = 465
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-MHXEKV = "".join(chr(c) for c in [51, 50, 75])
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MKQTDK = 52
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-MNHTBJ = 334
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NHTBJE = "".join(chr(c) for c in [72, 84, 82])
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-NIBXYB = "".join(chr(c) for c in [77, 73, 65])
-NKMLOI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-NMHXEK = "".join(chr(c) for c in [49, 54, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQTMFZ = 457
-NRJZTA = 452
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 346
-NXNKML = 332
-NZMJIG = 279
-OACMCV = 475
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 470
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = 338
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 451
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-QFYLJU = 315
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 330
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [66, 76, 79])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QTDKHT = 479
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 53])
-RKINEJ = 288
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-RXCHWD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-RYXBQF = 311
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [80, 51, 72])
-SELHBQ = 343
-SEMCGE = 464
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-SNQLNM = "".join(chr(c) for c in [105, 110, 89, 84])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SRURAZ = 479
-SSAKQX = 259
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-SSUHBV = 301
-STSEMC = 463
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 454
-TBJEUT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TDZXNQ = 455
-TFMNHT = 324
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TIXQVX = 467
-TMFZDG = 458
-TOPHUG = 337
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 297
-TYIYWS = 349
-UBSSUH = 300
-UBYGDS = "".join(chr(c) for c in [78, 65])
-UGSELH = 342
-UGTYIY = 339
-UHBVWV = 316
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 52])
-UNXNKM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-URAZMK = "".join(chr(c) for c in [76, 73])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [85, 76])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-VUBYGD = 320
-VUNXNK = 331
-VXOIHB = 469
-VYFCRT = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-WAJVDQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 48])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-WSKWIV = 326
-WVUBYG = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-XBQFYL = 314
-XCHWDA = 347
-XEKVKZ = "".join(chr(c) for c in [54, 52, 75])
-XFEFJT = 272
-XIBHZV = 472
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 57])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 468
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = 293
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XYBQSN = "".join(chr(c) for c in [105, 110, 88, 77])
-YBQSNQ = "".join(chr(c) for c in [75, 54, 48, 48])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 322
-YGDSBD = "".join(chr(c) for c in [80, 49, 76])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 54])
-ZUQEXL = 262
-ZVOACM = 474
-ZXNQTM = 456
-AZMKQT = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EKVKZI = [NMHXEK, MHXEKV, HXEKVK, XEKVKZ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HTBJEU = [
-    UBYGDS,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    NHTBJE,
-]
-IDNIBX = [AIIDNI, IIDNIB]
-IUSOOQ = [IVLASS, PHUOJR]
-JJJVYF = [
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    JHIUSO,
-    QRJJJV,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    RJJJVY,
-]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-NQLNMH = [
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-]
-RAZMKQ = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    URAZMK,
-]
-RURAZM = []
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VDQLAI = [AJVDQL, JVDQLA]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VWVUBY = [HBVWVU, BVWVUB]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-XNKMLO = [
-    UBYGDS,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-XWAJVD = [USOOQN, LXWAJV]
-ZILXWA = [VKZILX, KZILXW]
-ZMKQTD = [
-    YLJUIK,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    FYLJUI,
-    LJUIKF,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    BQFYLJ,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -888,277 +19,952 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return MKQTDK
+        return 52
 
     @property
     def begin(self):
-        return KQTDKH
+        return 256
 
     @property
     def end(self):
-        return QTDKHT
+        return 479
 
     @property
     def all_device_keys(self):
-        return RAZMKQ
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return AZMKQT
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return ZMKQTD
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoWordStructAccessor(self.struct, IRYXBQ, RYXBQF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, IFJBIA, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, XPICXQ, None),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, NQLNMH, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, QXPICX, EKVKZI, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, LNMHXE, ICXQIE, ZILXWA, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LNMHXE, OQNRSJ, XWAJVD, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, LNMHXE, XPICXQ, VDQLAI, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, LNMHXE, RSJMCB, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LNMHXE, QIEFXQ, None),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, LNMHXE, DNIBXT, IDNIBX, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoWordStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, VWVUBY, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, VUBYGD, None, JJJVYF, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, JVYFCR, None, JJJVYF, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, JJJVYF, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, JJJVYF, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, JJJVYF, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, HTBJEU, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, LASSAK),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, LASSAK),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, LASSAK),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, LASSAK),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, LASSAK),
-            GTYIYW: GeckoByteStructAccessor(self.struct, GTYIYW, TYIYWS, LASSAK),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, JJJVYF, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, JJJVYF, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, JJJVYF, None, None, LASSAK
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, JJJVYF, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, JJJVYF, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, JJJVYF, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, JJJVYF, None, None, LASSAK
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, XNKMLO, None, None, LASSAK
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, XNKMLO, None, None, LASSAK
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
             ),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, LASSAK),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, LASSAK),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, LASSAK),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, LASSAK),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, LASSAK),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, LASSAK),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, LASSAK),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, LASSAK),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-53.py
+++ b/src/geckolib/driver/packs/inxe-log-53.py
@@ -12,878 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 55])
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [50, 53, 65])
-AJVDQL = "".join(chr(c) for c in [53, 79, 80])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 468
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BDJQRJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = 479
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [80, 51, 72])
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 450
-BQSNQL = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-BVWVUB = "".join(chr(c) for c in [70, 117, 108, 108])
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-BXYBQS = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BYGDSB = "".join(chr(c) for c in [75, 52, 48, 48])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 53])
-CMCVDS = 53
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = 295
-CRTFMN = 361
-CTHBSK = 303
-CVDSSR = 479
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 454
-DGKEAK = 466
-DJQRJJ = "".join(chr(c) for c in [75, 49, 48, 48])
-DNIBXT = 7
-DNQGVU = 327
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-DSBDJQ = "".join(chr(c) for c in [75, 52])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [105, 110, 88, 69])
-EKCWAO = 264
-ELHBQN = "".join(chr(c) for c in [67, 70, 71, 49])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-EUTOPH = "".join(chr(c) for c in [80, 52, 72])
-FCRTFM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 296
-FIKJPU = 455
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [78, 65])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-FWRKIN = 287
-FYLJUI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = 465
-GDSBDJ = "".join(chr(c) for c in [75, 56])
-GETIXQ = 472
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [67, 70, 71, 48])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 50])
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HBXIBH = 477
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = "".join(chr(c) for c in [80, 50, 72])
-HUGTYI = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 453
-HXEKVK = "".join(chr(c) for c in [52, 56, 75])
-IACQFF = 294
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-IBXTIA = 291
-IBXYBQ = "".join(chr(c) for c in [68, 74, 83, 52])
-ICXQIE = 2
-IDUBSS = 299
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-IIDNIB = "".join(chr(c) for c in [51, 48, 65])
-IKFWRK = 285
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 56])
-ILXWAJ = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-INEJNI = 289
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IUXFEF = 271
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-IYWSKW = 323
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [80, 51, 76])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJVYFC = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 57])
-JQRJJJ = "".join(chr(c) for c in [75, 56, 48, 48])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(chr(c) for c in [51, 79, 80])
-JVHFTH = 319
-JVYFCR = 358
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = 459
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 467
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KJPUNR = 456
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-KWIVDN = 326
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [67, 69])
-LAIIDN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = 449
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LNMHXE = 290
-LOIJUG = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = "".join(chr(c) for c in [80, 50, 50])
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = 471
-MCVDSS = 256
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-MHXEKV = "".join(chr(c) for c in [51, 50, 75])
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = 333
-MNHTBJ = "".join(chr(c) for c in [80, 49, 72])
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NHTBJE = "".join(chr(c) for c in [80, 49, 76])
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-NIBXYB = "".join(chr(c) for c in [77, 73, 65])
-NKMLOI = 331
-NMHXEK = "".join(chr(c) for c in [49, 54, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQTMFZ = 463
-NRJZTA = 458
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 451
-NXNKML = 330
-NZMJIG = 279
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 476
-OIJUGS = 325
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 457
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-QFYLJU = 315
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 328
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 51])
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-RKINEJ = 288
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 52])
-RYXBQF = 311
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [75, 53])
-SELHBQ = 448
-SEMCGE = 470
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-SNQLNM = "".join(chr(c) for c in [105, 110, 89, 84])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SSAKQX = 259
-SSUHBV = 301
-STSEMC = 469
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 460
-TBJEUT = "".join(chr(c) for c in [80, 50, 76])
-TDZXNQ = 461
-TFMNHT = 320
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TIXQVX = 473
-TMFZDG = 464
-TOPHUG = "".join(chr(c) for c in [66, 76, 79])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 297
-TYIYWS = 322
-UBSSUH = 300
-UBYGDS = "".join(chr(c) for c in [75, 50, 48, 48])
-UGSELH = 332
-UGTYIY = 321
-UHBVWV = 316
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = "".join(chr(c) for c in [80, 52, 76])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [85, 76])
-VUBYGD = 357
-VUNXNK = 329
-VXOIHB = 475
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-WAJVDQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 54])
-WIVDNQ = "".join(chr(c) for c in [72, 84, 82])
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-WSKWIV = 324
-WVUBYG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-XBQFYL = 314
-XCHWDA = 452
-XEKVKZ = "".join(chr(c) for c in [54, 52, 75])
-XFEFJT = 272
-XIBHZV = 478
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 474
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = 293
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XYBQSN = "".join(chr(c) for c in [105, 110, 88, 77])
-YBQSNQ = "".join(chr(c) for c in [75, 54, 48, 48])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 360
-YGDSBD = "".join(chr(c) for c in [75, 56, 53])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-ZUQEXL = 262
-ZVOACM = "".join(chr(c) for c in [76, 73])
-ZXNQTM = 462
-ACMCVD = [
-    YLJUIK,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    FYLJUI,
-    LJUIKF,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    BQFYLJ,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EKVKZI = [NMHXEK, MHXEKV, HXEKVK, XEKVKZ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HZVOAC = []
-IDNIBX = [AIIDNI, IIDNIB]
-IJUGSE = [
-    FMNHTB,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-IUSOOQ = [IVLASS, PHUOJR]
-IVDNQG = [
-    FMNHTB,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    WIVDNQ,
-]
-JJJVYF = [
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    QRJJJV,
-    RJJJVY,
-]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-NQLNMH = [
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-]
-OACMCV = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-PHUGTY = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    JHIUSO,
-    TOPHUG,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    OPHUGT,
-]
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VDQLAI = [AJVDQL, JVDQLA]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VOACMC = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    ZVOACM,
-]
-VWVUBY = [HBVWVU, BVWVUB]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-XWAJVD = [USOOQN, LXWAJV]
-ZILXWA = [VKZILX, KZILXW]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -891,251 +19,743 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return CMCVDS
+        return 53
 
     @property
     def begin(self):
-        return MCVDSS
+        return 256
 
     @property
     def end(self):
-        return CVDSSR
+        return 479
 
     @property
     def all_device_keys(self):
-        return VOACMC
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return OACMCV
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return ACMCVD
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoWordStructAccessor(self.struct, IRYXBQ, RYXBQF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, IFJBIA, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, XPICXQ, None),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, NQLNMH, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, QXPICX, EKVKZI, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, LNMHXE, ICXQIE, ZILXWA, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LNMHXE, OQNRSJ, XWAJVD, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, LNMHXE, XPICXQ, VDQLAI, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, LNMHXE, RSJMCB, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LNMHXE, QIEFXQ, None),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, LNMHXE, DNIBXT, IDNIBX, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoWordStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, VWVUBY, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, VUBYGD, None, JJJVYF, None, None, None
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, PHUGTY, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, PHUGTY, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, PHUGTY, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, PHUGTY, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, PHUGTY, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, IVDNQG, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            VDNQGV: GeckoByteStructAccessor(self.struct, VDNQGV, DNQGVU, LASSAK),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, LASSAK),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, LASSAK),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, LASSAK),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, LASSAK),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, LASSAK),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, IJUGSE, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, LASSAK),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-54.py
+++ b/src/geckolib/driver/packs/inxe-log-54.py
@@ -12,883 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-ACMCVD = "".join(chr(c) for c in [76, 73])
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-AFIKJP = 453
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AONPYY = 266
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = 459
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BDJQRJ = "".join(chr(c) for c in [75, 52])
-BFEGZU = 310
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BJEUTO = "".join(chr(c) for c in [80, 49, 76])
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BQNRXC = "".join(chr(c) for c in [67, 70, 71, 49])
-BQSNQL = "".join(chr(c) for c in [105, 110, 88, 77])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-BVWVUB = 316
-BWJYKL = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-BXIBHZ = 476
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BXYBQS = "".join(chr(c) for c in [77, 73, 65])
-BYGDSB = 357
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-CGETIX = 470
-CHWDAF = 451
-CPQIPO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-CQBMJV = 317
-CQFFTT = 294
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-CTHBSK = 303
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 264
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 53])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-DJQRJJ = "".join(chr(c) for c in [75, 53])
-DNIBXT = "".join(chr(c) for c in [51, 48, 65])
-DNQGVU = "".join(chr(c) for c in [72, 84, 82])
-DQLAII = "".join(chr(c) for c in [51, 79, 80])
-DSBDJQ = "".join(chr(c) for c in [75, 56, 53])
-DSSRUR = 256
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DZXNQT = 460
-EAKSTS = 466
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 272
-EFXQGL = 258
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = 289
-EKVKZI = "".join(chr(c) for c in [52, 56, 75])
-ELHBQN = 332
-EMCGET = 469
-EOCTHB = 307
-ETIXQV = 471
-EUTOPH = "".join(chr(c) for c in [80, 50, 76])
-EXLSXU = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-FCRTFM = 358
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = 295
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 54])
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FJTACC = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FMNHTB = 361
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = 350
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-FWRKIN = 285
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-GDSBDJ = "".join(chr(c) for c in [75, 52, 48, 48])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-GKEAKS = 465
-GQPLSP = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-GVUNXN = 327
-GYOUSP = 280
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = 448
-HBSKSO = 362
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = "".join(chr(c) for c in [78, 65])
-HUGTYI = "".join(chr(c) for c in [66, 76, 79])
-HUOJRJ = 261
-HWDAFI = "".join(chr(c) for c in [67, 70, 71, 52])
-HXEKVK = "".join(chr(c) for c in [49, 54, 75])
-HZVOAC = 478
-IACQFF = 293
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IBHZVO = 477
-IBXTIA = 7
-IBXYBQ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [50, 53, 65])
-IDUBSS = 297
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IGYOUS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-IHBXIB = 475
-IIDNIB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-IJUGSE = 333
-IKFWRK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-IKJPUN = 454
-ILXWAJ = "".join(chr(c) for c in [67, 69])
-INEJNI = 288
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = 270
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = 472
-IYWSKW = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-JBIAMJ = 351
-JEUTOP = "".join(chr(c) for c in [80, 50, 72])
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JJJVYF = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JJVYFC = "".join(chr(c) for c in [75, 51, 48, 48])
-JMAOAW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-JMCBFE = 5
-JNIBXY = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-JPUNRJ = 455
-JQRJJJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JTACCP = 273
-JUGSEL = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-JUIKFW = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-JUTYEK = "".join(chr(c) for c in [83, 84, 79, 80])
-JVDQLA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JWMNZM = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JYKLGQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JYMOUN = "".join(chr(c) for c in [77, 69, 68])
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KCWAON = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 55])
-KLGQPL = 283
-KMLOIJ = 330
-KPHUOJ = 306
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = 467
-KVKZIL = "".join(chr(c) for c in [54, 52, 75])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-KXSJWM = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-LHBQNR = "".join(chr(c) for c in [67, 70, 71, 48])
-LIUXFE = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LJUIKF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-LKXSJW = 355
-LOIJUG = 331
-LRAHEO = 1
-LSPFTS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-MAOAWB = 354
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-MFZDGK = 463
-MHXEKV = 290
-MJIGYO = 279
-MJMAOA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-MNZMJI = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-NBLKXS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-NEJNIB = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-NHTBJE = 320
-NIBXYB = "".join(chr(c) for c in [105, 110, 88, 69])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-NPYYLI = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-NQJYMO = 313
-NQLNMH = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 57])
-NRSJMC = 3
-NRXCHW = "".join(chr(c) for c in [67, 70, 71, 50])
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-OAWBSI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 52, 72])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-OUSPBW = 281
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-PBWJYK = 352
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [80, 52, 76])
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-POUYNQ = 282
-PQIPOU = "".join(chr(c) for c in [67, 80, 79, 84])
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 56])
-PYYLIU = 267
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 262
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-QFYLJU = 314
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-QIEFXQ = 6
-QIPOUY = 274
-QJYMOU = "".join(chr(c) for c in [78, 79])
-QLNMHX = "".join(chr(c) for c in [105, 110, 89, 84])
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QNRXCH = 449
-QPLSPF = 284
-QRJJJV = "".join(chr(c) for c in [75, 49, 48, 48])
-QSNQLN = "".join(chr(c) for c in [75, 54, 48, 48])
-QTMFZD = 462
-QVXOIH = 473
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [75, 56, 48, 48])
-RJZTAT = 457
-RKINEJ = 287
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = 360
-RXCHWD = 450
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [75, 56])
-SELHBQ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-SIFJBI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SIRYXB = 309
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 275
-SKSOKP = 304
-SKWIVD = 323
-SNQLNM = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-SOKPHU = 305
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SPFTSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-SSAKQX = 259
-SSRURA = 479
-SSUHBV = 300
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-SUHBVW = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-SXUJUT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-TACCPQ = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TBJEUT = "".join(chr(c) for c in [80, 49, 72])
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 49, 76, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-TOPHUG = "".join(chr(c) for c in [80, 51, 76])
-TSEMCG = 468
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-TTIDUB = 296
-TYEKCW = "".join(chr(c) for c in [78, 69, 87])
-TYIYWS = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-UBSSUH = 299
-UBYGDS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-UGSELH = 325
-UGTYIY = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-UHBVWV = 301
-UIKFWR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-UJUTYE = "".join(chr(c) for c in [73, 68, 76, 69])
-UNBLKX = 353
-UNRJZT = 456
-UNXNKM = 328
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-USOOQN = 260
-USPBWJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-UTOPHU = "".join(chr(c) for c in [80, 51, 72])
-UTYEKC = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-UYNQJY = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-VDNQGV = 326
-VDQLAI = "".join(chr(c) for c in [53, 79, 80])
-VDSSRU = 54
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VOACMC = 479
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-VWVUBY = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-WAJVDQ = "".join(chr(c) for c in [80, 50, 50])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-WBSIRY = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-WDAFIK = 452
-WIVDNQ = 324
-WJYKLG = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-WMNZMJ = 277
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-WVUBYG = "".join(chr(c) for c in [70, 117, 108, 108])
-XBQFYL = 311
-XCHWDA = "".join(chr(c) for c in [67, 70, 71, 51])
-XEKVKZ = "".join(chr(c) for c in [51, 50, 75])
-XFEFJT = 271
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-XLSXUJ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-XNKMLO = 329
-XNQTMF = 461
-XOIHBX = 474
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-XSJWMN = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-XTIACQ = 291
-XUJUTY = 263
-XWAJVD = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-XYBQSN = "".join(chr(c) for c in [68, 74, 83, 52])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-YEKCWA = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YFCRTF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-YGDSBD = "".join(chr(c) for c in [75, 50, 48, 48])
-YIYWSK = 321
-YKLGQP = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-YLIUXF = 268
-YLJUIK = 315
-YMOUNB = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-YNQJYM = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YOUSPB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = 257
-YWSKWI = 322
-YXBQFY = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YYLIUX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 464
-ZILXWA = "".join(chr(c) for c in [85, 76])
-ZMJIGY = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-ZTATDZ = 458
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-AJVDQL = [OOQNRS, WAJVDQ]
-CMCVDS = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    ACMCVD,
-]
-CVDSSR = [
-    JUIKFW,
-    BIAMJM,
-    MJMAOA,
-    PLSPFT,
-    KXSJWM,
-    LJUIKF,
-    UIKFWR,
-    ZMJIGY,
-    CPQIPO,
-    IFJBIA,
-    PFTSIF,
-    BWJYKL,
-    SPBWJY,
-    FYLJUI,
-    SPFTSI,
-    FJBIAM,
-    SIFJBI,
-    LGQPLS,
-    JMAOAW,
-    YKLGQP,
-    WJYKLG,
-    IAMJMA,
-    AWBSIR,
-    AMJMAO,
-    JYKLGQ,
-    TSIFJB,
-    LSPFTS,
-    GQPLSP,
-]
-EKCWAO = [UJUTYE, JUTYEK, UTYEKC, TYEKCW, YEKCWA]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-GSELHB = [
-    HTBJEU,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    OQNRSJ,
-]
-GTYIYW = [
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    IUSOOQ,
-    HUGTYI,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    UGTYIY,
-]
-JRJHIU = [IVLASS, UOJRJH, OJRJHI]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-LNMHXE = [
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-]
-LSXUJU = [EXLSXU, XLSXUJ]
-LXWAJV = [ZILXWA, ILXWAJ]
-MCVDSS = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-MOUNBL = [QJYMOU, SAKQXP, JYMOUN, AKQXPI, YMOUNB]
-NIBXTI = [IDNIBX, DNIBXT]
-NQGVUN = [
-    HTBJEU,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    DNQGVU,
-]
-NZMJIG = [HFTHEC, MNZMJI, MNZMJI, MNZMJI]
-OACMCV = []
-QLAIID = [VDQLAI, DQLAII]
-RYXBQF = [HFTHEC, IRYXBQ, IRYXBQ, IRYXBQ]
-SOOQNR = [IVLASS, UOJRJH]
-VKZILX = [HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VUBYGD = [VWVUBY, WVUBYG]
-VYFCRT = [
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -896,252 +19,746 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return VDSSRU
+        return 54
 
     @property
     def begin(self):
-        return DSSRUR
+        return 256
 
     @property
     def end(self):
-        return SSRURA
+        return 479
 
     @property
     def all_device_keys(self):
-        return CMCVDS
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return MCVDSS
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdP1LTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return CVDSSR
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, LASSAK),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, QXPICX, JRJHIU, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, ICXQIE, JRJHIU, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, XPICXQ, JRJHIU, None, XPICXQ, None
+            "UdP1LTime": GeckoByteStructAccessor(self.struct, "UdP1LTime", 362, "ALL"),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, QIEFXQ, JRJHIU, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QXPICX, SOOQNR, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, QXPICX, LSXUJU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, EKCWAO, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            KCWAON: GeckoTimeStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, LASSAK),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, QEXLSX, ICXQIE, LSXUJU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, EKCWAO, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            YYLIUX: GeckoTimeStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, LASSAK),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, JTACCP, QXPICX, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, JTACCP, ICXQIE, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, JTACCP, NRSJMC, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, JTACCP, XPICXQ, None),
-            CPQIPO: GeckoBoolStructAccessor(self.struct, CPQIPO, JTACCP, JMCBFE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, ICXQIE, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, POUYNQ, NRSJMC, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, POUYNQ, JMCBFE, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, POUYNQ, QIEFXQ, None),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, MOUNBL, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, UNBLKX, JMCBFE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, UNBLKX, QIEFXQ, None),
-            BLKXSJ: GeckoWordStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, QIPOUY, LRAHEO, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoTempStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, USOOQN, JMCBFE, NZMJIG, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, MJIGYO, ICXQIE, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, MJIGYO, QIEFXQ, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, ICXQIE, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, LRAHEO, None),
-            USPBWJ: GeckoBoolStructAccessor(
-                self.struct, USPBWJ, OUSPBW, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, LRAHEO, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, NRSJMC, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, POUYNQ, QXPICX, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, POUYNQ, LRAHEO, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, ICXQIE, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, KLGQPL, NRSJMC, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, NRSJMC, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, QPLSPF, XPICXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, QPLSPF, JMCBFE, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, QPLSPF, QIEFXQ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, NRSJMC, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, XPICXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, FTSIFJ, JMCBFE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FTSIFJ, QIEFXQ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, ICXQIE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JBIAMJ, NRSJMC, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, PBWJYK, NRSJMC, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, UNBLKX, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, UNBLKX, LRAHEO, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, GYOUSP, QXPICX, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, KLGQPL, QXPICX, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, KLGQPL, LRAHEO, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, KLGQPL, XPICXQ, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, QXPICX, None),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, SIRYXB, LRAHEO, RYXBQF, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            YXBQFY: GeckoWordStructAccessor(self.struct, YXBQFY, XBQFYL, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YLJUIK, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, YLJUIK, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, JBIAMJ, QXPICX, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JBIAMJ, LRAHEO, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JBIAMJ, XPICXQ, None),
-            KFWRKI: GeckoWordStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, None),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, LNMHXE, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, QXPICX, VKZILX, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, MHXEKV, ICXQIE, LXWAJV, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, MHXEKV, NRSJMC, AJVDQL, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, MHXEKV, XPICXQ, QLAIID, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, MHXEKV, JMCBFE, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, MHXEKV, QIEFXQ, None),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, MHXEKV, IBXTIA, NIBXTI, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            BXTIAC: GeckoWordStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoWordStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, VUBYGD, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, VYFCRT, None, None, None
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            YFCRTF: GeckoWordStructAccessor(self.struct, YFCRTF, FCRTFM, None),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, None),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, GTYIYW, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, GTYIYW, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, GTYIYW, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, GTYIYW, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, GTYIYW, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, NQGVUN, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, LASSAK),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, LASSAK),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, LASSAK),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, LASSAK),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, GSELHB, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, LASSAK),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-55.py
+++ b/src/geckolib/driver/packs/inxe-log-55.py
@@ -12,880 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AFIKJP = 454
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [50, 53, 65])
-AJVDQL = "".join(chr(c) for c in [53, 79, 80])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = 460
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BDJQRJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [80, 50, 76])
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = "".join(chr(c) for c in [67, 70, 71, 50])
-BQSNQL = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-BVWVUB = "".join(chr(c) for c in [70, 117, 108, 108])
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = 477
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-BXYBQS = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BYGDSB = "".join(chr(c) for c in [75, 52, 48, 48])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = 471
-CHWDAF = 452
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = 295
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-CTHBSK = 303
-CVDSSR = 256
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 54])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-DJQRJJ = "".join(chr(c) for c in [75, 49, 48, 48])
-DNIBXT = 7
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-DSBDJQ = "".join(chr(c) for c in [75, 52])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DZXNQT = 461
-EAKSTS = 467
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [105, 110, 88, 69])
-EKCWAO = 264
-ELHBQN = 448
-EMCGET = 470
-EOCTHB = 307
-ETIXQV = 472
-EUTOPH = "".join(chr(c) for c in [80, 51, 76])
-FCRTFM = 360
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 296
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 55])
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = 320
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-FWRKIN = 287
-FYLJUI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-GDSBDJ = "".join(chr(c) for c in [75, 56])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-GKEAKS = 466
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = 332
-GTYIYW = 321
-GVUNXN = 328
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = 449
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = "".join(chr(c) for c in [67, 70, 71, 53])
-HXEKVK = "".join(chr(c) for c in [52, 56, 75])
-HZVOAC = 479
-IACQFF = 294
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = 478
-IBXTIA = 291
-IBXYBQ = "".join(chr(c) for c in [68, 74, 83, 52])
-ICXQIE = 2
-IDUBSS = 299
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = 476
-IIDNIB = "".join(chr(c) for c in [51, 48, 65])
-IJUGSE = 325
-IKFWRK = 285
-IKJPUN = 455
-ILXWAJ = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-INEJNI = 289
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IUXFEF = 271
-IVDNQG = "".join(chr(c) for c in [72, 84, 82])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = 473
-IYWSKW = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [80, 51, 72])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JPUNRJ = 456
-JQRJJJ = "".join(chr(c) for c in [75, 56, 48, 48])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUIKFW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(chr(c) for c in [51, 79, 80])
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 56])
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 331
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = 468
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [67, 69])
-LAIIDN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = "".join(chr(c) for c in [67, 70, 71, 49])
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LNMHXE = 290
-LOIJUG = 333
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = "".join(chr(c) for c in [80, 50, 50])
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-MCVDSS = 55
-MFZDGK = 464
-MHXEKV = "".join(chr(c) for c in [51, 50, 75])
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [78, 65])
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NHTBJE = "".join(chr(c) for c in [80, 49, 72])
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-NIBXYB = "".join(chr(c) for c in [77, 73, 65])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [49, 54, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = 327
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = "".join(chr(c) for c in [67, 70, 71, 51])
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-NZMJIG = 279
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-OIJUGS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [66, 76, 79])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 57])
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-QFYLJU = 315
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = 450
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QTMFZD = 463
-QVXOIH = 474
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [75, 51, 48, 48])
-RJZTAT = 458
-RKINEJ = 288
-RSJMCB = 5
-RTFMNH = 361
-RXCHWD = 451
-RYXBQF = 311
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [75, 53])
-SELHBQ = "".join(chr(c) for c in [67, 70, 71, 48])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = 324
-SNQLNM = "".join(chr(c) for c in [105, 110, 89, 84])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SSAKQX = 259
-SSUHBV = 301
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TBJEUT = "".join(chr(c) for c in [80, 50, 72])
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-TFMNHT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-TOPHUG = "".join(chr(c) for c in [80, 52, 76])
-TSEMCG = 469
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 297
-TYIYWS = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-UBSSUH = 300
-UBYGDS = "".join(chr(c) for c in [75, 50, 48, 48])
-UGSELH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-UGTYIY = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-UHBVWV = 316
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = 457
-UNXNKM = 329
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = "".join(chr(c) for c in [80, 52, 72])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDSSRU = 479
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [85, 76])
-VOACMC = "".join(chr(c) for c in [76, 73])
-VUBYGD = 357
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-VYFCRT = 358
-WAJVDQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = 453
-WIVDNQ = 326
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-WVUBYG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-XBQFYL = 314
-XCHWDA = "".join(chr(c) for c in [67, 70, 71, 52])
-XEKVKZ = "".join(chr(c) for c in [54, 52, 75])
-XFEFJT = 272
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 330
-XNQTMF = 462
-XOIHBX = 475
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = 293
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XYBQSN = "".join(chr(c) for c in [105, 110, 88, 77])
-YBQSNQ = "".join(chr(c) for c in [75, 54, 48, 48])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-YGDSBD = "".join(chr(c) for c in [75, 56, 53])
-YIYWSK = 322
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = 323
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 465
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZTATDZ = 459
-ZUQEXL = 262
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ACMCVD = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-CMCVDS = [
-    YLJUIK,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    FYLJUI,
-    LJUIKF,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    BQFYLJ,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EKVKZI = [NMHXEK, MHXEKV, HXEKVK, XEKVKZ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HUGTYI = [
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    JHIUSO,
-    OPHUGT,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    PHUGTY,
-]
-IDNIBX = [AIIDNI, IIDNIB]
-IUSOOQ = [IVLASS, PHUOJR]
-JJVYFC = [
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-]
-JUGSEL = [
-    MNHTBJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-NQLNMH = [
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-]
-OACMCV = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    VOACMC,
-]
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VDNQGV = [
-    MNHTBJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    IVDNQG,
-]
-VDQLAI = [AJVDQL, JVDQLA]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VWVUBY = [HBVWVU, BVWVUB]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-XWAJVD = [USOOQN, LXWAJV]
-ZILXWA = [VKZILX, KZILXW]
-ZVOACM = []
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -893,251 +19,744 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return MCVDSS
+        return 55
 
     @property
     def begin(self):
-        return CVDSSR
+        return 256
 
     @property
     def end(self):
-        return VDSSRU
+        return 479
 
     @property
     def all_device_keys(self):
-        return OACMCV
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ACMCVD
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return CMCVDS
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoWordStructAccessor(self.struct, IRYXBQ, RYXBQF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, IFJBIA, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, XPICXQ, None),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, NQLNMH, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, QXPICX, EKVKZI, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, LNMHXE, ICXQIE, ZILXWA, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LNMHXE, OQNRSJ, XWAJVD, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, LNMHXE, XPICXQ, VDQLAI, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, LNMHXE, RSJMCB, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LNMHXE, QIEFXQ, None),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, LNMHXE, DNIBXT, IDNIBX, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoWordStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, VWVUBY, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, VUBYGD, None, JJVYFC, None, None, None
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JVYFCR: GeckoWordStructAccessor(self.struct, JVYFCR, VYFCRT, None),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, None),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, HUGTYI, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, HUGTYI, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, HUGTYI, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, HUGTYI, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, HUGTYI, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, VDNQGV, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, LASSAK),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, LASSAK),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, LASSAK),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, LASSAK),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, JUGSEL, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, LASSAK),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-56.py
+++ b/src/geckolib/driver/packs/inxe-log-56.py
@@ -12,899 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 271
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-ACQFFT = 7
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 51])
-AHEOCT = 1
-AIIDNI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-AJVDQL = "".join(chr(c) for c in [85, 76])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 464
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AONPYY = "".join(chr(c) for c in [78, 69, 87])
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 57])
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-AZMKQT = 479
-BDJQRJ = 357
-BFEGZU = 310
-BHZVOA = 475
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BJEUTO = 361
-BLKXSJ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-BMJVHF = 256
-BQFYLJ = 309
-BQSNQL = "".join(chr(c) for c in [105, 110, 88, 69])
-BSIRYX = 354
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = 296
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-BWJYKL = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BXTIAC = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-BXYBQS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BYGDSB = 316
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 49])
-CMCVDS = 478
-CPQIPO = 272
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-CRTFMN = "".join(chr(c) for c in [75, 51, 48, 48])
-CTHBSK = 307
-CVDSSR = 479
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(chr(c) for c in [83, 84, 79, 80])
-CXQIEF = 4
-DAFIKJ = 450
-DGKEAK = 462
-DJQRJJ = "".join(chr(c) for c in [75, 50, 48, 48])
-DNQGVU = 323
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-DSSRUR = "".join(chr(c) for c in [76, 73])
-DUBSSU = 295
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = 268
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-EKCWAO = 263
-ELHBQN = 333
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EUTOPH = 320
-EXLSXU = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-FCRTFM = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-FEFJTA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-FIKJPU = 451
-FJBIAM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-FJTACC = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FMNHTB = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-FTHECV = 319
-FTSIFJ = 284
-FTTIDU = 293
-FWRKIN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FZDGKE = 461
-GDSBDJ = "".join(chr(c) for c in [70, 117, 108, 108])
-GETIXQ = 468
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-GSELHB = 331
-GTYIYW = "".join(chr(c) for c in [80, 51, 76])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = 325
-HBSKSO = 303
-HBVWVU = 299
-HBXIBH = 473
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = 360
-HUGTYI = "".join(chr(c) for c in [80, 50, 76])
-HUOJRJ = 261
-HWDAFI = 449
-HXEKVK = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-IAMJMA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-IBXTIA = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-IBXYBQ = 288
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [51, 79, 80])
-IDUBSS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-IGYOUS = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-IIDNIB = "".join(chr(c) for c in [53, 79, 80])
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 52])
-ILXWAJ = "".join(chr(c) for c in [52, 56, 75])
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-IVDNQG = 322
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IYWSKW = "".join(chr(c) for c in [66, 76, 79])
-JBIAMJ = 350
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = 277
-JJJVYF = "".join(chr(c) for c in [75, 52])
-JJVYFC = "".join(chr(c) for c in [75, 53])
-JMAOAW = 351
-JMCBFE = 5
-JNIBXY = 287
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 53])
-JQRJJJ = "".join(chr(c) for c in [75, 52, 48, 48])
-JTACCP = 270
-JUGSEL = 330
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JVDQLA = "".join(chr(c) for c in [67, 69])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-JYKLGQ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JYMOUN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JZTATD = 455
-KCWAON = "".join(chr(c) for c in [73, 68, 76, 69])
-KEAKST = 463
-KFWRKI = 315
-KINEJN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-KJPUNR = 452
-KLGQPL = 352
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KPHUOJ = 306
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-KWIVDN = 321
-KXSJWM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-KZILXW = "".join(chr(c) for c in [49, 54, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-LHBQNR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-LIUXFE = 266
-LJUIKF = 311
-LNMHXE = "".join(chr(c) for c in [105, 110, 88, 77])
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 283
-LSXUJU = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-LXWAJV = "".join(chr(c) for c in [54, 52, 75])
-MAOAWB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = 467
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-MHXEKV = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-MJIGYO = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-MJMAOA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = 328
-MNHTBJ = 358
-MNZMJI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-MOUNBL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-NBLKXS = "".join(chr(c) for c in [77, 69, 68])
-NEJNIB = 285
-NHTBJE = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-NIBXTI = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-NIBXYB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NKMLOI = 327
-NMHXEK = "".join(chr(c) for c in [75, 54, 48, 48])
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NQJYMO = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NQLNMH = "".join(chr(c) for c in [68, 74, 83, 52])
-NQTMFZ = 459
-NRJZTA = 454
-NRSJMC = 3
-NRXCHW = 332
-NZMJIG = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-OACMCV = 477
-OAWBSI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = 472
-OIJUGS = 329
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 49, 76])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = 313
-OUSPBW = 279
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-PBWJYK = 280
-PFTSIF = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-PHUGTY = "".join(chr(c) for c in [80, 50, 72])
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-POUYNQ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-PQIPOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PUNRJZ = 453
-PYYLIU = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 364
-QFFTTI = 291
-QFYLJU = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-QGVUNX = 324
-QIEFXQ = 2
-QIPOUY = 273
-QJYMOU = 282
-QLAIID = "".join(chr(c) for c in [80, 50, 50])
-QLNMHX = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QNRXCH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-QRJJJV = "".join(chr(c) for c in [75, 56, 53])
-QSNQLN = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 256
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [75, 56])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 55])
-RKINEJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 48])
-RYXBQF = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-SELHBQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-SEMCGE = 466
-SIFJBI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SIRYXB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-SKSOKP = 304
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-SNQLNM = "".join(chr(c) for c in [77, 73, 65])
-SOKPHU = 305
-SPBWJY = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-SPFTSI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-SSUHBV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-STSEMC = 465
-SUHBVW = 297
-SXUJUT = 367
-TACCPQ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-TATDZX = 456
-TBJEUT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-TDZXNQ = 457
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [51, 48, 65])
-TIDUBS = 294
-TIXQVX = 469
-TMFZDG = 460
-TOPHUG = "".join(chr(c) for c in [80, 49, 72])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-TSIFJB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TYIYWS = "".join(chr(c) for c in [80, 52, 72])
-UBSSUH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-UGSELH = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-UGTYIY = "".join(chr(c) for c in [80, 51, 72])
-UHBVWV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-UIKFWR = 314
-UJUTYE = 262
-UNBLKX = "".join(chr(c) for c in [78, 79])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 54])
-UNXNKM = "".join(chr(c) for c in [72, 84, 82])
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-URAZMK = 56
-USOOQN = 260
-USPBWJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-UTOPHU = "".join(chr(c) for c in [78, 65])
-UTYEKC = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-VHFTHE = 6
-VKZILX = 290
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-VUBYGD = 301
-VUNXNK = 326
-VWVUBY = 300
-VXOIHB = 471
-VYFCRT = "".join(chr(c) for c in [75, 49, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-WAONPY = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-WBSIRY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 50])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-WJYKLG = 281
-WMNZMJ = 355
-WRKINE = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-WVUBYG = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-XBQFYL = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-XCHWDA = 448
-XEKVKZ = "".join(chr(c) for c in [105, 110, 89, 84])
-XFEFJT = 267
-XIBHZV = 474
-XLSXUJ = 365
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 470
-XSJWMN = 353
-XTIACQ = "".join(chr(c) for c in [50, 53, 65])
-XUJUTY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XYBQSN = 289
-YBQSNQ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YFCRTF = "".join(chr(c) for c in [75, 56, 48, 48])
-YGDSBD = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-YIYWSK = "".join(chr(c) for c in [80, 52, 76])
-YKLGQP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-YLJUIK = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YMOUNB = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YNQJYM = "".join(chr(c) for c in [67, 80, 79, 84])
-YOUSPB = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-YXBQFY = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-YYLIUX = 264
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ZILXWA = "".join(chr(c) for c in [51, 50, 75])
-ZMJIGY = 275
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 56])
-ZVOACM = 476
-ZXNQTM = 458
-BQNRXC = [
-    UTOPHU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    OQNRSJ,
-]
-DNIBXT = [IIDNIB, IDNIBX]
-DSBDJQ = [YGDSBD, GDSBDJ]
-EKVKZI = [
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-]
-FYLJUI = [HECVYY, QFYLJU, QFYLJU, QFYLJU]
-GYOUSP = [HECVYY, IGYOUS, IGYOUS, IGYOUS]
-IACQFF = [XTIACQ, TIACQF]
-JRJHIU = [ASSAKQ, UOJRJH, OJRJHI]
-LAIIDN = [OOQNRS, QLAIID]
-LKXSJW = [UNBLKX, QXPICX, NBLKXS, XPICXQ, BLKXSJ]
-NPYYLI = [KCWAON, CWAONP, WAONPY, AONPYY, ONPYYL]
-NXNKML = [
-    UTOPHU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    UNXNKM,
-]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-RURAZM = [
-    WRKINE,
-    MAOAWB,
-    AWBSIR,
-    TSIFJB,
-    MNZMJI,
-    FWRKIN,
-    RKINEJ,
-    YOUSPB,
-    UYNQJY,
-    AMJMAO,
-    FJBIAM,
-    LGQPLS,
-    YKLGQP,
-    IKFWRK,
-    IFJBIA,
-    MJMAOA,
-    IAMJMA,
-    SPFTSI,
-    WBSIRY,
-    PLSPFT,
-    GQPLSP,
-    AOAWBS,
-    RYXBQF,
-    OAWBSI,
-    QPLSPF,
-    BIAMJM,
-    SIFJBI,
-    PFTSIF,
-]
-SOOQNR = [ASSAKQ, UOJRJH]
-SRURAZ = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-SSRURA = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    UQEXLS,
-    EXLSXU,
-    LSXUJU,
-    DSSRUR,
-]
-TFMNHT = [
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-]
-TYEKCW = [JUTYEK, UTYEKC]
-VDQLAI = [AJVDQL, JVDQLA]
-VDSSRU = []
-WSKWIV = [
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IUSOOQ,
-    IYWSKW,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YWSKWI,
-]
-XWAJVD = [KZILXW, ZILXWA, ILXWAJ, LXWAJV]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -912,257 +19,766 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return URAZMK
+        return 56
 
     @property
     def begin(self):
-        return RAZMKQ
+        return 256
 
     @property
     def end(self):
-        return AZMKQT
+        return 479
 
     @property
     def all_device_keys(self):
-        return SSRURA
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return SRURAZ
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return RURAZM
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, SAKQXP),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, ICXQIE, JRJHIU, None, CXQIEF, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, QIEFXQ, JRJHIU, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, CXQIEF, JRJHIU, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, VHFTHE, JRJHIU, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, SOOQNR, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, ZUQEXL, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EXLSXU: GeckoWordStructAccessor(self.struct, EXLSXU, XLSXUJ, None),
-            LSXUJU: GeckoWordStructAccessor(self.struct, LSXUJU, SXUJUT, SAKQXP),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, ICXQIE, TYEKCW, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, NPYYLI, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            PYYLIU: GeckoTimeStructAccessor(self.struct, PYYLIU, YYLIUX, SAKQXP),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, SAKQXP),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UJUTYE, QIEFXQ, TYEKCW, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, NPYYLI, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            FEFJTA: GeckoTimeStructAccessor(self.struct, FEFJTA, EFJTAC, SAKQXP),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, SAKQXP),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, ICXQIE, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, QIEFXQ, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, NRSJMC, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, QIPOUY, CXQIEF, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, QIPOUY, JMCBFE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, JVHFTH, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, QJYMOU, NRSJMC, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, QJYMOU, JMCBFE, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, QJYMOU, VHFTHE, None),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, JMCBFE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, VHFTHE, None),
-            JWMNZM: GeckoWordStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, JVHFTH, AHEOCT, None),
-            NZMJIG: GeckoTempStructAccessor(self.struct, NZMJIG, ZMJIGY, None),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, None),
-            IGYOUS: GeckoEnumStructAccessor(
-                self.struct, IGYOUS, USOOQN, JMCBFE, GYOUSP, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, QIEFXQ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, OUSPBW, VHFTHE, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, QIEFXQ, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, WJYKLG, AHEOCT, None),
-            JYKLGQ: GeckoBoolStructAccessor(
-                self.struct, JYKLGQ, WJYKLG, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, JVHFTH, NRSJMC, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QJYMOU, ICXQIE, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, QJYMOU, AHEOCT, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, LSPFTS, NRSJMC, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, NRSJMC, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, CXQIEF, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, FTSIFJ, JMCBFE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FTSIFJ, VHFTHE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, NRSJMC, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JBIAMJ, CXQIEF, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, JBIAMJ, JMCBFE, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, JBIAMJ, VHFTHE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, QIEFXQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, NRSJMC, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, KLGQPL, NRSJMC, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, XSJWMN, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, XSJWMN, AHEOCT, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, ICXQIE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, PBWJYK, ICXQIE, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, LSPFTS, ICXQIE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, LSPFTS, AHEOCT, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, LSPFTS, CXQIEF, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, ICXQIE, None),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, BQFYLJ, AHEOCT, FYLJUI, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            YLJUIK: GeckoWordStructAccessor(self.struct, YLJUIK, LJUIKF, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, KFWRKI, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, KFWRKI, AHEOCT, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, JMAOAW, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, JMAOAW, AHEOCT, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, JMAOAW, CXQIEF, None),
-            INEJNI: GeckoWordStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, None),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, EKVKZI, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, ICXQIE, XWAJVD, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, VKZILX, QIEFXQ, VDQLAI, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, VKZILX, NRSJMC, LAIIDN, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, VKZILX, CXQIEF, DNIBXT, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, VKZILX, JMCBFE, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, VKZILX, VHFTHE, None),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, VKZILX, ACQFFT, IACQFF, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            CQFFTT: GeckoWordStructAccessor(self.struct, CQFFTT, QFFTTI, None),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, None),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, None),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, None),
-            SSUHBV: GeckoWordStructAccessor(self.struct, SSUHBV, SUHBVW, None),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, None),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoWordStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, DSBDJQ, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, TFMNHT, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            FMNHTB: GeckoWordStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, WSKWIV, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, WSKWIV, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, WSKWIV, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, WSKWIV, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, WSKWIV, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, NXNKML, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, SAKQXP),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, SAKQXP),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, SAKQXP),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, SAKQXP),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, SAKQXP),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, SAKQXP),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, BQNRXC, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-57.py
+++ b/src/geckolib/driver/packs/inxe-log-57.py
@@ -12,883 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-ACQFFT = 294
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 54])
-AHEOCT = 1
-AIIDNI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-AJVDQL = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 467
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-AOAWBS = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-AONPYY = 266
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-AWBSIR = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-BDJQRJ = "".join(chr(c) for c in [75, 53])
-BFEGZU = 310
-BHZVOA = 478
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [80, 50, 72])
-BLKXSJ = 355
-BMJVHF = 256
-BQFYLJ = 314
-BQNRXC = 449
-BQSNQL = "".join(chr(c) for c in [75, 54, 48, 48])
-BSIRYX = 309
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = 300
-BVWVUB = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-BWJYKL = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-BXTIAC = 291
-BXYBQS = "".join(chr(c) for c in [68, 74, 83, 52])
-BYGDSB = "".join(chr(c) for c in [75, 50, 48, 48])
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 52])
-CPQIPO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-CRTFMN = 360
-CTHBSK = 307
-CVDSSR = 57
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 264
-CXQIEF = 4
-DAFIKJ = 453
-DGKEAK = 465
-DJQRJJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-DSBDJQ = "".join(chr(c) for c in [75, 56])
-DSSRUR = 479
-DUBSSU = 299
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = 272
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-EKVKZI = "".join(chr(c) for c in [54, 52, 75])
-ELHBQN = "".join(chr(c) for c in [67, 70, 71, 48])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-EUTOPH = "".join(chr(c) for c in [80, 51, 72])
-EXLSXU = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-FCRTFM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-FIKJPU = 454
-FJBIAM = 351
-FJTACC = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FMNHTB = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-FTTIDU = 296
-FWRKIN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = 315
-FZDGKE = 464
-GDSBDJ = "".join(chr(c) for c in [75, 56, 53])
-GETIXQ = 471
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = 284
-GSELHB = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-GYOUSP = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 49])
-HBSKSO = 303
-HBVWVU = 316
-HBXIBH = 476
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = "".join(chr(c) for c in [80, 49, 72])
-HUGTYI = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-HUOJRJ = 261
-HWDAFI = 452
-HXEKVK = "".join(chr(c) for c in [51, 50, 75])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-IACQFF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-IBXTIA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-IBXYBQ = "".join(chr(c) for c in [77, 73, 65])
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [51, 48, 65])
-IDUBSS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-IGYOUS = 280
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-IIDNIB = "".join(chr(c) for c in [50, 53, 65])
-IJUGSE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-IKFWRK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 55])
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = 282
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = 270
-IVDNQG = 326
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-IYWSKW = 322
-JBIAMJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-JEUTOP = "".join(chr(c) for c in [80, 50, 76])
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-JJJVYF = "".join(chr(c) for c in [75, 51, 48, 48])
-JJVYFC = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JMAOAW = 354
-JMCBFE = 5
-JNIBXY = "".join(chr(c) for c in [105, 110, 88, 69])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 56])
-JQRJJJ = "".join(chr(c) for c in [75, 49, 48, 48])
-JTACCP = 273
-JUGSEL = 325
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JUTYEK = "".join(chr(c) for c in [83, 84, 79, 80])
-JVDQLA = "".join(chr(c) for c in [53, 79, 80])
-JVHFTH = 274
-JWMNZM = 277
-JYKLGQ = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-JYMOUN = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-JZTATD = 458
-KCWAON = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-KEAKST = 466
-KFWRKI = 285
-KINEJN = 288
-KJPUNR = 455
-KLGQPL = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-KPHUOJ = 306
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-KWIVDN = 324
-KXSJWM = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KZILXW = "".join(chr(c) for c in [85, 76])
-LAIIDN = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-LHBQNR = 448
-LIUXFE = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LJUIKF = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-LKXSJW = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-LXWAJV = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-MAOAWB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = 470
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-MHXEKV = "".join(chr(c) for c in [49, 54, 75])
-MJIGYO = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MJMAOA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = 331
-MNHTBJ = 320
-MOUNBL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-NBLKXS = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-NEJNIB = 289
-NHTBJE = "".join(chr(c) for c in [78, 65])
-NIBXTI = 7
-NIBXYB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NKMLOI = 330
-NMHXEK = 290
-NPYYLI = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NQJYMO = "".join(chr(c) for c in [78, 79])
-NQLNMH = "".join(chr(c) for c in [105, 110, 89, 84])
-NQTMFZ = 462
-NRJZTA = 457
-NRSJMC = 3
-NRXCHW = 450
-NXNKML = 329
-NZMJIG = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-OACMCV = "".join(chr(c) for c in [76, 73])
-OAWBSI = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = 475
-OIJUGS = 333
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 52, 76])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = 353
-OUSPBW = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PBWJYK = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-PFTSIF = 350
-PHUGTY = "".join(chr(c) for c in [66, 76, 79])
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-PQIPOU = "".join(chr(c) for c in [67, 80, 79, 84])
-PUNRJZ = 456
-PYYLIU = 267
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 262
-QFFTTI = 295
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-QGVUNX = 327
-QIEFXQ = 2
-QIPOUY = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-QJYMOU = "".join(chr(c) for c in [77, 69, 68])
-QLAIID = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 50])
-QPLSPF = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [75, 56, 48, 48])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-RKINEJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 51])
-RYXBQF = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 52])
-SELHBQ = 332
-SEMCGE = 469
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-SIRYXB = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-SKSOKP = 304
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-SNQLNM = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-SOKPHU = 305
-SPBWJY = 352
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SSUHBV = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-STSEMC = 468
-SUHBVW = 301
-SXUJUT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-TACCPQ = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-TATDZX = 459
-TBJEUT = "".join(chr(c) for c in [80, 49, 76])
-TDZXNQ = 460
-TFMNHT = 361
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = 293
-TIDUBS = 297
-TIXQVX = 472
-TMFZDG = 463
-TOPHUG = "".join(chr(c) for c in [80, 52, 72])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TYEKCW = "".join(chr(c) for c in [78, 69, 87])
-TYIYWS = 321
-UBSSUH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-UBYGDS = 357
-UHBVWV = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-UIKFWR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-UJUTYE = "".join(chr(c) for c in [73, 68, 76, 69])
-UNBLKX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 57])
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-USOOQN = 260
-USPBWJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-UTOPHU = "".join(chr(c) for c in [80, 51, 76])
-UTYEKC = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-UYNQJY = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-VDNQGV = "".join(chr(c) for c in [72, 84, 82])
-VDQLAI = "".join(chr(c) for c in [51, 79, 80])
-VDSSRU = 256
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VUBYGD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-VUNXNK = 328
-VWVUBY = "".join(chr(c) for c in [70, 117, 108, 108])
-VXOIHB = 474
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-WBSIRY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 53])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-WJYKLG = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-WMNZMJ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-WRKINE = 287
-WSKWIV = 323
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = 451
-XEKVKZ = "".join(chr(c) for c in [52, 56, 75])
-XFEFJT = 271
-XIBHZV = 477
-XLSXUJ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 473
-XSJWMN = 275
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-XUJUTY = 263
-XWAJVD = "".join(chr(c) for c in [80, 50, 50])
-XYBQSN = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 88, 77])
-YEKCWA = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YFCRTF = 358
-YGDSBD = "".join(chr(c) for c in [75, 52, 48, 48])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-YKLGQP = 283
-YLIUXF = 268
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YNQJYM = 313
-YOUSPB = 281
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-YXBQFY = 311
-YYLIUX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-ZILXWA = "".join(chr(c) for c in [67, 69])
-ZMJIGY = 279
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-ZVOACM = 479
-ZXNQTM = 461
-ACMCVD = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    OACMCV,
-]
-CMCVDS = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-DNIBXT = [IIDNIB, IDNIBX]
-DNQGVU = [
-    NHTBJE,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    VDNQGV,
-]
-DQLAII = [JVDQLA, VDQLAI]
-EKCWAO = [UJUTYE, JUTYEK, UTYEKC, TYEKCW, YEKCWA]
-ILXWAJ = [KZILXW, ZILXWA]
-IRYXBQ = [HECVYY, SIRYXB, SIRYXB, SIRYXB]
-JRJHIU = [ASSAKQ, UOJRJH, OJRJHI]
-JVYFCR = [
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-]
-KVKZIL = [MHXEKV, HXEKVK, XEKVKZ, EKVKZI]
-LSXUJU = [EXLSXU, XLSXUJ]
-MCVDSS = [
-    LJUIKF,
-    JBIAMJ,
-    AMJMAO,
-    QPLSPF,
-    LKXSJW,
-    YLJUIK,
-    JUIKFW,
-    NZMJIG,
-    CPQIPO,
-    SIFJBI,
-    SPFTSI,
-    PBWJYK,
-    USPBWJ,
-    QFYLJU,
-    LSPFTS,
-    IFJBIA,
-    TSIFJB,
-    KLGQPL,
-    MJMAOA,
-    JYKLGQ,
-    BWJYKL,
-    BIAMJM,
-    OAWBSI,
-    IAMJMA,
-    WJYKLG,
-    FTSIFJ,
-    PLSPFT,
-    LGQPLS,
-]
-MNZMJI = [HECVYY, WMNZMJ, WMNZMJ, WMNZMJ]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QLNMHX = [
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-]
-RAHEOC = [ASSAKQ, LRAHEO]
-SOOQNR = [ASSAKQ, UOJRJH]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UGSELH = [
-    NHTBJE,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    OQNRSJ,
-]
-UGTYIY = [
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    IUSOOQ,
-    PHUGTY,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HUGTYI,
-]
-VOACMC = []
-WAJVDQ = [OOQNRS, XWAJVD]
-WVUBYG = [BVWVUB, VWVUBY]
-YMOUNB = [NQJYMO, QXPICX, QJYMOU, XPICXQ, JYMOUN]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -896,252 +19,747 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return CVDSSR
+        return 57
 
     @property
     def begin(self):
-        return VDSSRU
+        return 256
 
     @property
     def end(self):
-        return DSSRUR
+        return 479
 
     @property
     def all_device_keys(self):
-        return ACMCVD
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return CMCVDS
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return MCVDSS
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, SAKQXP),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, ICXQIE, JRJHIU, None, CXQIEF, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, QIEFXQ, JRJHIU, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, CXQIEF, JRJHIU, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, VHFTHE, JRJHIU, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, SOOQNR, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, ICXQIE, LSXUJU, None, QIEFXQ, SAKQXP
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, EKCWAO, None, None, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            KCWAON: GeckoTimeStructAccessor(self.struct, KCWAON, CWAONP, SAKQXP),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, SAKQXP),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, QEXLSX, QIEFXQ, LSXUJU, None, QIEFXQ, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, EKCWAO, None, None, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            YYLIUX: GeckoTimeStructAccessor(self.struct, YYLIUX, YLIUXF, SAKQXP),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, SAKQXP),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, SAKQXP),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, SAKQXP),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, JTACCP, ICXQIE, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, JTACCP, QIEFXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, JTACCP, NRSJMC, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, JTACCP, CXQIEF, None),
-            CPQIPO: GeckoBoolStructAccessor(self.struct, CPQIPO, JTACCP, JMCBFE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, JVHFTH, QIEFXQ, None),
-            QIPOUY: GeckoBoolStructAccessor(self.struct, QIPOUY, IPOUYN, NRSJMC, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, IPOUYN, JMCBFE, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, IPOUYN, VHFTHE, None),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, YMOUNB, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoBoolStructAccessor(self.struct, MOUNBL, OUNBLK, JMCBFE, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, OUNBLK, VHFTHE, None),
-            NBLKXS: GeckoWordStructAccessor(self.struct, NBLKXS, BLKXSJ, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, AHEOCT, None),
-            KXSJWM: GeckoTempStructAccessor(self.struct, KXSJWM, XSJWMN, None),
-            SJWMNZ: GeckoTempStructAccessor(self.struct, SJWMNZ, JWMNZM, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, USOOQN, JMCBFE, MNZMJI, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, ZMJIGY, VHFTHE, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, QIEFXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, YOUSPB, AHEOCT, None),
-            OUSPBW: GeckoBoolStructAccessor(
-                self.struct, OUSPBW, YOUSPB, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, SPBWJY, AHEOCT, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, JVHFTH, NRSJMC, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, IPOUYN, ICXQIE, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, IPOUYN, AHEOCT, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, QIEFXQ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, YKLGQP, NRSJMC, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, NRSJMC, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, CXQIEF, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, GQPLSP, JMCBFE, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, GQPLSP, VHFTHE, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, NRSJMC, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, CXQIEF, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, PFTSIF, JMCBFE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, PFTSIF, VHFTHE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, QIEFXQ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, FJBIAM, NRSJMC, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, SPBWJY, NRSJMC, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, OUNBLK, ICXQIE, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, OUNBLK, AHEOCT, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, ICXQIE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, IGYOUS, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, YKLGQP, ICXQIE, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, YKLGQP, AHEOCT, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, YKLGQP, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, ICXQIE, None),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, BSIRYX, AHEOCT, IRYXBQ, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            RYXBQF: GeckoWordStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, ICXQIE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, ICXQIE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, AHEOCT, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FJBIAM, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FJBIAM, AHEOCT, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, FJBIAM, CXQIEF, None),
-            IKFWRK: GeckoWordStructAccessor(self.struct, IKFWRK, KFWRKI, None),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, None),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, None),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, NEJNIB, None, QLNMHX, None, None, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, NMHXEK, ICXQIE, KVKZIL, None, CXQIEF, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, NMHXEK, QIEFXQ, ILXWAJ, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, NMHXEK, NRSJMC, WAJVDQ, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            AJVDQL: GeckoEnumStructAccessor(
-                self.struct, AJVDQL, NMHXEK, CXQIEF, DQLAII, None, QIEFXQ, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, NMHXEK, JMCBFE, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, NMHXEK, VHFTHE, None),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, NMHXEK, NIBXTI, DNIBXT, None, QIEFXQ, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            IBXTIA: GeckoWordStructAccessor(self.struct, IBXTIA, BXTIAC, None),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, None),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, None),
-            CQFFTT: GeckoByteStructAccessor(self.struct, CQFFTT, QFFTTI, None),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoWordStructAccessor(self.struct, TTIDUB, TIDUBS, None),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, None),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, None),
-            SSUHBV: GeckoWordStructAccessor(self.struct, SSUHBV, SUHBVW, None),
-            UHBVWV: GeckoEnumStructAccessor(
-                self.struct, UHBVWV, HBVWVU, None, WVUBYG, None, QIEFXQ, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, JVYFCR, None, None, None
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            VYFCRT: GeckoWordStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, UGTYIY, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, UGTYIY, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, UGTYIY, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, UGTYIY, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, UGTYIY, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, DNQGVU, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, SAKQXP),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, SAKQXP),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, SAKQXP),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, SAKQXP),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, SAKQXP),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, SAKQXP),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, UGSELH, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-58.py
+++ b/src/geckolib/driver/packs/inxe-log-58.py
@@ -12,1052 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 470
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [52, 56, 75])
-AJVDQL = "".join(chr(c) for c in [105, 110, 89, 84])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 57])
-AMJMAO = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 449
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-BBEKBD = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-BDFSRO = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-BDJQRJ = 300
-BEKBDF = 372
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-BIAMJM = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BJEUTO = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BQSNQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BVWVUB = 294
-BWJYKL = 275
-BXIBHZ = 466
-BXYBQS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 460
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [53, 79, 80])
-CRTFMN = "".join(chr(c) for c in [75, 52, 48, 48])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = 330
-DDPMXF = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-DFSROG = 374
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 55])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-DNIBXT = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-DNQGVU = "".join(chr(c) for c in [80, 50, 72])
-DPMXFU = 375
-DQLAII = 290
-DSBDJQ = 299
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-DUBSSU = "".join(chr(c) for c in [51, 48, 65])
-DZXNQT = 450
-EAKSTS = 456
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-EKBDFS = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [105, 110, 88, 69])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-EMCGET = 459
-EOCTHB = 308
-ETIXQV = 461
-EUTOPH = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FCRTFM = "".join(chr(c) for c in [75, 50, 48, 48])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FIKJPU = 331
-FJBIAM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-FMNHTB = "".join(chr(c) for c in [75, 52])
-FSROGM = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 54])
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-GKEAKS = 455
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-GTYIYW = 361
-GVUNXN = "".join(chr(c) for c in [80, 51, 76])
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [72, 84, 82])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [75, 49, 48, 48])
-HTZBBE = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-HUGTYI = 360
-HUOJRJ = 305
-HWDAFI = 329
-HXEKVK = 289
-HZVOAC = 468
-IAMJMA = 283
-IBHZVO = 467
-IBXTIA = "".join(chr(c) for c in [67, 69])
-IBXYBQ = 315
-ICXQIE = 0
-IDUBSS = "".join(chr(c) for c in [50, 53, 65])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = 465
-IIDNIB = "".join(chr(c) for c in [54, 52, 75])
-IJUGSE = 322
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-ILXWAJ = "".join(chr(c) for c in [105, 110, 88, 77])
-INEJNI = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [80, 49, 72])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 462
-IYWSKW = "".join(chr(c) for c in [45, 45, 45])
-JBIAMJ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JEUTOP = "".join(chr(c) for c in [75, 51, 48, 48])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-JJVYFC = "".join(chr(c) for c in [70, 117, 108, 108])
-JLOINE = 58
-JMAOAW = 284
-JMCBFE = 260
-JNIBXY = 314
-JPUNRJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-JQRJJJ = 301
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-JUIKFW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVHFTH = 274
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 48])
-KBDFSR = 373
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 56])
-KFWRKI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KHTZBB = 479
-KJPUNR = 333
-KPHUOJ = 304
-KQTDKH = 477
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 457
-KVKZIL = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-KWIVDN = 320
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [68, 74, 83, 52])
-LAIIDN = "".join(chr(c) for c in [51, 50, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 326
-LIUXFE = 263
-LJUIKF = 354
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-LOIJUG = 321
-LOINEL = 256
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [75, 54, 48, 48])
-MAOAWB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-MCVDSS = 471
-MFZDGK = 453
-MHXEKV = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-MNHTBJ = "".join(chr(c) for c in [75, 53])
-MNZMJI = 313
-MOUNBL = 273
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = 311
-NHTBJE = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-NIBXTI = "".join(chr(c) for c in [85, 76])
-NIBXYB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NKMLOI = "".join(chr(c) for c in [65, 85, 88])
-NMHXEK = 288
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [80, 50, 76])
-NQJYMO = 271
-NQLNMH = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 52])
-NRJZTA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 327
-NXNKML = "".join(chr(c) for c in [66, 76, 79])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-OAWBSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-OINELW = 479
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = 358
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = 325
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [51, 79, 80])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-QGVUNX = "".join(chr(c) for c in [80, 51, 72])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [49, 54, 75])
-QLNMHX = 287
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-QSNQLN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-QTMFZD = 452
-QVXOIH = 463
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 475
-RJHIUS = 362
-RJJJVY = 316
-RJZTAT = 332
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-ROGMDD = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(chr(c) for c in [75, 56, 53])
-RURAZM = 474
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SELHBQ = 324
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-SIFJBI = 352
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-SNQLNM = 285
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-SSRURA = 473
-SSUHBV = 291
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49])
-TBJEUT = "".join(chr(c) for c in [75, 56, 48, 48])
-TDKHTZ = 478
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 50])
-TFMNHT = "".join(chr(c) for c in [75, 56])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 50, 50])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 53])
-TOPHUG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-TSEMCG = 458
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-TZBBEK = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-UBYGDS = 296
-UGSELH = 323
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-UHBVWV = 293
-UIKFWR = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNXNKM = "".join(chr(c) for c in [80, 52, 76])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-USOOQN = 261
-USPBWJ = 355
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = "".join(chr(c) for c in [80, 49, 76])
-VDQLAI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-VDSSRU = 472
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [77, 73, 65])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 469
-VUBYGD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VUNXNK = "".join(chr(c) for c in [80, 52, 72])
-VWVUBY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-WAONPY = 367
-WBSIRY = 350
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-WIVDNQ = "".join(chr(c) for c in [78, 65])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = 309
-WVUBYG = 295
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XCHWDA = 328
-XEKVKZ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = "".join(chr(c) for c in [76, 73])
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-XNQTMF = 451
-XOIHBX = 464
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-XSJWMN = 282
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-XYBQSN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YBQSNQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-YEKCWA = 364
-YFCRTF = 357
-YGDSBD = 297
-YIYWSK = 376
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-YXBQFY = 351
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 371
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 454
-ZILXWA = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = 476
-ZTATDZ = 448
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 51])
-BJLOIN = [
-    XYBQSN,
-    XBQFYL,
-    FYLJUI,
-    MAOAWB,
-    SPBWJY,
-    BXYBQS,
-    YBQSNQ,
-    LGQPLS,
-    BLKXSJ,
-    IRYXBQ,
-    AWBSIR,
-    IFJBIA,
-    TSIFJB,
-    NIBXYB,
-    OAWBSI,
-    RYXBQF,
-    SIRYXB,
-    AMJMAO,
-    YLJUIK,
-    BIAMJM,
-    FJBIAM,
-    BQFYLJ,
-    IKFWRK,
-    QFYLJU,
-    JBIAMJ,
-    BSIRYX,
-    AOAWBS,
-    MJMAOA,
-]
-BQNRXC = [
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HBQNRX,
-]
-BXTIAC = [NIBXTI, IBXTIA]
-FFTTID = [CQFFTT, QFFTTI]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FUBJLO = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    XFUBJL,
-]
-IACQFF = [CBFEGZ, TIACQF]
-IDNIBX = [QLAIID, LAIIDN, AIIDNI, IIDNIB]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JVDQLA = [
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-]
-JVYFCR = [JJJVYF, JJVYFC]
-KINEJN = [HECVYY, RKINEJ, RKINEJ, RKINEJ]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-KMLOIJ = [
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    SJMCBF,
-    NXNKML,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XNKMLO,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    NKMLOI,
-]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDDPMX = [FSROGM, SROGMD, ROGMDD, OGMDDP, GMDDPM]
-MXFUBJ = []
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UBJLOI = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-UBSSUH = [IDUBSS, DUBSSU]
-UNRJZT = [
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-UTOPHU = [
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-WSKWIV = [IYWSKW, YWSKWI]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1065,282 +19,861 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return JLOINE
+        return 58
 
     @property
     def begin(self):
-        return LOINEL
+        return 256
 
     @property
     def end(self):
-        return OINELW
+        return 479
 
     @property
     def all_device_keys(self):
-        return FUBJLO
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return UBJLOI
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return BJLOIN
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, EGZUQE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, XSJWMN, ICXQIE, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, XSJWMN, AHEOCT, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QIEFXQ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, EGZUQE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, CXQIEF, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JMAOAW, UQEXLS, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JMAOAW, VHFTHE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, WBSIRY, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, WBSIRY, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, QIEFXQ, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, EGZUQE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, SIFJBI, EGZUQE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, GYOUSP, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, GYOUSP, AHEOCT, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, LSPFTS, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IAMJMA, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, IAMJMA, AHEOCT, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, IAMJMA, CXQIEF, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, WRKINE, ICXQIE, None),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, WRKINE, AHEOCT, KINEJN, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            INEJNI: GeckoWordStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, JNIBXY, ICXQIE, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, IBXYBQ, ICXQIE, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, IBXYBQ, AHEOCT, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, YXBQFY, ICXQIE, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, YXBQFY, AHEOCT, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YXBQFY, CXQIEF, None),
-            QSNQLN: GeckoWordStructAccessor(self.struct, QSNQLN, SNQLNM, None),
-            NQLNMH: GeckoByteStructAccessor(self.struct, NQLNMH, QLNMHX, None),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, None),
-            MHXEKV: GeckoEnumStructAccessor(
-                self.struct, MHXEKV, HXEKVK, None, JVDQLA, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, ICXQIE, IDNIBX, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, DQLAII, QIEFXQ, BXTIAC, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, DQLAII, EGZUQE, IACQFF, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, DQLAII, CXQIEF, FFTTID, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, DQLAII, UQEXLS, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, DQLAII, VHFTHE, None),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, DQLAII, XLSXUJ, UBSSUH, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoWordStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoWordStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, JVYFCR, None, QIEFXQ, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, UTOPHU, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            TOPHUG: GeckoWordStructAccessor(self.struct, TOPHUG, OPHUGT, None),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, None),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, WSKWIV, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, KMLOIJ, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, LOIJUG, None, KMLOIJ, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, KMLOIJ, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, KMLOIJ, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, KMLOIJ, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, BQNRXC, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, SAKQXP),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, SAKQXP),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, SAKQXP),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, SAKQXP),
-            IKJPUN: GeckoByteStructAccessor(self.struct, IKJPUN, KJPUNR, SAKQXP),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, UNRJZT, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            NRJZTA: GeckoByteStructAccessor(self.struct, NRJZTA, RJZTAT, SAKQXP),
-            HTZBBE: GeckoBoolStructAccessor(self.struct, HTZBBE, JVHFTH, UQEXLS, None),
-            TZBBEK: GeckoByteStructAccessor(self.struct, TZBBEK, ZBBEKB, SAKQXP),
-            BBEKBD: GeckoByteStructAccessor(self.struct, BBEKBD, BEKBDF, SAKQXP),
-            EKBDFS: GeckoByteStructAccessor(self.struct, EKBDFS, KBDFSR, SAKQXP),
-            BDFSRO: GeckoEnumStructAccessor(
-                self.struct, BDFSRO, DFSROG, None, MDDPMX, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            DDPMXF: GeckoBoolStructAccessor(
-                self.struct, DDPMXF, DPMXFU, ICXQIE, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            PMXFUB: GeckoBoolStructAccessor(self.struct, PMXFUB, YIYWSK, ICXQIE, None),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxe-log-60.py
+++ b/src/geckolib/driver/packs/inxe-log-60.py
@@ -12,1108 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 468
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-AJVDQL = "".join(chr(c) for c in [105, 110, 88, 77])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 55])
-AMJMAO = 350
-AOAWBS = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 332
-AWBSIR = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BBEKBD = 479
-BDFSRO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-BDJQRJ = 297
-BEKBDF = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-BIAMJM = 284
-BJEUTO = "".join(chr(c) for c in [75, 53])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-BQNRXC = 324
-BQSNQL = 315
-BSIRYX = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-BVWVUB = 291
-BWJYKL = 275
-BXIBHZ = 464
-BXYBQS = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BYGDSB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 458
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = 328
-DDPMXF = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-DFSROG = 372
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 53])
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-DNIBXT = "".join(chr(c) for c in [51, 50, 75])
-DNQGVU = 320
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-DSBDJQ = 296
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-DUBSSU = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-DZXNQT = 448
-EAKSTS = 454
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-EKBDFS = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = 288
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-ELWUEU = 256
-EMCGET = 457
-EOCTHB = 308
-ETIXQV = 459
-EUTOPH = "".join(chr(c) for c in [75, 49, 48, 48])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FCRTFM = "".join(chr(c) for c in [70, 117, 108, 108])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FIKJPU = 329
-FJBIAM = 377
-FMNHTB = "".join(chr(c) for c in [75, 50, 48, 48])
-FSROGM = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-FUBJLO = 375
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = 351
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 52])
-GDSBDJ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-GKEAKS = 453
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-GTYIYW = 358
-GVUNXN = "".join(chr(c) for c in [80, 49, 76])
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [75, 56])
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-HUOJRJ = 305
-HWDAFI = 327
-HXEKVK = 287
-HZVOAC = 466
-IACQFF = "".join(chr(c) for c in [67, 69])
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-IBHZVO = 465
-IBXTIA = "".join(chr(c) for c in [54, 52, 75])
-IBXYBQ = 311
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [49, 54, 75])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = 463
-IIDNIB = 290
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-ILXWAJ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-INEJNI = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 460
-IYWSKW = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JJVYFC = 301
-JLOINE = "".join(chr(c) for c in [76, 73])
-JMAOAW = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-JMCBFE = 260
-JPUNRJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-JQRJJJ = 299
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [75, 54, 48, 48])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 325
-KBDFSR = 371
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 54])
-KFWRKI = 354
-KHTZBB = 477
-KINEJN = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KJPUNR = 330
-KMLOIJ = "".join(chr(c) for c in [80, 52, 76])
-KPHUOJ = 304
-KQTDKH = 475
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 455
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KWIVDN = "".join(chr(c) for c in [45, 45, 45])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 323
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-LOIJUG = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 479
-LXWAJV = "".join(chr(c) for c in [77, 73, 65])
-MAOAWB = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-MCVDSS = 469
-MDDPMX = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-MFZDGK = 451
-MHXEKV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-MLOIJU = "".join(chr(c) for c in [66, 76, 79])
-MNHTBJ = "".join(chr(c) for c in [75, 52, 48, 48])
-MNZMJI = 313
-MOUNBL = 273
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = 309
-NELWUE = 60
-NHTBJE = "".join(chr(c) for c in [75, 56, 53])
-NIBXTI = "".join(chr(c) for c in [52, 56, 75])
-NIBXYB = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-NKMLOI = "".join(chr(c) for c in [80, 52, 72])
-NMHXEK = 285
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [78, 65])
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 50])
-NRJZTA = 333
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 326
-NXNKML = "".join(chr(c) for c in [80, 51, 72])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OAWBSI = 283
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = 374
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-OIJUGS = "".join(chr(c) for c in [65, 85, 88])
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [75, 51, 48, 48])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = 331
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 50, 50])
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-QGVUNX = "".join(chr(c) for c in [80, 49, 72])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [105, 110, 89, 84])
-QLNMHX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-QSNQLN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-QTMFZD = 450
-QVXOIH = 461
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 473
-RJHIUS = 362
-RJJJVY = 300
-RJZTAT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ROGMDD = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-RURAZM = 472
-RXCHWD = "".join(chr(c) for c in [72, 84, 82])
-RYXBQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-SELHBQ = 322
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 57])
-SIFJBI = 352
-SIRYXB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = 376
-SNQLNM = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = 373
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-SSRURA = 471
-SSUHBV = "".join(chr(c) for c in [50, 53, 65])
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 56])
-SUHBVW = "".join(chr(c) for c in [51, 48, 65])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-TBJEUT = "".join(chr(c) for c in [75, 52])
-TDKHTZ = 476
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 48])
-TFMNHT = 357
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [85, 76])
-TIDUBS = "".join(chr(c) for c in [51, 79, 80])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 51])
-TOPHUG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-TSEMCG = 456
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = "".join(chr(c) for c in [53, 79, 80])
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-TZBBEK = 478
-UBJLOI = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-UBSSUH = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-UBYGDS = 294
-UGSELH = 321
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-UNXNKM = "".join(chr(c) for c in [80, 50, 76])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [75, 56, 48, 48])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-VDQLAI = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-VDSSRU = 470
-VHFTHE = 6
-VKZILX = 289
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 467
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-VUNXNK = "".join(chr(c) for c in [80, 50, 72])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VYFCRT = 316
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-WIVDNQ = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-WSKWIV = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-WVUBYG = 293
-XBQFYL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-XEKVKZ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [80, 51, 76])
-XNQTMF = 449
-XOIHBX = 462
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-XSJWMN = 282
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [68, 74, 83, 52])
-XYBQSN = 314
-YBQSNQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-YGDSBD = 295
-YIYWSK = 360
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = 361
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 452
-ZILXWA = "".join(chr(c) for c in [105, 110, 88, 69])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = 474
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49])
-ACQFFT = [TIACQF, IACQFF]
-BJLOIN = []
-BXTIAC = [IDNIBX, DNIBXT, NIBXTI, IBXTIA]
-CRTFMN = [YFCRTF, FCRTFM]
-FFTTID = [CBFEGZ, QFFTTI]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-HUGTYI = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-]
-IDUBSS = [TTIDUB, TIDUBS]
-IJUGSE = [
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    SJMCBF,
-    MLOIJU,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LOIJUG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    OIJUGS,
-]
-INELWU = [
-    SNQLNM,
-    YLJUIK,
-    UIKFWR,
-    BSIRYX,
-    SPBWJY,
-    QSNQLN,
-    NQLNMH,
-    LGQPLS,
-    BLKXSJ,
-    BQFYLJ,
-    RYXBQF,
-    MJMAOA,
-    TSIFJB,
-    YBQSNQ,
-    IRYXBQ,
-    QFYLJU,
-    XBQFYL,
-    AWBSIR,
-    IKFWRK,
-    AOAWBS,
-    JMAOAW,
-    LJUIKF,
-    RKINEJ,
-    JUIKFW,
-    MAOAWB,
-    YXBQFY,
-    SIRYXB,
-    WBSIRY,
-]
-IVDNQG = [KWIVDN, WIVDNQ]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JNIBXY = [HECVYY, EJNIBX, EJNIBX, EJNIBX]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-LAIIDN = [
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-    DQLAII,
-    QLAIID,
-]
-LOINEL = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    JLOINE,
-]
-MCBFEG = [ASSAKQ, SOOQNR]
-MXFUBJ = [GMDDPM, MDDPMX, DDPMXF, DPMXFU, PMXFUB]
-OINELW = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UHBVWV = [SSUHBV, SUHBVW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XCHWDA = [
-    NQGVUN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RXCHWD,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-ZTATDZ = [
-    NQGVUN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1121,285 +19,870 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return NELWUE
+        return 60
 
     @property
     def begin(self):
-        return ELWUEU
+        return 256
 
     @property
     def end(self):
-        return LWUEUH
+        return 479
 
     @property
     def all_device_keys(self):
-        return LOINEL
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return OINELW
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return INELWU
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, BIAMJM, ICXQIE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, AMJMAO, ICXQIE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JVHFTH, EGZUQE, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, XSJWMN, ICXQIE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, XSJWMN, AHEOCT, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QIEFXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, EGZUQE, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BIAMJM, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, BIAMJM, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, BIAMJM, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, BIAMJM, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, AMJMAO, EGZUQE, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, AMJMAO, CXQIEF, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, AMJMAO, UQEXLS, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, AMJMAO, VHFTHE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, QIEFXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, EGZUQE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, SIFJBI, EGZUQE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, GYOUSP, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, GYOUSP, AHEOCT, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, KFWRKI, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, LSPFTS, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, OAWBSI, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, OAWBSI, AHEOCT, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, OAWBSI, CXQIEF, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, ICXQIE, None),
-            EJNIBX: GeckoEnumStructAccessor(
-                self.struct, EJNIBX, NEJNIB, AHEOCT, JNIBXY, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            NIBXYB: GeckoWordStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, XYBQSN, ICXQIE, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, ICXQIE, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, AHEOCT, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, FYLJUI, ICXQIE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, FYLJUI, AHEOCT, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, FYLJUI, CXQIEF, None),
-            LNMHXE: GeckoWordStructAccessor(self.struct, LNMHXE, NMHXEK, None),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, None),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, None),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, LAIIDN, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, IIDNIB, ICXQIE, BXTIAC, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, IIDNIB, QIEFXQ, ACQFFT, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, IIDNIB, EGZUQE, FFTTID, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, IIDNIB, CXQIEF, IDUBSS, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, IIDNIB, UQEXLS, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, IIDNIB, VHFTHE, None),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, IIDNIB, XLSXUJ, UHBVWV, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoWordStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, None),
-            JJJVYF: GeckoWordStructAccessor(self.struct, JJJVYF, JJVYFC, None),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, CRTFMN, None, QIEFXQ, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, HUGTYI, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, IVDNQG, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, IJUGSE, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, IJUGSE, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, IJUGSE, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, IJUGSE, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, IJUGSE, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            QNRXCH: GeckoEnumStructAccessor(
-                self.struct, QNRXCH, NRXCHW, None, XCHWDA, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, SAKQXP),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, SAKQXP),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, SAKQXP),
-            IKJPUN: GeckoByteStructAccessor(self.struct, IKJPUN, KJPUNR, SAKQXP),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, SAKQXP),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, None, ZTATDZ, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, SAKQXP),
-            BEKBDF: GeckoBoolStructAccessor(self.struct, BEKBDF, JVHFTH, UQEXLS, None),
-            EKBDFS: GeckoByteStructAccessor(self.struct, EKBDFS, KBDFSR, SAKQXP),
-            BDFSRO: GeckoByteStructAccessor(self.struct, BDFSRO, DFSROG, SAKQXP),
-            FSROGM: GeckoByteStructAccessor(self.struct, FSROGM, SROGMD, SAKQXP),
-            ROGMDD: GeckoEnumStructAccessor(
-                self.struct, ROGMDD, OGMDDP, None, MXFUBJ, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            XFUBJL: GeckoBoolStructAccessor(
-                self.struct, XFUBJL, FUBJLO, ICXQIE, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            UBJLOI: GeckoBoolStructAccessor(self.struct, UBJLOI, SKWIVD, ICXQIE, None),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxe.py
+++ b/src/geckolib/driver/packs/inxe.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inxm-cfg-1.py
+++ b/src/geckolib/driver/packs/inxm-cfg-1.py
@@ -12,1119 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [70, 105, 108, 116, 77, 105, 110, 68, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [70, 97, 110, 84, 101, 109, 112, 79, 112, 116, 105, 111, 110]
-)
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        67,
-        97,
-        110,
-        99,
-        101,
-        108,
-        79,
-        116,
-        104,
-        101,
-        114,
-        85,
-        68,
-    ]
-)
-AJVDQL = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-AKQXPI = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-AMJMAO = 78
-AOAWBS = 80
-AONPYY = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-ASSAKQ = "".join(chr(c) for c in [70, 98, 77, 116, 114])
-AWBSIR = 81
-BDJQRJ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BFEGZU = "".join(
-    chr(c)
-    for c in [
-        80,
-        117,
-        109,
-        112,
-        82,
-        101,
-        115,
-        101,
-        116,
-        84,
-        105,
-        109,
-        101,
-        79,
-        117,
-        116,
-    ]
-)
-BIAMJM = 7
-BLKXSJ = "".join(chr(c) for c in [78, 79, 78, 69])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = 85
-BSIRYX = 82
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-BSSUHB = 31
-BVWVUB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-BWJYKL = 40
-BXTIAC = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-BXYBQS = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        49,
-        95,
-        52,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-CBFEGZ = 1
-CCPQIP = 60
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-CQBMJV = 1
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-CTHBSK = "".join(chr(c) for c in [68, 101, 115, 99, 101, 110, 100, 97, 110, 116])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-DJQRJJ = 24
-DNIBXT = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-DQLAII = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-DSBDJQ = "".join(chr(c) for c in [70])
-DUBSSU = 30
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        68,
-        101,
-        102,
-        80,
-        117,
-        114,
-        103,
-        101,
-        84,
-        105,
-        109,
-        101,
-    ]
-)
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-EGZUQE = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116, 83, 104, 97, 114, 101]
-)
-EKCWAO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-EKVKZI = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-EOCTHB = 18
-EXLSXU = 38
-FCRTFM = "".join(
-    chr(c)
-    for c in [
-        75,
-        105,
-        110,
-        101,
-        116,
-        105,
-        99,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-FEGZUQ = 3
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        65,
-        79,
-        84,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-        49,
-        54,
-    ]
-)
-FJTACC = 56
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FTTIDU = 26
-FWRKIN = "".join(chr(c) for c in [54, 48, 72, 90])
-FXQGLR = 203
-FYLJUI = 70
-GDSBDJ = "".join(chr(c) for c in [67])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 72, 101, 97, 116, 101, 114])
-GQPLSP = 76
-GYOUSP = 68
-GZUQEX = 4
-HBSKSO = 2
-HBVWVU = 35
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(
-    chr(c)
-    for c in [
-        80,
-        117,
-        109,
-        112,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        79,
-        114,
-        100,
-        101,
-        114,
-    ]
-)
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        79,
-        114,
-        100,
-        101,
-        114,
-    ]
-)
-HUOJRJ = 208
-HXEKVK = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-IAMJMA = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-IBXYBQ = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        49,
-        95,
-        51,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-IDNIBX = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-IEFXQG = 202
-IFJBIA = "".join(chr(c) for c in [65, 110, 121, 70, 114, 101, 101, 80, 117, 109, 112])
-IGYOUS = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-IKFWRK = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-ILXWAJ = 94
-INEJNI = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 59
-IRYXBQ = 83
-IUSOOQ = 0
-IUXFEF = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-JHIUSO = 87
-JIGYOU = 67
-JJJVYF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-JJVYFC = "".join(chr(c) for c in [65, 109, 80, 109])
-JMAOAW = 79
-JMCBFE = "".join(chr(c) for c in [79, 110, 67, 104, 97, 110, 103, 101])
-JNIBXY = "".join(chr(c) for c in [70, 117, 115, 101, 77, 97, 112, 112, 105, 110, 103])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-JTACCP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        68,
-        101,
-        102,
-        80,
-        49,
-        80,
-        117,
-        114,
-        103,
-        101,
-        84,
-        105,
-        109,
-        101,
-    ]
-)
-JUTYEK = "".join(chr(c) for c in [67, 108, 101, 97, 110, 80, 49])
-JVDQLA = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [50, 52, 104])
-JWMNZM = "".join(chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 105, 110, 103])
-JYKLGQ = 42
-JYMOUN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 77, 105, 110, 79, 110, 84, 105, 109, 101]
-)
-KCWAON = 37
-KFWRKI = 86
-KINEJN = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-KLGQPL = 74
-KPHUOJ = 207
-KQXPIC = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-KVKZIL = 92
-KZILXW = 93
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        82,
-        101,
-        115,
-        116,
-        111,
-        114,
-        101,
-        65,
-        108,
-        108,
-        85,
-        68,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 65, 78])
-LGQPLS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-LJUIKF = "".join(chr(c) for c in [72, 105, 103, 104])
-LKXSJW = "".join(chr(c) for c in [80, 49])
-LNMHXE = 89
-LRAHEO = 209
-LSPFTS = "".join(
-    chr(c) for c in [69, 99, 111, 110, 80, 114, 111, 103, 69, 110, 97, 98, 108, 101]
-)
-LSXUJU = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 49])
-LXWAJV = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-MAOAWB = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-MHXEKV = 90
-MJIGYO = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-MJMAOA = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-MJVHFT = 200
-MNZMJI = 5
-MOUNBL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 77, 97, 120, 68, 117, 114]
-)
-NBLKXS = 66
-NEJNIB = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-NIBXTI = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [85, 76])
-NMHXEK = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-NQJYMO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-NQLNMH = 88
-NRSJMC = 21
-NZMJIG = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-OAWBSI = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-OCTHBS = "".join(chr(c) for c in [65, 115, 99, 101, 110, 100, 97, 110, 116])
-OJRJHI = 210
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 98, 101, 114, 84, 105, 109, 101, 79, 117, 116]
-)
-OQNRSJ = 20
-OUNBLK = 64
-OUSPBW = 69
-OUYNQJ = 65
-PBWJYK = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-PFTSIF = "".join(
-    chr(c) for c in [69, 99, 111, 110, 80, 114, 111, 103, 77, 111, 100, 101]
-)
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-PICXQI = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 71
-POUYNQ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-PQIPOU = 58
-PYYLIU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        80,
-        79,
-        84,
-        76,
-        105,
-        109,
-        105,
-        116,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-QFFTTI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QFYLJU = "".join(
-    chr(c) for c in [83, 87, 77, 80, 117, 114, 103, 101, 83, 112, 101, 101, 100]
-)
-QGLRAH = 204
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-QIPOUY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-QJYMOU = 62
-QLAIID = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-QLNMHX = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-QNRSJM = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-QRJJJV = 73
-QSNQLN = 8
-QXPICX = "".join(chr(c) for c in [83, 65, 78, 73])
-RAHEOC = "".join(chr(c) for c in [])
-RJHIUS = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-RJJJVY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 84, 69, 110, 97, 98, 108, 101]
-)
-RSJMCB = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        115,
-        101,
-        116,
-        84,
-        105,
-        109,
-        101,
-        79,
-        117,
-        116,
-    ]
-)
-RYXBQF = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-SAKQXP = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SIFJBI = "".join(
-    chr(c)
-    for c in [78, 101, 120, 116, 70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-SIRYXB = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-SJMCBF = "".join(chr(c) for c in [79, 110, 83, 116, 97, 114, 116])
-SJWMNZ = "".join(
-    chr(c) for c in [79, 51, 68, 117, 114, 105, 110, 103, 70, 105, 108, 116]
-)
-SKSOKP = 205
-SNQLNM = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-SOKPHU = 206
-SOOQNR = 19
-SPBWJY = 39
-SPFTSI = "".join(
-    chr(c) for c in [69, 99, 111, 110, 85, 115, 101, 114, 68, 101, 109, 97, 110, 100]
-)
-SSAKQX = "".join(chr(c) for c in [70, 98, 76, 105])
-SSUHBV = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-        49,
-        54,
-    ]
-)
-SUHBVW = 33
-SXUJUT = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 50])
-TACCPQ = 57
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [78, 111, 110, 101])
-TIDUBS = 28
-TSIFJB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-TTIDUB = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        65,
-        79,
-        84,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-        49,
-        54,
-    ]
-)
-TYEKCW = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 80])
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-        49,
-        54,
-    ]
-)
-UBYGDS = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-UHBVWV = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-UIKFWR = "".join(
-    chr(c) for c in [83, 87, 77, 80, 117, 114, 103, 101, 66, 108, 111, 119, 101, 114]
-)
-UNBLKX = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-UQEXLS = 72
-USOOQN = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-USPBWJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-UTYEKC = 36
-UXFEFJ = "".join(chr(c) for c in [76, 111])
-UYNQJY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-VLASSA = "".join(chr(c) for c in [76, 73])
-VUBYGD = "".join(chr(c) for c in [78, 111])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-WAONPY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-WBSIRY = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-WJYKLG = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-WMNZMJ = "".join(
-    chr(c) for c in [79, 51, 85, 115, 101, 114, 68, 101, 109, 97, 110, 100]
-)
-WRKINE = "".join(chr(c) for c in [53, 48, 72, 90])
-WVUBYG = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-XBQFYL = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-XEKVKZ = 91
-XFEFJT = "".join(chr(c) for c in [72, 105])
-XLSXUJ = "".join(chr(c) for c in [83, 116, 97, 114, 116, 68, 117, 114, 70, 114, 101])
-XPICXQ = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-XQIEFX = 201
-XSJWMN = "".join(chr(c) for c in [79, 51, 65, 108, 119, 97, 121, 115, 79, 78])
-XTIACQ = 23
-XUJUTY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-XWAJVD = 22
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        50,
-        95,
-        51,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        50,
-        95,
-        52,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-YEKCWA = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-YFCRTF = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        83,
-        116,
-        97,
-        116,
-        101,
-        85,
-        115,
-        101,
-        114,
-        68,
-        101,
-        109,
-        97,
-        110,
-        100,
-    ]
-)
-YGDSBD = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YKLGQP = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        109,
-        105,
-        116,
-        101,
-        100,
-        73,
-        102,
-        83,
-        80,
-        66,
-        101,
-        108,
-        111,
-        119,
-        57,
-        53,
-        70,
-    ]
-)
-YLJUIK = "".join(chr(c) for c in [76, 111, 119])
-YMOUNB = 63
-YNQJYM = 61
-YOUSPB = "".join(
-    chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 101, 80, 101, 114, 105, 111, 100]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 84
-YYLIUX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-ZMJIGY = 6
-ZUQEXL = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-AHEOCT = [
-    JVHFTH,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    IVLASS,
-]
-BQSNQL = [NIBXYB, IBXYBQ, BXYBQS, XYBQSN, YBQSNQ, RAHEOC, RAHEOC, RAHEOC]
-BYGDSB = [VUBYGD, UBYGDS]
-CRTFMN = [
-    BMJVHF,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    GLRAHE,
-    HEOCTH,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    HIUSOO,
-]
-EJNIBX = [INEJNI, NEJNIB]
-FEFJTA = [UXFEFJ, XFEFJT]
-FJBIAM = [TSIFJB, SIFJBI, IFJBIA]
-IACQFF = [TIACQF, LKXSJW, PIPIVL]
-IBXTIA = [DNIBXT, NIBXTI]
-ICXQIE = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-    PICXQI,
-]
-IIDNIB = [QLAIID, LAIIDN, JVHFTH, AIIDNI]
-JRJHIU = [
-    JVHFTH,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    VLASSA,
-]
-JUIKFW = [YLJUIK, LJUIKF]
-KXSJWM = [BLKXSJ, LKXSJW, PIPIVL, RAHEOC]
-LIUXFE = [YYLIUX, YLIUXF]
-MCBFEG = [SJMCBF, JMCBFE]
-NPYYLI = [AONPYY, ONPYYL]
-RKINEJ = [FWRKIN, WRKINE]
-RTFMNH = [VLASSA]
-SBDJQR = [GDSBDJ, DSBDJQ]
-TFMNHT = []
-THBSKS = [OCTHBS, CTHBSK]
-UJUTYE = [XLSXUJ, LSXUJU, SXUJUT, XUJUTY]
-VDQLAI = [WAJVDQ, AJVDQL, JVDQLA, RAHEOC]
-VWVUBY = [RAHEOC, PIPIVL, LKXSJW]
-VYFCRT = [JJVYFC, JVYFCR]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1132,220 +19,706 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return CBFEGZ
+        return 1
 
     @property
     def output_keys(self):
-        return CRTFMN
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHeater",
+            "PumpActivationOrder",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "OutLi",
+            "LightActivationOrder",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ICXQIE, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 1, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, ICXQIE, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                200,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, ICXQIE, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                201,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, ICXQIE, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                202,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, ICXQIE, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                203,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, None, AHEOCT, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                204,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, HBSKSO, THBSKS, None, HBSKSO, QBMJVH
+            "OutHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHeater",
+                209,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, ICXQIE, None, None, QBMJVH
+            "PumpActivationOrder": GeckoEnumStructAccessor(
+                self.struct,
+                "PumpActivationOrder",
+                18,
+                2,
+                ["Ascendant", "Descendant"],
+                None,
+                2,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, ICXQIE, None, None, QBMJVH
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                205,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, ICXQIE, None, None, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                206,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, ICXQIE, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                207,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, JRJHIU, None, None, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                208,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoByteStructAccessor(self.struct, RJHIUS, JHIUSO, QBMJVH),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, EOCTHB, IUSOOQ, THBSKS, None, HBSKSO, QBMJVH
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                210,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, EOCTHB, CBFEGZ, MCBFEG, None, HBSKSO, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 87, "ALL"),
+            "LightActivationOrder": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationOrder",
+                18,
+                0,
+                ["Ascendant", "Descendant"],
+                None,
+                2,
+                "ALL",
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, EOCTHB, FEGZUQ, MCBFEG, None, HBSKSO, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 19, "ALL"
             ),
-            EGZUQE: GeckoBoolStructAccessor(
-                self.struct, EGZUQE, EOCTHB, GZUQEX, QBMJVH
+            "FiberTimeOut": GeckoByteStructAccessor(
+                self.struct, "FiberTimeOut", 20, "ALL"
             ),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, EXLSXU, None, UJUTYE, None, None, QBMJVH
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 21, "ALL"
             ),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, CBFEGZ, QBMJVH
+            "LightResetTimeOut": GeckoEnumStructAccessor(
+                self.struct,
+                "LightResetTimeOut",
+                18,
+                1,
+                ["OnStart", "OnChange"],
+                None,
+                2,
+                "ALL",
             ),
-            TYEKCW: GeckoBoolStructAccessor(
-                self.struct, TYEKCW, UTYEKC, HBSKSO, QBMJVH
+            "PumpResetTimeOut": GeckoEnumStructAccessor(
+                self.struct,
+                "PumpResetTimeOut",
+                18,
+                3,
+                ["OnStart", "OnChange"],
+                None,
+                2,
+                "ALL",
             ),
-            YEKCWA: GeckoBoolStructAccessor(
-                self.struct, YEKCWA, UTYEKC, FEGZUQ, QBMJVH
+            "PumpTimeOutShare": GeckoBoolStructAccessor(
+                self.struct, "PumpTimeOutShare", 18, 4, "ALL"
             ),
-            EKCWAO: GeckoBoolStructAccessor(
-                self.struct, EKCWAO, KCWAON, IUSOOQ, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 72, "ALL"
             ),
-            CWAONP: GeckoBoolStructAccessor(
-                self.struct, CWAONP, KCWAON, CBFEGZ, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                38,
+                None,
+                ["StartDurFre", "NotUsed1", "NotUsed2", "PurgeOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, KCWAON, HBSKSO, NPYYLI, None, HBSKSO, QBMJVH
+            "CleanP1": GeckoBoolStructAccessor(self.struct, "CleanP1", 36, 1, "ALL"),
+            "CleanCP": GeckoBoolStructAccessor(self.struct, "CleanCP", 36, 2, "ALL"),
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 36, 3, "ALL"
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, KCWAON, FEGZUQ, LIUXFE, None, HBSKSO, QBMJVH
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 37, 0, "ALL"
             ),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UTYEKC, IUSOOQ, FEFJTA, None, HBSKSO, QBMJVH
+            "FiltCPOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltCPOTOption", 37, 1, "ALL"
             ),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoByteStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, NBLKXS, IUSOOQ, KXSJWM, None, GZUQEX, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 37, 2, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            XSJWMN: GeckoBoolStructAccessor(
-                self.struct, XSJWMN, NBLKXS, HBSKSO, QBMJVH
+            "FiltCPOTLimitOption": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltCPOTLimitOption",
+                37,
+                3,
+                ["AlwaysEnabled", "LimitedIfSPBelow95F"],
+                None,
+                2,
+                "ALL",
             ),
-            SJWMNZ: GeckoBoolStructAccessor(
-                self.struct, SJWMNZ, NBLKXS, FEGZUQ, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 36, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            JWMNZM: GeckoBoolStructAccessor(
-                self.struct, JWMNZM, NBLKXS, GZUQEX, QBMJVH
+            "FiltDefPurgeTime": GeckoByteStructAccessor(
+                self.struct, "FiltDefPurgeTime", 56, "ALL"
             ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, NBLKXS, MNZMJI, QBMJVH
+            "FiltDefP1PurgeTime": GeckoByteStructAccessor(
+                self.struct, "FiltDefP1PurgeTime", 57, "ALL"
             ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, NBLKXS, ZMJIGY, NPYYLI, None, None, QBMJVH
+            "FiltMinDur": GeckoByteStructAccessor(self.struct, "FiltMinDur", 60, "ALL"),
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 58, "ALL"
             ),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoTimeStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoTimeStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoTimeStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoTimeStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoBoolStructAccessor(
-                self.struct, QPLSPF, PLSPFT, FEGZUQ, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 59, "ALL"
             ),
-            LSPFTS: GeckoBoolStructAccessor(
-                self.struct, LSPFTS, PLSPFT, GZUQEX, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 65, "ALL"
             ),
-            SPFTSI: GeckoBoolStructAccessor(
-                self.struct, SPFTSI, PLSPFT, MNZMJI, QBMJVH
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 61, "ALL"
             ),
-            PFTSIF: GeckoBoolStructAccessor(
-                self.struct, PFTSIF, PLSPFT, ZMJIGY, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 62, "ALL"
             ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, EOCTHB, MNZMJI, FJBIAM, None, GZUQEX, QBMJVH
+            "FiltCPMinOnTime": GeckoByteStructAccessor(
+                self.struct, "FiltCPMinOnTime", 63, "ALL"
             ),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, EOCTHB, BIAMJM, QBMJVH
+            "FiltCPOTMaxDur": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTMaxDur", 64, "ALL"
             ),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, IUSOOQ, JUIKFW, None, HBSKSO, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 66, 0, ["NONE", "P1", "CP", ""], None, 4, "ALL"
             ),
-            UIKFWR: GeckoBoolStructAccessor(
-                self.struct, UIKFWR, FYLJUI, CBFEGZ, QBMJVH
+            "O3AlwaysON": GeckoBoolStructAccessor(
+                self.struct, "O3AlwaysON", 66, 2, "ALL"
             ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, GZUQEX, RKINEJ, None, HBSKSO, QBMJVH
+            "O3DuringFilt": GeckoBoolStructAccessor(
+                self.struct, "O3DuringFilt", 66, 3, "ALL"
             ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, KFWRKI, MNZMJI, EJNIBX, None, HBSKSO, QBMJVH
+            "O3Toggling": GeckoBoolStructAccessor(
+                self.struct, "O3Toggling", 66, 4, "ALL"
             ),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, KFWRKI, CBFEGZ, BQSNQL, None, QSNQLN, QBMJVH
+            "O3UserDemand": GeckoBoolStructAccessor(
+                self.struct, "O3UserDemand", 66, 5, "ALL"
             ),
-            SNQLNM: GeckoByteStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoByteStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, QBMJVH),
-            HXEKVK: GeckoByteStructAccessor(self.struct, HXEKVK, XEKVKZ, QBMJVH),
-            EKVKZI: GeckoByteStructAccessor(self.struct, EKVKZI, KVKZIL, QBMJVH),
-            VKZILX: GeckoByteStructAccessor(self.struct, VKZILX, KZILXW, QBMJVH),
-            ZILXWA: GeckoByteStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, GZUQEX, VDQLAI, None, GZUQEX, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                66,
+                6,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, PLSPFT, CBFEGZ, IIDNIB, None, GZUQEX, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 67, "ALL"
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, PLSPFT, IUSOOQ, IBXTIA, None, HBSKSO, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 68, "ALL"
             ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, FEGZUQ, IACQFF, None, GZUQEX, QBMJVH
+            "O3TogglePeriod": GeckoByteStructAccessor(
+                self.struct, "O3TogglePeriod", 69, "ALL"
             ),
-            ACQFFT: GeckoBoolStructAccessor(
-                self.struct, ACQFFT, XWAJVD, ZMJIGY, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 39, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 40, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 42, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 74, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 76, "ALL"),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 71, 3, "ALL"
             ),
-            CQFFTT: GeckoBoolStructAccessor(
-                self.struct, CQFFTT, XWAJVD, BIAMJM, QBMJVH
+            "EconProgEnable": GeckoBoolStructAccessor(
+                self.struct, "EconProgEnable", 71, 4, "ALL"
             ),
-            QFFTTI: GeckoBoolStructAccessor(
-                self.struct, QFFTTI, XTIACQ, IUSOOQ, QBMJVH
+            "EconUserDemand": GeckoBoolStructAccessor(
+                self.struct, "EconUserDemand", 71, 5, "ALL"
             ),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, QBMJVH),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, QBMJVH),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, XWAJVD, None, VWVUBY, None, GZUQEX, QBMJVH
+            "EconProgMode": GeckoBoolStructAccessor(
+                self.struct, "EconProgMode", 71, 6, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, KFWRKI, ZMJIGY, BYGDSB, None, HBSKSO, QBMJVH
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                18,
+                5,
+                ["LastPumpKey", "NextFreePumpKey", "AnyFreePump"],
+                None,
+                4,
+                "ALL",
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, XWAJVD, HBSKSO, SBDJQR, None, HBSKSO, QBMJVH
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 18, 7, "ALL"
             ),
-            BDJQRJ: GeckoTempStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, QBMJVH),
-            RJJJVY: GeckoBoolStructAccessor(
-                self.struct, RJJJVY, XTIACQ, CBFEGZ, QBMJVH
+            "SWMPurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "SWMPurgeSpeed", 70, 0, ["Low", "High"], None, 2, "ALL"
             ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, KFWRKI, IUSOOQ, VYFCRT, None, HBSKSO, QBMJVH
+            "SWMPurgeBlower": GeckoBoolStructAccessor(
+                self.struct, "SWMPurgeBlower", 70, 1, "ALL"
             ),
-            YFCRTF: GeckoBoolStructAccessor(
-                self.struct, YFCRTF, XWAJVD, FEGZUQ, QBMJVH
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 86, 4, ["60HZ", "50HZ"], None, 2, "ALL"
             ),
-            FCRTFM: GeckoBoolStructAccessor(
-                self.struct, FCRTFM, XTIACQ, HBSKSO, QBMJVH
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 86, 5, ["240Vac", "230VAC"], None, 2, "ALL"
+            ),
+            "FuseMapping": GeckoEnumStructAccessor(
+                self.struct,
+                "FuseMapping",
+                86,
+                1,
+                [
+                    "UL",
+                    "CE_Jmp1_3_Installed",
+                    "CE_Jmp1_4_Installed",
+                    "CE_Jmp2_3_Installed",
+                    "CE_Jmp2_4_Installed",
+                    "",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 88, None
+            ),
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 89, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 90, "ALL"
+            ),
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 91, "ALL"
+            ),
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 92, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 93, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 94, "ALL"
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                22,
+                4,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                71,
+                1,
+                [
+                    "IgnoreUD",
+                    "ExitQuietAndRestoreAllUD",
+                    "NA",
+                    "ExitQuietAndCancelOtherUD",
+                ],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                71,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 23, 3, ["None", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanTempOption": GeckoBoolStructAccessor(
+                self.struct, "FanTempOption", 22, 6, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 22, 7, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 23, 0, "ALL"
+            ),
+            "FanSetAOTTempAdc16": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc16", 26, "ALL"
+            ),
+            "FanClrAOTTempAdc16": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc16", 28, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 30, "ALL"
+            ),
+            "FanSetForceOffTempAdc16": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc16", 31, "ALL"
+            ),
+            "FanClrForceOffTempAdc16": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc16", 33, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 35, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 22, None, ["", "CP", "P1"], None, 4, "ALL"
+            ),
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                86,
+                6,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 22, 2, ["C", "F"], None, 2, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 24, "ALL"),
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 73, "ALL"
+            ),
+            "AmbiantOTEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOTEnable", 23, 1, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 86, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "InStateUserDemand": GeckoBoolStructAccessor(
+                self.struct, "InStateUserDemand", 22, 3, "ALL"
+            ),
+            "KineticProtection": GeckoBoolStructAccessor(
+                self.struct, "KineticProtection", 23, 2, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-2.py
+++ b/src/geckolib/driver/packs/inxm-cfg-2.py
@@ -12,1095 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 33
-ACQFFT = "".join(chr(c) for c in [85, 76])
-AIIDNI = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-AJVDQL = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-AKQXPI = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-AMJMAO = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-AONPYY = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-ASSAKQ = "".join(chr(c) for c in [70, 98, 77, 116, 114])
-AWBSIR = "".join(
-    chr(c) for c in [69, 99, 111, 110, 80, 114, 111, 103, 83, 116, 97, 116, 117, 115]
-)
-BFEGZU = 211
-BIAMJM = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-BJEUTO = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-BLKXSJ = "".join(chr(c) for c in [70, 105, 108, 116, 77, 105, 110, 68, 117, 114])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = "".join(chr(c) for c in [65, 110, 121, 70, 114, 101, 101, 80, 117, 109, 112])
-BQSNQL = "".join(chr(c) for c in [72, 105, 103, 104])
-BSIRYX = "".join(chr(c) for c in [78, 111, 116, 65, 99, 116, 105, 118, 101])
-BSKSOK = "".join(
-    chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114, 114, 101, 110, 116]
-)
-BSSUHB = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-BVWVUB = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        82,
-        101,
-        115,
-        116,
-        111,
-        114,
-        101,
-        65,
-        108,
-        108,
-        85,
-        68,
-    ]
-)
-BWJYKL = "".join(chr(c) for c in [80, 49])
-BXTIAC = "".join(
-    chr(c) for c in [78, 111, 116, 65, 118, 97, 105, 108, 97, 98, 108, 101]
-)
-BXYBQS = "".join(
-    chr(c) for c in [83, 87, 77, 80, 117, 114, 103, 101, 83, 112, 101, 101, 100]
-)
-BYGDSB = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-CCPQIP = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 80])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-CQBMJV = 1
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        49,
-        95,
-        51,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-CRTFMN = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-CTHBSK = 221
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        115,
-        67,
-        111,
-        111,
-        108,
-        105,
-        110,
-        103,
-        68,
-        101,
-        118,
-        105,
-        99,
-        101,
-    ]
-)
-DNIBXT = 92
-DNQGVU = "".join(
-    chr(c)
-    for c in [
-        65,
-        117,
-        120,
-        50,
-        65,
-        115,
-        83,
-        112,
-        101,
-        97,
-        107,
-        101,
-        114,
-        76,
-        105,
-        102,
-        116,
-        101,
-        114,
-    ]
-)
-DQLAII = 89
-DSBDJQ = 24
-DUBSSU = 23
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 50])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-EGZUQE = 212
-EJNIBX = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-EKCWAO = "".join(chr(c) for c in [79, 110, 83, 116, 97, 114, 116])
-EKVKZI = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-EOCTHB = 220
-EUTOPH = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-EXLSXU = "".join(chr(c) for c in [65, 115, 99, 101, 110, 100, 97, 110, 116])
-FCRTFM = 29
-FEFJTA = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 49])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        50,
-        95,
-        51,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-FJBIAM = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-FMNHTB = 31
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(
-    chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 101, 80, 101, 114, 105, 111, 100]
-)
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        50,
-        95,
-        52,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-FXQGLR = 203
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 72, 101, 97, 116, 101, 114])
-GQPLSP = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-GTYIYW = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-GVUNXN = "".join(chr(c) for c in [79, 110, 80, 50])
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-HBSKSO = 222
-HBVWVU = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(
-    chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 225
-HTBJEU = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-HUGTYI = "".join(chr(c) for c in [70])
-HUOJRJ = 206
-HXEKVK = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-IACQFF = "".join(chr(c) for c in [70, 117, 115, 101, 77, 97, 112, 112, 105, 110, 103])
-IAMJMA = 39
-IBXTIA = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-IBXYBQ = 82
-IDNIBX = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-IEFXQG = 202
-IFJBIA = 36
-IGYOUS = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 77, 105, 110, 79, 110, 84, 105, 109, 101]
-)
-IIDNIB = 91
-IKFWRK = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-ILXWAJ = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-INEJNI = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-IUSOOQ = "".join(
-    chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-IUXFEF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-IVDNQG = "".join(
-    chr(c) for c in [65, 117, 120, 49, 65, 115, 84, 86, 76, 105, 102, 116, 101, 114]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 70
-JBIAMJ = 37
-JEUTOP = "".join(chr(c) for c in [78, 111])
-JHIUSO = "".join(
-    chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-JIGYOU = 59
-JJJVYF = "".join(
-    chr(c)
-    for c in [70, 97, 110, 83, 101, 116, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-JJVYFC = 27
-JMAOAW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-JMCBFE = 210
-JNIBXY = 81
-JQRJJJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        84,
-    ]
-)
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-JUIKFW = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-JUTYEK = 18
-JVDQLA = 88
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c)
-    for c in [70, 97, 110, 67, 108, 114, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-JWMNZM = 56
-JYKLGQ = 4
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        109,
-        105,
-        116,
-        101,
-        100,
-        73,
-        102,
-        83,
-        80,
-        66,
-        101,
-        108,
-        111,
-        119,
-        57,
-        53,
-        70,
-    ]
-)
-KCWAON = "".join(chr(c) for c in [79, 110, 67, 104, 97, 110, 103, 101])
-KFWRKI = 77
-KINEJN = 79
-KLGQPL = "".join(
-    chr(c) for c in [79, 51, 68, 117, 114, 105, 110, 103, 70, 105, 108, 116]
-)
-KPHUOJ = 205
-KQXPIC = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-KSOKPH = "".join(
-    chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-KWIVDN = "".join(chr(c) for c in [50, 52, 104])
-KXSJWM = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-KZILXW = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LAIIDN = 90
-LASSAK = "".join(chr(c) for c in [70, 65, 78])
-LGQPLS = "".join(chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 105, 110, 103])
-LIUXFE = 69
-LJUIKF = 75
-LKXSJW = 57
-LNMHXE = "".join(chr(c) for c in [54, 48, 72, 90])
-LRAHEO = 209
-LSPFTS = 64
-LXWAJV = 86
-MAOAWB = 73
-MJIGYO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-MJMAOA = 71
-MJVHFT = 200
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-MNZMJI = 62
-MOUNBL = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-NEJNIB = 80
-NHTBJE = 32
-NIBXTI = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 77, 101, 110, 117])
-NIBXYB = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-NMHXEK = "".join(chr(c) for c in [53, 48, 72, 90])
-NPYYLI = "".join(
-    chr(c)
-    for c in [
-        80,
-        117,
-        109,
-        112,
-        82,
-        101,
-        115,
-        101,
-        116,
-        84,
-        105,
-        109,
-        101,
-        79,
-        117,
-        116,
-    ]
-)
-NQGVUN = "".join(chr(c) for c in [68, 74, 83, 95, 78, 111, 49])
-NQJYMO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        80,
-        79,
-        84,
-        76,
-        105,
-        109,
-        105,
-        116,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-NQLNMH = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-NRSJMC = "".join(
-    chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-NXNKML = "".join(chr(c) for c in [68, 74, 83, 95, 78, 111, 50])
-NZMJIG = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-OAWBSI = 68
-OCTHBS = "".join(
-    chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114, 114, 101, 110, 116]
-)
-OJRJHI = 207
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-ONPYYL = 20
-OOQNRS = 227
-OPHUGT = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-OQNRSJ = "".join(
-    chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-OUNBLK = "".join(chr(c) for c in [76, 111])
-OUSPBW = 61
-OUYNQJ = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-PBWJYK = "".join(chr(c) for c in [78, 79, 78, 69])
-PFTSIF = 65
-PHUGTY = "".join(chr(c) for c in [67])
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-PICXQI = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-POUYNQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-PQIPOU = 34
-PYYLIU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116, 83, 104, 97, 114, 101]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 17
-QFFTTI = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        49,
-        95,
-        52,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-QGLRAH = 204
-QGVUNX = "".join(chr(c) for c in [79, 110, 80, 49])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-QIPOUY = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-QJYMOU = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QLAIID = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-QLNMHX = 83
-QNRSJM = 228
-QPLSPF = 6
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-QXPICX = "".join(chr(c) for c in [83, 65, 78, 73])
-RAHEOC = "".join(chr(c) for c in [])
-RJHIUS = 208
-RJJJVY = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-RKINEJ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-RSJMCB = 123
-RTFMNH = 30
-RYXBQF = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-SAKQXP = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SBDJQR = "".join(chr(c) for c in [78, 111, 110, 101])
-SIFJBI = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-SIRYXB = "".join(chr(c) for c in [65, 99, 116, 105, 118, 101])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-SJWMNZ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-SKSOKP = 223
-SKWIVD = "".join(chr(c) for c in [65, 109, 80, 109])
-SNQLNM = "".join(
-    chr(c) for c in [83, 87, 77, 80, 117, 114, 103, 101, 66, 108, 111, 119, 101, 114]
-)
-SOKPHU = 224
-SOOQNR = "".join(
-    chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-SPBWJY = 63
-SPFTSI = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SSAKQX = "".join(chr(c) for c in [70, 98, 76, 105])
-SSUHBV = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-SXUJUT = 0
-TACCPQ = "".join(chr(c) for c in [67, 108, 101, 97, 110, 80, 49])
-TFMNHT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-THBSKS = "".join(
-    chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 7
-TIDUBS = 8
-TOPHUG = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-TSIFJB = 66
-TYEKCW = 19
-TYIYWS = 25
-UBSSUH = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-UBYGDS = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-UHBVWV = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-UIKFWR = 76
-UJUTYE = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-UNBLKX = "".join(chr(c) for c in [72, 105])
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-UQEXLS = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        79,
-        114,
-        100,
-        101,
-        114,
-    ]
-)
-USOOQN = 226
-USPBWJ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-UTYEKC = "".join(
-    chr(c) for c in [70, 105, 98, 101, 114, 84, 105, 109, 101, 79, 117, 116]
-)
-UXFEFJ = 35
-UYNQJY = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-VDNQGV = 21
-VDQLAI = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 5
-VLASSA = "".join(chr(c) for c in [76, 73])
-VUBYGD = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-VUNXNK = "".join(chr(c) for c in [79, 110, 80, 51])
-VWVUBY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        67,
-        97,
-        110,
-        99,
-        101,
-        108,
-        79,
-        116,
-        104,
-        101,
-        114,
-        85,
-        68,
-    ]
-)
-VYFCRT = 28
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 87
-WAONPY = 1
-WBSIRY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-WRKINE = 78
-WSKWIV = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XBQFYL = "".join(
-    chr(c)
-    for c in [78, 101, 120, 116, 70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-XEKVKZ = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-XFEFJT = "".join(chr(c) for c in [83, 116, 97, 114, 116, 68, 117, 114, 70, 114, 101])
-XLSXUJ = "".join(chr(c) for c in [68, 101, 115, 99, 101, 110, 100, 97, 110, 116])
-XPICXQ = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-XQIEFX = 201
-XSJWMN = 55
-XUJUTY = 2
-XWAJVD = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-XYBQSN = 67
-YBQSNQ = "".join(chr(c) for c in [76, 111, 119])
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        115,
-        101,
-        116,
-        84,
-        105,
-        109,
-        101,
-        79,
-        117,
-        116,
-    ]
-)
-YFCRTF = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-YIYWSK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-YKLGQP = "".join(
-    chr(c) for c in [79, 51, 70, 111, 108, 108, 111, 119, 80, 117, 109, 112]
-)
-YLIUXF = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YLJUIK = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-YOUSPB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 77, 97, 120, 68, 117, 114]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 84, 69, 110, 97, 98, 108, 101]
-)
-YXBQFY = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-YYLIUX = 3
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 85
-ZMJIGY = 58
-ZUQEXL = 84
-AHEOCT = [
-    JVHFTH,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    IVLASS,
-]
-BDJQRJ = [SBDJQR, BWJYKL, PIPIVL]
-CWAONP = [EKCWAO, KCWAON]
-ICXQIE = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-    PICXQI,
-]
-IRYXBQ = [WBSIRY, BSIRYX, JVHFTH, SIRYXB]
-JTACCP = [XFEFJT, FEFJTA, EFJTAC, FJTACC]
-KMLOIJ = []
-KVKZIL = [XEKVKZ, EKVKZI]
-LSXUJU = [EXLSXU, XLSXUJ]
-MCBFEG = [
-    JVHFTH,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    VLASSA,
-]
-MHXEKV = [LNMHXE, NMHXEK]
-NBLKXS = [OUNBLK, UNBLKX]
-NKMLOI = [VLASSA]
-QFYLJU = [YXBQFY, XBQFYL, BQFYLJ]
-QSNQLN = [YBQSNQ, BQSNQL]
-SUHBVW = [UBSSUH, BSSUHB, SSUHBV, RAHEOC]
-TBJEUT = [RAHEOC, PIPIVL, BWJYKL]
-TTIDUB = [ACQFFT, CQFFTT, QFFTTI, FFTTID, FTTIDU, RAHEOC, RAHEOC, RAHEOC]
-UGTYIY = [PHUGTY, HUGTYI]
-UNXNKM = [JVHFTH, QGVUNX, GVUNXN, VUNXNK]
-UTOPHU = [JEUTOP, EUTOPH]
-WIVDNQ = [SKWIVD, KWIVDN]
-WJYKLG = [PBWJYK, BWJYKL, PIPIVL, RAHEOC]
-WVUBYG = [HBVWVU, BVWVUB, JVHFTH, VWVUBY]
-XNKMLO = [
-    BMJVHF,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    GLRAHE,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    SJMCBF,
-    CBFEGZ,
-    FEGZUQ,
-    UQEXLS,
-]
-XTIACQ = [IBXTIA, BXTIAC]
-YGDSBD = [UBYGDS, BYGDSB]
-YMOUNB = [QJYMOU, JYMOUN]
-YNQJYM = [OUYNQJ, UYNQJY]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1108,238 +19,828 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return XUJUTY
+        return 2
 
     @property
     def output_keys(self):
-        return XNKMLO
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHeater",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+            "LightActivationOrder",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ICXQIE, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 1, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, ICXQIE, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                200,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, ICXQIE, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                201,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, ICXQIE, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                202,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, ICXQIE, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                203,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, None, AHEOCT, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                204,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, ICXQIE, None, None, QBMJVH
+            "OutHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHeater",
+                209,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, ICXQIE, None, None, QBMJVH
+            "Out1ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out1ACurrent", 220, "ALL"
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, ICXQIE, None, None, QBMJVH
+            "Out1BCurrent": GeckoByteStructAccessor(
+                self.struct, "Out1BCurrent", 221, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, ICXQIE, None, None, QBMJVH
+            "Out2ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out2ACurrent", 222, "ALL"
             ),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, MCBFEG, None, None, QBMJVH
+            "Out2BCurrent": GeckoByteStructAccessor(
+                self.struct, "Out2BCurrent", 223, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ICXQIE, None, None, QBMJVH
+            "Out3ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out3ACurrent", 224, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, EGZUQE, None, ICXQIE, None, None, QBMJVH
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                205,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, SXUJUT, LSXUJU, None, XUJUTY, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                206,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, QBMJVH),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, QEXLSX, WAONPY, CWAONP, None, XUJUTY, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                207,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, QEXLSX, XUJUTY, CWAONP, None, XUJUTY, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                208,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PYYLIU: GeckoBoolStructAccessor(
-                self.struct, PYYLIU, QEXLSX, YYLIUX, QBMJVH
+            "Out4ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out4ACurrent", 225, "ALL"
             ),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, None, JTACCP, None, None, QBMJVH
+            "Out5ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out5ACurrent", 226, "ALL"
             ),
-            TACCPQ: GeckoBoolStructAccessor(
-                self.struct, TACCPQ, ACCPQI, WAONPY, QBMJVH
+            "Out6ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out6ACurrent", 227, "ALL"
             ),
-            CCPQIP: GeckoBoolStructAccessor(
-                self.struct, CCPQIP, ACCPQI, XUJUTY, QBMJVH
+            "Out7ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out7ACurrent", 228, "ALL"
             ),
-            CPQIPO: GeckoBoolStructAccessor(
-                self.struct, CPQIPO, PQIPOU, SXUJUT, QBMJVH
+            "DirectCurrent": GeckoByteStructAccessor(
+                self.struct, "DirectCurrent", 123, "ALL"
             ),
-            QIPOUY: GeckoBoolStructAccessor(
-                self.struct, QIPOUY, ACCPQI, YYLIUX, QBMJVH
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                210,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            IPOUYN: GeckoBoolStructAccessor(
-                self.struct, IPOUYN, PQIPOU, WAONPY, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                211,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, PQIPOU, XUJUTY, YNQJYM, None, XUJUTY, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                212,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, PQIPOU, YYLIUX, YMOUNB, None, XUJUTY, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 84, "ALL"),
+            "LightActivationOrder": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationOrder",
+                17,
+                0,
+                ["Ascendant", "Descendant"],
+                None,
+                2,
+                "ALL",
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, ACCPQI, SXUJUT, NBLKXS, None, XUJUTY, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 18, "ALL"
             ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, SXUJUT, WJYKLG, None, JYKLGQ, QBMJVH
+            "FiberTimeOut": GeckoByteStructAccessor(
+                self.struct, "FiberTimeOut", 19, "ALL"
             ),
-            YKLGQP: GeckoBoolStructAccessor(
-                self.struct, YKLGQP, SPBWJY, XUJUTY, QBMJVH
+            "LightResetTimeOut": GeckoEnumStructAccessor(
+                self.struct,
+                "LightResetTimeOut",
+                17,
+                1,
+                ["OnStart", "OnChange"],
+                None,
+                2,
+                "ALL",
             ),
-            KLGQPL: GeckoBoolStructAccessor(
-                self.struct, KLGQPL, SPBWJY, YYLIUX, QBMJVH
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 20, "ALL"
             ),
-            LGQPLS: GeckoBoolStructAccessor(
-                self.struct, LGQPLS, SPBWJY, JYKLGQ, QBMJVH
+            "PumpResetTimeOut": GeckoEnumStructAccessor(
+                self.struct,
+                "PumpResetTimeOut",
+                17,
+                2,
+                ["OnStart", "OnChange"],
+                None,
+                2,
+                "ALL",
             ),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, SPBWJY, QPLSPF, YNQJYM, None, None, QBMJVH
+            "PumpTimeOutShare": GeckoBoolStructAccessor(
+                self.struct, "PumpTimeOutShare", 17, 3, "ALL"
             ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoByteStructAccessor(self.struct, FTSIFJ, TSIFJB, QBMJVH),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoTimeStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTimeStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoTimeStructAccessor(self.struct, AMJMAO, MJMAOA, QBMJVH),
-            JMAOAW: GeckoTimeStructAccessor(self.struct, JMAOAW, MAOAWB, QBMJVH),
-            AOAWBS: GeckoBoolStructAccessor(
-                self.struct, AOAWBS, OAWBSI, YYLIUX, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 69, "ALL"
             ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, OAWBSI, JYKLGQ, IRYXBQ, None, JYKLGQ, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                35,
+                None,
+                ["StartDurFre", "NotUsed1", "NotUsed2", "PurgeOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, QEXLSX, JYKLGQ, QFYLJU, None, JYKLGQ, QBMJVH
+            "CleanP1": GeckoBoolStructAccessor(self.struct, "CleanP1", 33, 1, "ALL"),
+            "CleanCP": GeckoBoolStructAccessor(self.struct, "CleanCP", 33, 2, "ALL"),
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 34, 0, "ALL"
             ),
-            FYLJUI: GeckoBoolStructAccessor(
-                self.struct, FYLJUI, QEXLSX, QPLSPF, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 33, 3, "ALL"
             ),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, SXUJUT, QSNQLN, None, XUJUTY, QBMJVH
+            "FiltCPOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltCPOTOption", 34, 1, "ALL"
             ),
-            SNQLNM: GeckoBoolStructAccessor(
-                self.struct, SNQLNM, XYBQSN, WAONPY, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 34, 2, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            NQLNMH: GeckoEnumStructAccessor(
-                self.struct, NQLNMH, QLNMHX, JYKLGQ, MHXEKV, None, XUJUTY, QBMJVH
+            "FiltCPOTLimitOption": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltCPOTLimitOption",
+                34,
+                3,
+                ["AlwaysEnabled", "LimitedIfSPBelow95F"],
+                None,
+                2,
+                "ALL",
             ),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, QLNMHX, VKZILX, KVKZIL, None, XUJUTY, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 33, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            KZILXW: GeckoByteStructAccessor(self.struct, KZILXW, ZILXWA, None),
-            ILXWAJ: GeckoByteStructAccessor(self.struct, ILXWAJ, LXWAJV, None),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, None),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoByteStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoByteStructAccessor(self.struct, QLAIID, LAIIDN, QBMJVH),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, QLNMHX, TIACQF, XTIACQ, None, XUJUTY, QBMJVH
+            "FiltMinDur": GeckoByteStructAccessor(self.struct, "FiltMinDur", 57, "ALL"),
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 55, "ALL"
             ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, QLNMHX, WAONPY, TTIDUB, None, TIDUBS, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 56, "ALL"
             ),
-            IDUBSS: GeckoEnumStructAccessor(
-                self.struct, IDUBSS, DUBSSU, YYLIUX, SUHBVW, None, JYKLGQ, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            UHBVWV: GeckoEnumStructAccessor(
-                self.struct, UHBVWV, OAWBSI, WAONPY, WVUBYG, None, JYKLGQ, QBMJVH
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 58, "ALL"
             ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, OAWBSI, SXUJUT, YGDSBD, None, XUJUTY, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 59, "ALL"
             ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, WAONPY, BDJQRJ, None, JYKLGQ, QBMJVH
+            "FiltCPMinOnTime": GeckoByteStructAccessor(
+                self.struct, "FiltCPMinOnTime", 60, "ALL"
             ),
-            DJQRJJ: GeckoBoolStructAccessor(
-                self.struct, DJQRJJ, DSBDJQ, YYLIUX, QBMJVH
+            "FiltCPOTMaxDur": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTMaxDur", 61, "ALL"
             ),
-            JQRJJJ: GeckoBoolStructAccessor(
-                self.struct, JQRJJJ, DUBSSU, VKZILX, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 63, 0, ["NONE", "P1", "CP", ""], None, 4, "ALL"
             ),
-            QRJJJV: GeckoBoolStructAccessor(
-                self.struct, QRJJJV, DUBSSU, QPLSPF, QBMJVH
+            "O3FollowPump": GeckoBoolStructAccessor(
+                self.struct, "O3FollowPump", 63, 2, "ALL"
             ),
-            RJJJVY: GeckoBoolStructAccessor(
-                self.struct, RJJJVY, DUBSSU, TIACQF, QBMJVH
+            "O3DuringFilt": GeckoBoolStructAccessor(
+                self.struct, "O3DuringFilt", 63, 3, "ALL"
             ),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, QBMJVH),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, DUBSSU, None, TBJEUT, None, JYKLGQ, QBMJVH
+            "O3Toggling": GeckoBoolStructAccessor(
+                self.struct, "O3Toggling", 63, 4, "ALL"
             ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, QLNMHX, QPLSPF, UTOPHU, None, XUJUTY, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                63,
+                6,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            TOPHUG: GeckoBoolStructAccessor(
-                self.struct, TOPHUG, DSBDJQ, JYKLGQ, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 64, "ALL"
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, DUBSSU, XUJUTY, UGTYIY, None, XUJUTY, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 65, "ALL"
             ),
-            GTYIYW: GeckoTempStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoByteStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoBoolStructAccessor(
-                self.struct, YWSKWI, DSBDJQ, SXUJUT, QBMJVH
+            "O3TogglePeriod": GeckoByteStructAccessor(
+                self.struct, "O3TogglePeriod", 66, "ALL"
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, QLNMHX, SXUJUT, WIVDNQ, None, XUJUTY, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 36, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 37, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 39, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 71, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 73, "ALL"),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 68, 3, "ALL"
             ),
-            IVDNQG: GeckoBoolStructAccessor(
-                self.struct, IVDNQG, VDNQGV, SXUJUT, QBMJVH
+            "EconProgStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgStatus",
+                68,
+                4,
+                ["Disabled", "NotActive", "NA", "Active"],
+                None,
+                4,
+                "ALL",
             ),
-            DNQGVU: GeckoBoolStructAccessor(
-                self.struct, DNQGVU, VDNQGV, WAONPY, QBMJVH
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                17,
+                4,
+                ["LastPumpKey", "NextFreePumpKey", "AnyFreePump"],
+                None,
+                4,
+                "ALL",
             ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, VDNQGV, XUJUTY, UNXNKM, None, JYKLGQ, QBMJVH
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 17, 6, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, VDNQGV, JYKLGQ, UNXNKM, None, JYKLGQ, QBMJVH
+            "SWMPurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "SWMPurgeSpeed", 67, 0, ["Low", "High"], None, 2, "ALL"
+            ),
+            "SWMPurgeBlower": GeckoBoolStructAccessor(
+                self.struct, "SWMPurgeBlower", 67, 1, "ALL"
+            ),
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 83, 4, ["60HZ", "50HZ"], None, 2, "ALL"
+            ),
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 83, 5, ["240Vac", "230VAC"], None, 2, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 85, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 86, None
+            ),
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 87, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 88, "ALL"
+            ),
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 89, "ALL"
+            ),
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 90, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 91, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 92, "ALL"
+            ),
+            "BreakerMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerMenu",
+                83,
+                7,
+                ["Available", "NotAvailable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "FuseMapping": GeckoEnumStructAccessor(
+                self.struct,
+                "FuseMapping",
+                83,
+                1,
+                [
+                    "UL",
+                    "CE_Jmp1_3_Installed",
+                    "CE_Jmp1_4_Installed",
+                    "CE_Jmp2_3_Installed",
+                    "CE_Jmp2_4_Installed",
+                    "",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                23,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                68,
+                1,
+                [
+                    "IgnoreUD",
+                    "ExitQuietAndRestoreAllUD",
+                    "NA",
+                    "ExitQuietAndCancelOtherUD",
+                ],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                68,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 24, 1, ["None", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanAsCoolingDevice": GeckoBoolStructAccessor(
+                self.struct, "FanAsCoolingDevice", 24, 3, "ALL"
+            ),
+            "FanActiveOnAmbiantOT": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnAmbiantOT", 23, 5, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 23, 6, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 23, 7, "ALL"
+            ),
+            "FanSetAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc", 27, "ALL"
+            ),
+            "FanClrAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc", 28, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 29, "ALL"
+            ),
+            "FanSetForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc", 30, "ALL"
+            ),
+            "FanClrForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc", 31, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 32, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 23, None, ["", "CP", "P1"], None, 4, "ALL"
+            ),
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                83,
+                6,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 24, 4, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 23, 2, ["C", "F"], None, 2, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 25, "ALL"),
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 70, "ALL"
+            ),
+            "AmbiantOTEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOTEnable", 24, 0, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 83, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "Aux1AsTVLifter": GeckoBoolStructAccessor(
+                self.struct, "Aux1AsTVLifter", 21, 0, "ALL"
+            ),
+            "Aux2AsSpeakerLifter": GeckoBoolStructAccessor(
+                self.struct, "Aux2AsSpeakerLifter", 21, 1, "ALL"
+            ),
+            "DJS_No1": GeckoEnumStructAccessor(
+                self.struct,
+                "DJS_No1",
+                21,
+                2,
+                ["NA", "OnP1", "OnP2", "OnP3"],
+                None,
+                4,
+                "ALL",
+            ),
+            "DJS_No2": GeckoEnumStructAccessor(
+                self.struct,
+                "DJS_No2",
+                21,
+                4,
+                ["NA", "OnP1", "OnP2", "OnP3"],
+                None,
+                4,
+                "ALL",
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-3.py
+++ b/src/geckolib/driver/packs/inxm-cfg-3.py
@@ -12,1092 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 5
-ACQFFT = 99
-AFIKJP = "".join(chr(c) for c in [65, 109, 80, 109])
-AJVDQL = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-AKQXPI = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-AMJMAO = 55
-AOAWBS = 77
-AONPYY = 41
-ASSAKQ = "".join(chr(c) for c in [70, 98, 77, 116, 114])
-AWBSIR = 72
-BDJQRJ = 30
-BFEGZU = 211
-BIAMJM = 53
-BJEUTO = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        84,
-    ]
-)
-BLKXSJ = 62
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BQSNQL = 84
-BSIRYX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-BSKSOK = "".join(
-    chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114, 114, 101, 110, 116]
-)
-BSSUHB = 104
-BVWVUB = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        49,
-        95,
-        52,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-BWJYKL = 68
-BXTIAC = 97
-BXYBQS = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53])
-BYGDSB = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 77, 101, 110, 117])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-CHWDAF = "".join(chr(c) for c in [67, 80, 80, 87, 77, 68, 101, 102, 97, 117, 108, 116])
-CPQIPO = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-CQBMJV = 1
-CQFFTT = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-CRTFMN = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-CTHBSK = 221
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 73
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-DAFIKJ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-DJQRJJ = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-DNIBXT = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-DNQGVU = "".join(
-    chr(c) for c in [86, 83, 80, 70, 105, 108, 116, 101, 114, 83, 112, 101, 101, 100]
-)
-DQLAII = 95
-DUBSSU = 103
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 4
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-EGZUQE = 212
-EJNIBX = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51])
-EKCWAO = 2
-EKVKZI = 89
-ELHBQN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-EOCTHB = 220
-EUTOPH = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-EXLSXU = "".join(
-    chr(c) for c in [70, 105, 98, 101, 114, 84, 105, 109, 101, 79, 117, 116]
-)
-FCRTFM = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-FEFJTA = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-FFTTID = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-FIKJPU = "".join(chr(c) for c in [50, 52, 104])
-FJBIAM = 51
-FJTACC = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-FMNHTB = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 43
-FTTIDU = 101
-FWRKIN = "".join(chr(c) for c in [67, 104, 97, 110, 103, 101, 87, 97, 116, 101, 114])
-FXQGLR = 203
-GDSBDJ = "".join(
-    chr(c) for c in [78, 111, 116, 65, 118, 97, 105, 108, 97, 98, 108, 101]
-)
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 72, 101, 97, 116, 101, 114])
-GQPLSP = 59
-GSELHB = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-GTYIYW = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-GVUNXN = 26
-GZUQEX = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-HBQNRX = "".join(chr(c) for c in [70])
-HBSKSO = 222
-HBVWVU = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        49,
-        95,
-        51,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(
-    chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 225
-HUGTYI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-HUOJRJ = 206
-HWDAFI = 22
-HXEKVK = 88
-IACQFF = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-IAMJMA = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-IBXTIA = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-IBXYBQ = 82
-IDNIBX = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-IDUBSS = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-IEFXQG = 202
-IFJBIA = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-IGYOUS = "".join(chr(c) for c in [80, 49])
-IIDNIB = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-IJUGSE = "".join(chr(c) for c in [78, 111])
-IKFWRK = "".join(chr(c) for c in [80, 72])
-ILXWAJ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-INEJNI = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        80,
-        79,
-        84,
-        76,
-        105,
-        109,
-        105,
-        116,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-IRYXBQ = "".join(chr(c) for c in [65, 99, 116, 105, 118, 101])
-IUSOOQ = "".join(
-    chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-IUXFEF = 40
-IVDNQG = "".join(
-    chr(c)
-    for c in [86, 83, 80, 67, 104, 101, 99, 107, 102, 108, 111, 83, 112, 101, 101, 100]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 38
-JBIAMJ = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-JEUTOP = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-JHIUSO = "".join(
-    chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-JIGYOU = "".join(chr(c) for c in [78, 79, 78, 69])
-JJJVYF = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-JJVYFC = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-JMAOAW = 75
-JMCBFE = 210
-JNIBXY = 81
-JPUNRJ = "".join(
-    chr(c)
-    for c in [
-        65,
-        117,
-        120,
-        50,
-        65,
-        115,
-        83,
-        112,
-        101,
-        97,
-        107,
-        101,
-        114,
-        76,
-        105,
-        102,
-        116,
-        101,
-        114,
-    ]
-)
-JQRJJJ = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-JTACCP = 3
-JUGSEL = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-JUIKFW = 79
-JUTYEK = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JVDQLA = 94
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        82,
-        101,
-        115,
-        116,
-        111,
-        114,
-        101,
-        65,
-        108,
-        108,
-        85,
-        68,
-    ]
-)
-JWMNZM = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 77, 97, 120, 68, 117, 114]
-)
-JYKLGQ = 69
-JYMOUN = "".join(chr(c) for c in [72, 105])
-JZTATD = "".join(chr(c) for c in [79, 110, 80, 51])
-KCWAON = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-KFWRKI = "".join(chr(c) for c in [67, 104, 101, 99, 107, 71, 70, 67, 73])
-KJPUNR = "".join(
-    chr(c) for c in [65, 117, 120, 49, 65, 115, 84, 86, 76, 105, 102, 116, 101, 114]
-)
-KLGQPL = 70
-KMLOIJ = 29
-KPHUOJ = 205
-KQXPIC = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-KSOKPH = "".join(
-    chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-KVKZIL = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-KWIVDN = 23
-KXSJWM = 63
-KZILXW = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-LAIIDN = "".join(chr(c) for c in [53, 48, 72, 90])
-LASSAK = "".join(chr(c) for c in [70, 65, 78])
-LGQPLS = "".join(chr(c) for c in [83, 97, 110, 105, 76, 101, 118, 101, 108])
-LHBQNR = "".join(chr(c) for c in [67])
-LIUXFE = "".join(chr(c) for c in [67, 108, 101, 97, 110, 80, 49])
-LJUIKF = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49])
-LKXSJW = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-LNMHXE = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-LRAHEO = 209
-LSPFTS = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-LSXUJU = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-LXWAJV = 92
-MAOAWB = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-MHXEKV = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-MJIGYO = 67
-MJMAOA = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-MJVHFT = 200
-MLOIJU = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-MNHTBJ = 31
-MNZMJI = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-MOUNBL = 0
-NBLKXS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-NEJNIB = 80
-NHTBJE = "".join(chr(c) for c in [78, 111, 110, 101])
-NIBXYB = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52])
-NKMLOI = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 51]
-)
-NMHXEK = 87
-NPYYLI = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 49])
-NQGVUN = 25
-NQJYMO = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-NQLNMH = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56])
-NRJZTA = "".join(chr(c) for c in [79, 110, 80, 49])
-NRSJMC = "".join(
-    chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-NRXCHW = 32
-NXNKML = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 50]
-)
-NZMJIG = 66
-OAWBSI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-OCTHBS = "".join(
-    chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114, 114, 101, 110, 116]
-)
-OIJUGS = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-OJRJHI = 207
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-ONPYYL = "".join(chr(c) for c in [83, 116, 97, 114, 116, 68, 117, 114, 70, 114, 101])
-OOQNRS = 227
-OPHUGT = "".join(
-    chr(c)
-    for c in [70, 97, 110, 67, 108, 114, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-OQNRSJ = "".join(
-    chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-OUNBLK = "".join(chr(c) for c in [70, 105, 108, 116, 77, 105, 110, 68, 117, 114])
-OUSPBW = "".join(
-    chr(c) for c in [79, 51, 68, 117, 114, 105, 110, 103, 70, 105, 108, 116]
-)
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        109,
-        105,
-        116,
-        101,
-        100,
-        73,
-        102,
-        83,
-        80,
-        66,
-        101,
-        108,
-        111,
-        119,
-        57,
-        53,
-        70,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-PFTSIF = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-PHUGTY = 35
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-PICXQI = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 60
-POUYNQ = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-PQIPOU = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-PUNRJZ = "".join(chr(c) for c in [65, 117, 120, 50, 65, 115, 79, 110, 122, 101, 110])
-PYYLIU = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 50])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 18
-QFFTTI = 100
-QFYLJU = "".join(
-    chr(c)
-    for c in [78, 101, 120, 116, 70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-QGLRAH = 204
-QGVUNX = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 48]
-)
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-QJYMOU = "".join(chr(c) for c in [76, 111])
-QLAIID = "".join(chr(c) for c in [54, 48, 72, 90])
-QLNMHX = 86
-QNRSJM = 228
-QNRXCH = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-QPLSPF = "".join(chr(c) for c in [83, 97, 110, 105, 79, 110, 84, 105, 109, 101])
-QRJJJV = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-QSNQLN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55])
-QXPICX = "".join(chr(c) for c in [83, 65, 78, 73])
-RAHEOC = "".join(chr(c) for c in [])
-RJHIUS = 208
-RJZTAT = "".join(chr(c) for c in [79, 110, 80, 50])
-RKINEJ = "".join(
-    chr(c) for c in [82, 101, 112, 108, 97, 99, 101, 70, 105, 108, 116, 101, 114]
-)
-RSJMCB = 123
-RTFMNH = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-SAKQXP = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-SELHBQ = "".join(
-    chr(c)
-    for c in [
-        79,
-        118,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SIFJBI = 45
-SIRYXB = "".join(chr(c) for c in [78, 111, 116, 65, 99, 116, 105, 118, 101])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-SJWMNZ = 64
-SKSOKP = 223
-SKWIVD = "".join(chr(c) for c in [80, 117, 109, 112, 49, 65, 115, 86, 83, 80])
-SNQLNM = 85
-SOKPHU = 224
-SOOQNR = "".join(
-    chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-SPBWJY = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-SPFTSI = 42
-SSAKQX = "".join(chr(c) for c in [70, 98, 76, 105])
-SSUHBV = "".join(
-    chr(c) for c in [67, 69, 95, 50, 120, 50, 48, 65, 108, 108, 111, 119, 101, 100]
-)
-SUHBVW = "".join(chr(c) for c in [70, 117, 115, 101, 77, 97, 112, 112, 105, 110, 103])
-SXUJUT = 20
-TACCPQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-TATDZX = "".join(chr(c) for c in [68, 74, 83, 95, 78, 111, 50])
-TBJEUT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        115,
-        67,
-        111,
-        111,
-        108,
-        105,
-        110,
-        103,
-        68,
-        101,
-        118,
-        105,
-        99,
-        101,
-    ]
-)
-THBSKS = "".join(
-    chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 98
-TIDUBS = 102
-TOPHUG = 34
-TSIFJB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-TTIDUB = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-TYIYWS = 37
-UBSSUH = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-UBYGDS = 8
-UGTYIY = 36
-UHBVWV = "".join(chr(c) for c in [85, 76])
-UIKFWR = "".join(chr(c) for c in [67, 108, 101, 97, 110, 70, 105, 108, 116, 101, 114])
-UJUTYE = 21
-UNBLKX = 61
-UNRJZT = "".join(chr(c) for c in [68, 74, 83, 95, 78, 111, 49])
-UNXNKM = 27
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-UQEXLS = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-USOOQN = 226
-USPBWJ = "".join(chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 105, 110, 103])
-UTOPHU = "".join(
-    chr(c)
-    for c in [70, 97, 110, 83, 101, 116, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-UTYEKC = "".join(chr(c) for c in [79, 119, 110])
-UXFEFJ = 1
-VDNQGV = 24
-VDQLAI = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 90
-VLASSA = "".join(chr(c) for c in [76, 73])
-VUNXNK = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 49]
-)
-VWVUBY = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        50,
-        95,
-        51,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-VYFCRT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        67,
-        97,
-        110,
-        99,
-        101,
-        108,
-        79,
-        116,
-        104,
-        101,
-        114,
-        85,
-        68,
-    ]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 93
-WAONPY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-WBSIRY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 80, 114, 111, 103, 83, 116, 97, 116, 117, 115]
-)
-WDAFIK = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 84, 69, 110, 97, 98, 108, 101]
-)
-WIVDNQ = "".join(chr(c) for c in [80, 117, 109, 112, 51, 65, 115, 86, 83, 80])
-WJYKLG = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-WMNZMJ = 65
-WRKINE = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 111, 118, 101, 114])
-WSKWIV = 39
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        67,
-        69,
-        95,
-        74,
-        109,
-        112,
-        50,
-        95,
-        52,
-        95,
-        73,
-        110,
-        115,
-        116,
-        97,
-        108,
-        108,
-        101,
-        100,
-    ]
-)
-XBQFYL = 17
-XCHWDA = 74
-XEKVKZ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-XFEFJT = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 80])
-XLSXUJ = 19
-XNKMLO = 28
-XPICXQ = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-XQIEFX = 201
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 77, 105, 110, 79, 110, 84, 105, 109, 101]
-)
-XTIACQ = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-XUJUTY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-XWAJVD = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-XYBQSN = 83
-YBQSNQ = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54])
-YEKCWA = 6
-YGDSBD = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-YIYWSK = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-YKLGQP = "".join(
-    chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 101, 80, 101, 114, 105, 111, 100]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YNQJYM = 7
-YOUSPB = "".join(
-    chr(c) for c in [79, 51, 70, 111, 108, 108, 111, 119, 80, 117, 109, 112]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-YXBQFY = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-YYLIUX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 91
-ZMJIGY = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-ZUQEXL = 96
-AHEOCT = [
-    JVHFTH,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    IVLASS,
-]
-AIIDNI = [QLAIID, LAIIDN]
-ATDZXN = [
-    BMJVHF,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    GLRAHE,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    SJMCBF,
-    CBFEGZ,
-    FEGZUQ,
-]
-BQNRXC = [LHBQNR, HBQNRX]
-DSBDJQ = [YGDSBD, GDSBDJ]
-DZXNQT = []
-FYLJUI = [BQFYLJ, QFYLJU]
-GYOUSP = [JIGYOU, IGYOUS, PIPIVL, RAHEOC]
-HTBJEU = [NHTBJE, IGYOUS, PIPIVL]
-ICXQIE = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-    PICXQI,
-]
-IKJPUN = [AFIKJP, FIKJPU]
-KINEJN = [UIKFWR, IKFWRK, KFWRKI, FWRKIN, WRKINE, RKINEJ]
-LOIJUG = [RAHEOC, PIPIVL, IGYOUS]
-MCBFEG = [
-    JVHFTH,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    RAHEOC,
-    VLASSA,
-]
-NIBXTI = [IDNIBX, DNIBXT]
-QIPOUY = [CPQIPO, PQIPOU]
-RJJJVY = [DJQRJJ, JQRJJJ, QRJJJV, RAHEOC]
-RYXBQF = [BSIRYX, SIRYXB, JVHFTH, IRYXBQ]
-TDZXNQ = [VLASSA]
-TFMNHT = [CRTFMN, RTFMNH]
-TYEKCW = [JUTYEK, UTYEKC]
-UGSELH = [IJUGSE, JUGSEL]
-UYNQJY = [POUYNQ, OUYNQJ]
-VUBYGD = [UHBVWV, HBVWVU, BVWVUB, VWVUBY, WVUBYG, RAHEOC, RAHEOC, RAHEOC]
-YFCRTF = [JJVYFC, JVYFCR, JVHFTH, VYFCRT]
-YLIUXF = [ONPYYL, NPYYLI, PYYLIU, YYLIUX]
-YMOUNB = [QJYMOU, JYMOUN]
-ZTATDZ = [JVHFTH, NRJZTA, RJZTAT, JZTATD]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1105,248 +19,826 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JTACCP
+        return 3
 
     @property
     def output_keys(self):
-        return ATDZXN
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHeater",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ICXQIE, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 1, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, ICXQIE, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                200,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, ICXQIE, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                201,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, ICXQIE, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                202,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, ICXQIE, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                203,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, None, AHEOCT, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                204,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, ICXQIE, None, None, QBMJVH
+            "OutHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHeater",
+                209,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, ICXQIE, None, None, QBMJVH
+            "Out1ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out1ACurrent", 220, "ALL"
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, ICXQIE, None, None, QBMJVH
+            "Out1BCurrent": GeckoByteStructAccessor(
+                self.struct, "Out1BCurrent", 221, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, ICXQIE, None, None, QBMJVH
+            "Out2ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out2ACurrent", 222, "ALL"
             ),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, MCBFEG, None, None, QBMJVH
+            "Out2BCurrent": GeckoByteStructAccessor(
+                self.struct, "Out2BCurrent", 223, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ICXQIE, None, None, QBMJVH
+            "Out3ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out3ACurrent", 224, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, EGZUQE, None, ICXQIE, None, None, QBMJVH
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                205,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, YEKCWA, TYEKCW, None, EKCWAO, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                206,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YLIUXF, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                207,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            LIUXFE: GeckoBoolStructAccessor(
-                self.struct, LIUXFE, IUXFEF, UXFEFJ, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                208,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XFEFJT: GeckoBoolStructAccessor(
-                self.struct, XFEFJT, IUXFEF, EKCWAO, QBMJVH
+            "Out4ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out4ACurrent", 225, "ALL"
             ),
-            FEFJTA: GeckoBoolStructAccessor(
-                self.struct, FEFJTA, IUXFEF, EFJTAC, QBMJVH
+            "Out5ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out5ACurrent", 226, "ALL"
             ),
-            FJTACC: GeckoBoolStructAccessor(
-                self.struct, FJTACC, IUXFEF, JTACCP, QBMJVH
+            "Out6ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out6ACurrent", 227, "ALL"
             ),
-            TACCPQ: GeckoBoolStructAccessor(
-                self.struct, TACCPQ, IUXFEF, ACCPQI, QBMJVH
+            "Out7ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out7ACurrent", 228, "ALL"
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, IUXFEF, YEKCWA, QIPOUY, None, EKCWAO, QBMJVH
+            "DirectCurrent": GeckoByteStructAccessor(
+                self.struct, "DirectCurrent", 123, "ALL"
             ),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, IUXFEF, YNQJYM, UYNQJY, None, EKCWAO, QBMJVH
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                210,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, IUXFEF, MOUNBL, YMOUNB, None, EKCWAO, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                211,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, MOUNBL, GYOUSP, None, EFJTAC, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                212,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, MJIGYO, EKCWAO, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 96, "ALL"),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 18, "ALL"
             ),
-            OUSPBW: GeckoBoolStructAccessor(
-                self.struct, OUSPBW, MJIGYO, JTACCP, QBMJVH
+            "FiberTimeOut": GeckoByteStructAccessor(
+                self.struct, "FiberTimeOut", 19, "ALL"
             ),
-            USPBWJ: GeckoBoolStructAccessor(
-                self.struct, USPBWJ, MJIGYO, EFJTAC, QBMJVH
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 20, "ALL"
             ),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, MJIGYO, YEKCWA, QIPOUY, None, None, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 21, 6, ["Shared", "Own"], None, 2, "ALL"
             ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoTimeStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoTimeStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoTimeStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTimeStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoTimeStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTimeStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoBoolStructAccessor(
-                self.struct, OAWBSI, AWBSIR, JTACCP, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 73, "ALL"
             ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, AWBSIR, EFJTAC, RYXBQF, None, EFJTAC, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                41,
+                None,
+                ["StartDurFre", "NotUsed1", "NotUsed2", "PurgeOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            YXBQFY: GeckoEnumStructAccessor(
-                self.struct, YXBQFY, XBQFYL, MOUNBL, FYLJUI, None, EKCWAO, QBMJVH
+            "CleanP1": GeckoBoolStructAccessor(self.struct, "CleanP1", 40, 1, "ALL"),
+            "CleanCP": GeckoBoolStructAccessor(self.struct, "CleanCP", 40, 2, "ALL"),
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 40, 4, "ALL"
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, XBQFYL, UXFEFJ, QBMJVH
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 40, 3, "ALL"
             ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, EFJTAC, AIIDNI, None, EKCWAO, QBMJVH
+            "FiltCPOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltCPOTOption", 40, 5, "ALL"
             ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, DQLAII, ACCPQI, NIBXTI, None, EKCWAO, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 40, 6, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, None),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, None),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, None),
-            CQFFTT: GeckoByteStructAccessor(self.struct, CQFFTT, QFFTTI, QBMJVH),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, QBMJVH),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, QBMJVH),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoBoolStructAccessor(
-                self.struct, SSUHBV, AWBSIR, YEKCWA, QBMJVH
+            "FiltCPOTLimitOption": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltCPOTLimitOption",
+                40,
+                7,
+                ["AlwaysEnabled", "LimitedIfSPBelow95F"],
+                None,
+                2,
+                "ALL",
             ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, DQLAII, UXFEFJ, VUBYGD, None, UBYGDS, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 40, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, DQLAII, YNQJYM, DSBDJQ, None, EKCWAO, QBMJVH
+            "FiltMinDur": GeckoByteStructAccessor(self.struct, "FiltMinDur", 61, "ALL"),
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 62, "ALL"
             ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, JTACCP, RJJJVY, None, EFJTAC, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 63, "ALL"
             ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, AWBSIR, UXFEFJ, YFCRTF, None, EFJTAC, QBMJVH
+            "FiltCPMinOnTime": GeckoByteStructAccessor(
+                self.struct, "FiltCPMinOnTime", 64, "ALL"
             ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, AWBSIR, MOUNBL, TFMNHT, None, EKCWAO, QBMJVH
+            "FiltCPOTMaxDur": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTMaxDur", 65, "ALL"
             ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, UXFEFJ, HTBJEU, None, EFJTAC, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 66, "ALL"
             ),
-            TBJEUT: GeckoBoolStructAccessor(
-                self.struct, TBJEUT, MNHTBJ, JTACCP, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 67, 0, ["NONE", "P1", "CP", ""], None, 4, "ALL"
             ),
-            BJEUTO: GeckoBoolStructAccessor(
-                self.struct, BJEUTO, BDJQRJ, ACCPQI, QBMJVH
+            "O3FollowPump": GeckoBoolStructAccessor(
+                self.struct, "O3FollowPump", 67, 2, "ALL"
             ),
-            JEUTOP: GeckoBoolStructAccessor(
-                self.struct, JEUTOP, BDJQRJ, YEKCWA, QBMJVH
+            "O3DuringFilt": GeckoBoolStructAccessor(
+                self.struct, "O3DuringFilt", 67, 3, "ALL"
             ),
-            EUTOPH: GeckoBoolStructAccessor(
-                self.struct, EUTOPH, BDJQRJ, YNQJYM, QBMJVH
+            "O3Toggling": GeckoBoolStructAccessor(
+                self.struct, "O3Toggling", 67, 4, "ALL"
             ),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoByteStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoByteStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoByteStructAccessor(self.struct, YWSKWI, WSKWIV, QBMJVH),
-            SKWIVD: GeckoBoolStructAccessor(
-                self.struct, SKWIVD, KWIVDN, MOUNBL, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                67,
+                6,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, KWIVDN, EKCWAO, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 68, "ALL"
             ),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, QBMJVH),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, QBMJVH),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, QBMJVH),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, QBMJVH),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, QBMJVH),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, BDJQRJ, None, LOIJUG, None, EFJTAC, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 69, "ALL"
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, DQLAII, YEKCWA, UGSELH, None, EKCWAO, QBMJVH
+            "O3TogglePeriod": GeckoByteStructAccessor(
+                self.struct, "O3TogglePeriod", 70, "ALL"
             ),
-            GSELHB: GeckoBoolStructAccessor(
-                self.struct, GSELHB, MNHTBJ, EFJTAC, QBMJVH
+            "SaniLevel": GeckoByteStructAccessor(self.struct, "SaniLevel", 59, "ALL"),
+            "SaniOnTime": GeckoByteStructAccessor(self.struct, "SaniOnTime", 60, "ALL"),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 42, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 43, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 45, "ALL"),
+            "OnzenStart": GeckoTimeStructAccessor(self.struct, "OnzenStart", 51, "ALL"),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 53, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 55, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 75, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 77, "ALL"),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 3, "ALL"
             ),
-            SELHBQ: GeckoBoolStructAccessor(
-                self.struct, SELHBQ, MNHTBJ, ACCPQI, QBMJVH
+            "EconProgStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgStatus",
+                72,
+                4,
+                ["Disabled", "NotActive", "NA", "Active"],
+                None,
+                4,
+                "ALL",
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, BDJQRJ, EKCWAO, BQNRXC, None, EKCWAO, QBMJVH
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                17,
+                0,
+                ["LastPumpKey", "NextFreePumpKey"],
+                None,
+                2,
+                "ALL",
             ),
-            QNRXCH: GeckoTempStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, QBMJVH),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, MNHTBJ, MOUNBL, QBMJVH
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 17, 1, "ALL"
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, DQLAII, MOUNBL, IKJPUN, None, EKCWAO, QBMJVH
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 95, 4, ["60HZ", "50HZ"], None, 2, "ALL"
             ),
-            KJPUNR: GeckoBoolStructAccessor(
-                self.struct, KJPUNR, UJUTYE, MOUNBL, QBMJVH
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 95, 5, ["240Vac", "230VAC"], None, 2, "ALL"
             ),
-            JPUNRJ: GeckoBoolStructAccessor(
-                self.struct, JPUNRJ, UJUTYE, UXFEFJ, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 97, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 98, None
             ),
-            PUNRJZ: GeckoBoolStructAccessor(
-                self.struct, PUNRJZ, UJUTYE, YEKCWA, QBMJVH
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 99, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 100, "ALL"
             ),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, UJUTYE, EKCWAO, ZTATDZ, None, EFJTAC, QBMJVH
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 101, "ALL"
             ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, UJUTYE, EFJTAC, ZTATDZ, None, EFJTAC, QBMJVH
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 102, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 103, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 104, "ALL"
+            ),
+            "CE_2x20Allowed": GeckoBoolStructAccessor(
+                self.struct, "CE_2x20Allowed", 72, 6, "ALL"
+            ),
+            "FuseMapping": GeckoEnumStructAccessor(
+                self.struct,
+                "FuseMapping",
+                95,
+                1,
+                [
+                    "UL",
+                    "CE_Jmp1_3_Installed",
+                    "CE_Jmp1_4_Installed",
+                    "CE_Jmp2_3_Installed",
+                    "CE_Jmp2_4_Installed",
+                    "",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "BreakerMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerMenu",
+                95,
+                7,
+                ["Available", "NotAvailable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                30,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                72,
+                1,
+                [
+                    "IgnoreUD",
+                    "ExitQuietAndRestoreAllUD",
+                    "NA",
+                    "ExitQuietAndCancelOtherUD",
+                ],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                72,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 31, 1, ["None", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanAsCoolingDevice": GeckoBoolStructAccessor(
+                self.struct, "FanAsCoolingDevice", 31, 3, "ALL"
+            ),
+            "FanActiveOnAmbiantOT": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnAmbiantOT", 30, 5, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 30, 6, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 30, 7, "ALL"
+            ),
+            "FanSetAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc", 34, "ALL"
+            ),
+            "FanClrAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc", 35, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 36, "ALL"
+            ),
+            "FanSetForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc", 37, "ALL"
+            ),
+            "FanClrForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc", 38, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 39, "ALL"
+            ),
+            "Pump1AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump1AsVSP", 23, 0, "ALL"
+            ),
+            "Pump3AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump3AsVSP", 23, 2, "ALL"
+            ),
+            "VSPCheckfloSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPCheckfloSpeed", 24, "ALL"
+            ),
+            "VSPFilterSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilterSpeed", 25, "ALL"
+            ),
+            "VSPSpeedLevel0": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel0", 26, "ALL"
+            ),
+            "VSPSpeedLevel1": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel1", 27, "ALL"
+            ),
+            "VSPSpeedLevel2": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel2", 28, "ALL"
+            ),
+            "VSPSpeedLevel3": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel3", 29, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 30, None, ["", "CP", "P1"], None, 4, "ALL"
+            ),
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                95,
+                6,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 31, 4, "ALL"
+            ),
+            "OverSetpointEnable": GeckoBoolStructAccessor(
+                self.struct, "OverSetpointEnable", 31, 5, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 30, 2, ["C", "F"], None, 2, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 32, "ALL"),
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 74, "ALL"
+            ),
+            "CPPWMDefault": GeckoByteStructAccessor(
+                self.struct, "CPPWMDefault", 22, "ALL"
+            ),
+            "AmbiantOTEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOTEnable", 31, 0, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 95, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "Aux1AsTVLifter": GeckoBoolStructAccessor(
+                self.struct, "Aux1AsTVLifter", 21, 0, "ALL"
+            ),
+            "Aux2AsSpeakerLifter": GeckoBoolStructAccessor(
+                self.struct, "Aux2AsSpeakerLifter", 21, 1, "ALL"
+            ),
+            "Aux2AsOnzen": GeckoBoolStructAccessor(
+                self.struct, "Aux2AsOnzen", 21, 6, "ALL"
+            ),
+            "DJS_No1": GeckoEnumStructAccessor(
+                self.struct,
+                "DJS_No1",
+                21,
+                2,
+                ["NA", "OnP1", "OnP2", "OnP3"],
+                None,
+                4,
+                "ALL",
+            ),
+            "DJS_No2": GeckoEnumStructAccessor(
+                self.struct,
+                "DJS_No2",
+                21,
+                4,
+                ["NA", "OnP1", "OnP2", "OnP3"],
+                None,
+                4,
+                "ALL",
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-4.py
+++ b/src/geckolib/driver/packs/inxm-cfg-4.py
@@ -12,960 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 5
-ACQFFT = "".join(chr(c) for c in [78, 111, 110, 101])
-AHEOCT = "".join(
-    chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        84,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-AMJMAO = 15
-AOAWBS = 85
-AONPYY = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 49])
-ASSAKQ = "".join(chr(c) for c in [70, 98, 77, 116, 114])
-AWBSIR = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-BDJQRJ = 28
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-BJEUTO = "".join(chr(c) for c in [65, 99, 116, 105, 118, 101])
-BLKXSJ = 48
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-BQNRXC = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-BQSNQL = 93
-BSIRYX = 3
-BSKSOK = 111
-BSSUHB = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 48]
-)
-BVWVUB = 10
-BWJYKL = "".join(
-    chr(c) for c in [79, 51, 68, 117, 114, 105, 110, 103, 70, 105, 108, 116]
-)
-BXTIAC = 21
-BXYBQS = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-BYGDSB = "".join(
-    chr(c)
-    for c in [78, 101, 120, 116, 70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-CBFEGZ = 106
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-CPQIPO = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-CQBMJV = 0
-CRTFMN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-CTHBSK = "".join(
-    chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 27
-CXQIEF = 96
-DJQRJJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-DNIBXT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-DNQGVU = 74
-DQLAII = "".join(
-    chr(c)
-    for c in [70, 97, 110, 67, 108, 114, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-DSBDJQ = "".join(chr(c) for c in [75, 54, 48, 48, 70, 111, 114, 77, 97, 121])
-DUBSSU = "".join(
-    chr(c) for c in [86, 83, 80, 70, 105, 108, 116, 101, 114, 83, 112, 101, 101, 100]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-EFXQGL = 98
-EGZUQE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-EJNIBX = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-EKCWAO = 63
-EKVKZI = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-ELHBQN = 83
-EOCTHB = "".join(
-    chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114, 114, 101, 110, 116]
-)
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49])
-EXLSXU = 3
-FCRTFM = 41
-FEFJTA = 25
-FEGZUQ = 107
-FFTTID = "".join(chr(c) for c in [80, 117, 109, 112, 49, 65, 115, 86, 83, 80])
-FJBIAM = "".join(chr(c) for c in [67])
-FJTACC = 26
-FMNHTB = 67
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [83, 97, 110, 105, 79, 110, 84, 105, 109, 101])
-FTTIDU = 5
-FWRKIN = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-FYLJUI = "".join(chr(c) for c in [53, 48, 72, 90])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GLRAHE = 104
-GQPLSP = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-GSELHB = 82
-GTYIYW = "".join(
-    chr(c) for c in [82, 101, 112, 108, 97, 99, 101, 70, 105, 108, 116, 101, 114]
-)
-GVUNXN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56])
-GYOUSP = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-GZUQEX = 86
-HBQNRX = 84
-HBSKSO = "".join(
-    chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114, 114, 101, 110, 116]
-)
-HBVWVU = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 50]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 108
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(
-    chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-HTBJEU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-HUGTYI = "".join(chr(c) for c in [67, 104, 97, 110, 103, 101, 87, 97, 116, 101, 114])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        67,
-        97,
-        110,
-        99,
-        101,
-        108,
-        79,
-        116,
-        104,
-        101,
-        114,
-        85,
-        68,
-    ]
-)
-IACQFF = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-IAMJMA = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-IBXTIA = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-IBXYBQ = 91
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-IDNIBX = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-IDUBSS = 6
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-IFJBIA = 13
-IGYOUS = 54
-IIDNIB = 19
-IJUGSE = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-IKFWRK = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-ILXWAJ = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-INEJNI = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 6
-IRYXBQ = 14
-IUSOOQ = 114
-IUXFEF = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 80])
-IVDNQG = 73
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 70
-JBIAMJ = "".join(chr(c) for c in [70])
-JHIUSO = 113
-JIGYOU = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JJJVYF = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-JJVYFC = 37
-JMAOAW = 12
-JNIBXY = 90
-JQRJJJ = 29
-JRJHIU = 103
-JTACCP = 4
-JUGSEL = 81
-JUIKFW = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-JUTYEK = "".join(chr(c) for c in [79, 119, 110])
-JVDQLA = "".join(
-    chr(c)
-    for c in [70, 97, 110, 83, 101, 116, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-JWMNZM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-JYKLGQ = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-JYMOUN = "".join(chr(c) for c in [76, 111])
-KCWAON = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-KINEJN = 88
-KLGQPL = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-KMLOIJ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-KQXPIC = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-KSOKPH = 112
-KVKZIL = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-KWIVDN = 72
-KXSJWM = 49
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 65, 78])
-LGQPLS = 59
-LHBQNR = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-LIUXFE = 0
-LJUIKF = 1
-LKXSJW = "".join(chr(c) for c in [70, 105, 108, 116, 77, 105, 110, 68, 117, 114])
-LNMHXE = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-LOIJUG = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-LRAHEO = "".join(chr(c) for c in [])
-LSPFTS = 61
-LSXUJU = 4
-LXWAJV = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-MAOAWB = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        105,
-        116,
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        110,
-        100,
-        82,
-        101,
-        115,
-        116,
-        111,
-        114,
-        101,
-        65,
-        108,
-        108,
-        85,
-        68,
-    ]
-)
-MJIGYO = 53
-MJMAOA = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-MJVHFT = 95
-MLOIJU = 79
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MNZMJI = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 77, 105, 110, 79, 110, 84, 105, 109, 101]
-)
-NBLKXS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-NEJNIB = 89
-NHTBJE = "".join(
-    chr(c) for c in [69, 99, 111, 110, 80, 114, 111, 103, 83, 116, 97, 116, 117, 115]
-)
-NIBXTI = 20
-NIBXYB = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-NKMLOI = 78
-NMHXEK = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-NPYYLI = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-NQGVUN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55])
-NQJYMO = 7
-NQLNMH = "".join(
-    chr(c) for c in [67, 69, 95, 50, 120, 50, 48, 65, 108, 108, 111, 119, 101, 100]
-)
-NRSJMC = 117
-NRXCHW = "".join(chr(c) for c in [50, 52, 104])
-NXNKML = 77
-NZMJIG = 52
-OAWBSI = "".join(chr(c) for c in [78, 111])
-OCTHBS = 109
-OIJUGS = 80
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-OKPHUO = 100
-ONPYYL = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 50])
-OOQNRS = "".join(
-    chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-OPHUGT = "".join(chr(c) for c in [80, 72])
-OQNRSJ = 116
-OUNBLK = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-OUSPBW = "".join(chr(c) for c in [80, 49])
-OUYNQJ = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-PBWJYK = 56
-PFTSIF = 45
-PHUGTY = "".join(chr(c) for c in [67, 104, 101, 99, 107, 71, 70, 67, 73])
-PHUOJR = 101
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 101, 80, 101, 114, 105, 111, 100]
-)
-POUYNQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        80,
-        79,
-        84,
-        76,
-        105,
-        109,
-        105,
-        116,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-PQIPOU = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [70, 105, 98, 101, 114, 84, 105, 109, 101, 79, 117, 116]
-)
-QFFTTI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        115,
-        67,
-        111,
-        111,
-        108,
-        105,
-        110,
-        103,
-        68,
-        101,
-        118,
-        105,
-        99,
-        101,
-    ]
-)
-QFYLJU = "".join(chr(c) for c in [54, 48, 72, 90])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 101, 97, 116, 101, 114])
-QGVUNX = 75
-QIEFXQ = 97
-QJYMOU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-QLAIID = 18
-QLNMHX = 62
-QNRSJM = "".join(
-    chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-QNRXCH = "".join(chr(c) for c in [65, 109, 80, 109])
-QPLSPF = 60
-QRJJJV = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-QSNQLN = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-QXPICX = "".join(chr(c) for c in [83, 65, 78, 73])
-RJHIUS = "".join(
-    chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-RJJJVY = 31
-RKINEJ = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-RTFMNH = 65
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        79,
-        118,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SAKQXP = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SBDJQR = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-SELHBQ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-SIFJBI = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-SIRYXB = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-SJMCBF = 105
-SJWMNZ = 50
-SKSOKP = "".join(
-    chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-SKWIVD = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52])
-SNQLNM = 94
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-SOOQNR = 115
-SPBWJY = "".join(
-    chr(c) for c in [79, 51, 70, 111, 108, 108, 111, 119, 80, 117, 109, 112]
-)
-SPFTSI = "".join(chr(c) for c in [83, 97, 110, 105, 76, 101, 118, 101, 108])
-SSAKQX = "".join(chr(c) for c in [70, 98, 76, 105])
-SSUHBV = 8
-SUHBVW = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 49]
-)
-SXUJUT = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-TACCPQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-TBJEUT = "".join(chr(c) for c in [78, 111, 116, 65, 99, 116, 105, 118, 101])
-TFMNHT = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-THBSKS = 110
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 22
-TIDUBS = "".join(
-    chr(c)
-    for c in [86, 83, 80, 67, 104, 101, 99, 107, 102, 108, 111, 83, 112, 101, 101, 100]
-)
-TOPHUG = "".join(chr(c) for c in [67, 108, 101, 97, 110, 70, 105, 108, 116, 101, 114])
-TSIFJB = 46
-TTIDUB = "".join(chr(c) for c in [80, 117, 109, 112, 51, 65, 115, 86, 83, 80])
-TYEKCW = 2
-UBSSUH = 7
-UBYGDS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-UGSELH = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-UGTYIY = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 111, 118, 101, 114])
-UHBVWV = 9
-UIKFWR = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-UJUTYE = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UNBLKX = 47
-UNXNKM = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-UOJRJH = 102
-UQEXLS = 2
-USOOQN = "".join(
-    chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114, 114, 101, 110, 116]
-)
-UTOPHU = 69
-UXFEFJ = 24
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        109,
-        105,
-        116,
-        101,
-        100,
-        73,
-        102,
-        83,
-        80,
-        66,
-        101,
-        108,
-        111,
-        119,
-        57,
-        53,
-        70,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54])
-VDQLAI = 17
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-VLASSA = "".join(chr(c) for c in [76, 73])
-VUBYGD = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VUNXNK = 76
-VWVUBY = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 51]
-)
-VYFCRT = 39
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [83, 116, 97, 114, 116, 68, 117, 114, 70, 114, 101])
-WIVDNQ = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53])
-WJYKLG = 57
-WMNZMJ = 51
-WRKINE = 87
-WSKWIV = 71
-WVUBYG = 11
-XBQFYL = 64
-XCHWDA = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 84, 69, 110, 97, 98, 108, 101]
-)
-XFEFJT = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-XLSXUJ = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-XNKMLO = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-XPICXQ = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-XQGLRA = 99
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-XSJWMN = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-XUJUTY = 1
-XWAJVD = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-XYBQSN = 92
-YBQSNQ = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-YEKCWA = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YFCRTF = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-YIYWSK = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50])
-YKLGQP = 58
-YLIUXF = 23
-YMOUNB = "".join(chr(c) for c in [72, 105])
-YOUSPB = 55
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51])
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-YYLIUX = "".join(chr(c) for c in [67, 108, 101, 97, 110, 80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 77, 97, 120, 68, 117, 114]
-)
-ZUQEXL = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-BIAMJM = [FJBIAM, JBIAMJ]
-CHWDAF = [
-    BMJVHF,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    QGLRAH,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RSJMCB,
-    MCBFEG,
-    BFEGZU,
-]
-CQFFTT = [ACQFFT, OUSPBW, PIPIVL]
-HWDAFI = [VLASSA]
-JEUTOP = [HTBJEU, TBJEUT, JVHFTH, BJEUTO]
-JMCBFE = [
-    JVHFTH,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    VLASSA,
-]
-KFWRKI = [UIKFWR, IKFWRK]
-KZILXW = [KVKZIL, VKZILX]
-MOUNBL = [JYMOUN, YMOUNB]
-PICXQI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-]
-PYYLIU = [WAONPY, AONPYY, ONPYYL, NPYYLI]
-QIPOUY = [CPQIPO, PQIPOU]
-RAHEOC = [
-    JVHFTH,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    LRAHEO,
-    IVLASS,
-]
-RXCHWD = [QNRXCH, NRXCHW]
-TYIYWS = [TOPHUG, OPHUGT, PHUGTY, HUGTYI, UGTYIY, GTYIYW]
-USPBWJ = [PIPIVL, OUSPBW]
-UTYEKC = [UJUTYE, JUTYEK]
-WAJVDQ = [ILXWAJ, LXWAJV, XWAJVD, LRAHEO]
-WBSIRY = [OAWBSI, AWBSIR]
-WDAFIK = []
-XEKVKZ = [NMHXEK, MHXEKV, JVHFTH, HXEKVK]
-YGDSBD = [UBYGDS, BYGDSB]
-YLJUIK = [QFYLJU, FYLJUI]
-YNQJYM = [OUYNQJ, UYNQJY]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -973,225 +19,757 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JTACCP
+        return 4
 
     @property
     def output_keys(self):
-        return CHWDAF
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHeater",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, PICXQI, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, PICXQI, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                95,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, PICXQI, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                96,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, PICXQI, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                97,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, PICXQI, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                98,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, None, RAHEOC, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                99,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, PICXQI, None, None, QBMJVH
+            "OutHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHeater",
+                104,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, PICXQI, None, None, QBMJVH
+            "Out1ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out1ACurrent", 108, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, PICXQI, None, None, QBMJVH
+            "Out1BCurrent": GeckoByteStructAccessor(
+                self.struct, "Out1BCurrent", 109, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, PICXQI, None, None, QBMJVH
+            "Out2ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out2ACurrent", 110, "ALL"
             ),
-            RJHIUS: GeckoByteStructAccessor(self.struct, RJHIUS, JHIUSO, QBMJVH),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, QBMJVH),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, JMCBFE, None, None, QBMJVH
+            "Out2BCurrent": GeckoByteStructAccessor(
+                self.struct, "Out2BCurrent", 111, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, PICXQI, None, None, QBMJVH
+            "Out3ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out3ACurrent", 112, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, PICXQI, None, None, QBMJVH
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                100,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, QBMJVH),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, TYEKCW, UTYEKC, None, TYEKCW, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                101,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, PYYLIU, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                102,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            YYLIUX: GeckoBoolStructAccessor(
-                self.struct, YYLIUX, YLIUXF, LIUXFE, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                103,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUXFEF: GeckoBoolStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, LIUXFE, QBMJVH
+            "Out4ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out4ACurrent", 113, "ALL"
             ),
-            XFEFJT: GeckoBoolStructAccessor(
-                self.struct, XFEFJT, FEFJTA, LIUXFE, QBMJVH
+            "Out5ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out5ACurrent", 114, "ALL"
             ),
-            EFJTAC: GeckoBoolStructAccessor(
-                self.struct, EFJTAC, FJTACC, JTACCP, QBMJVH
+            "Out6ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out6ACurrent", 115, "ALL"
             ),
-            TACCPQ: GeckoBoolStructAccessor(
-                self.struct, TACCPQ, FJTACC, ACCPQI, QBMJVH
+            "Out7ACurrent": GeckoByteStructAccessor(
+                self.struct, "Out7ACurrent", 116, "ALL"
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, FJTACC, IPOUYN, QIPOUY, None, TYEKCW, QBMJVH
+            "DirectCurrent": GeckoByteStructAccessor(
+                self.struct, "DirectCurrent", 117, "ALL"
             ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, FJTACC, NQJYMO, YNQJYM, None, TYEKCW, QBMJVH
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                105,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, FJTACC, LIUXFE, MOUNBL, None, TYEKCW, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                106,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, USPBWJ, None, None, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                107,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoBoolStructAccessor(
-                self.struct, SPBWJY, PBWJYK, LIUXFE, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 86, "ALL"),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 2, "ALL"
             ),
-            BWJYKL: GeckoBoolStructAccessor(
-                self.struct, BWJYKL, WJYKLG, LIUXFE, QBMJVH
+            "FiberTimeOut": GeckoByteStructAccessor(
+                self.struct, "FiberTimeOut", 3, "ALL"
             ),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, QIPOUY, None, None, QBMJVH
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 4, "ALL"
             ),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoByteStructAccessor(self.struct, GQPLSP, QPLSPF, QBMJVH),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoByteStructAccessor(self.struct, FTSIFJ, TSIFJB, QBMJVH),
-            SIFJBI: GeckoEnumStructAccessor(
-                self.struct, SIFJBI, IFJBIA, TYEKCW, BIAMJM, None, TYEKCW, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 1, 2, ["Shared", "Own"], None, 2, "ALL"
             ),
-            IAMJMA: GeckoTempStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, USPBWJ, None, None, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 63, "ALL"
             ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, AOAWBS, BSIRYX, WBSIRY, None, TYEKCW, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                27,
+                None,
+                ["StartDurFre", "NotUsed1", "NotUsed2", "PurgeOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, JTACCP, QBMJVH
+            "CleanP1": GeckoBoolStructAccessor(self.struct, "CleanP1", 23, 0, "ALL"),
+            "CleanCP": GeckoBoolStructAccessor(self.struct, "CleanCP", 24, 0, "ALL"),
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 25, 0, "ALL"
             ),
-            RYXBQF: GeckoBoolStructAccessor(
-                self.struct, RYXBQF, IRYXBQ, ACCPQI, QBMJVH
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 26, 4, "ALL"
             ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, AOAWBS, LJUIKF, YLJUIK, None, TYEKCW, QBMJVH
+            "FiltCPOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltCPOTOption", 26, 5, "ALL"
             ),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, AOAWBS, TYEKCW, KFWRKI, None, TYEKCW, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 26, 6, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, None),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, None),
-            INEJNI: GeckoByteStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoByteStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, QBMJVH),
-            NQLNMH: GeckoBoolStructAccessor(
-                self.struct, NQLNMH, QLNMHX, IPOUYN, QBMJVH
+            "FiltCPOTLimitOption": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltCPOTLimitOption",
+                26,
+                7,
+                ["AlwaysEnabled", "LimitedIfSPBelow95F"],
+                None,
+                2,
+                "ALL",
             ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, QLNMHX, LJUIKF, XEKVKZ, None, JTACCP, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 26, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, QLNMHX, LIUXFE, KZILXW, None, TYEKCW, QBMJVH
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 47, "ALL"
             ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, IFJBIA, BSIRYX, WAJVDQ, None, JTACCP, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 48, "ALL"
             ),
-            AJVDQL: GeckoBoolStructAccessor(
-                self.struct, AJVDQL, IFJBIA, ACCPQI, QBMJVH
+            "FiltMinDur": GeckoByteStructAccessor(self.struct, "FiltMinDur", 49, "ALL"),
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 50, "ALL"
             ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoBoolStructAccessor(
-                self.struct, LAIIDN, IFJBIA, IPOUYN, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 51, "ALL"
             ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoBoolStructAccessor(
-                self.struct, IDNIBX, IFJBIA, NQJYMO, QBMJVH
+            "FiltCPMinOnTime": GeckoByteStructAccessor(
+                self.struct, "FiltCPMinOnTime", 52, "ALL"
             ),
-            DNIBXT: GeckoByteStructAccessor(self.struct, DNIBXT, NIBXTI, QBMJVH),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, QBMJVH),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, IRYXBQ, LJUIKF, CQFFTT, None, JTACCP, QBMJVH
+            "FiltCPOTMaxDur": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTMaxDur", 53, "ALL"
             ),
-            QFFTTI: GeckoBoolStructAccessor(
-                self.struct, QFFTTI, IRYXBQ, BSIRYX, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 54, "ALL"
             ),
-            FFTTID: GeckoBoolStructAccessor(
-                self.struct, FFTTID, FTTIDU, LIUXFE, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 55, None, ["CP", "P1"], None, None, "ALL"
             ),
-            TTIDUB: GeckoBoolStructAccessor(
-                self.struct, TTIDUB, FTTIDU, TYEKCW, QBMJVH
+            "O3FollowPump": GeckoBoolStructAccessor(
+                self.struct, "O3FollowPump", 56, 0, "ALL"
             ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, XUJUTY, LIUXFE, YGDSBD, None, TYEKCW, QBMJVH
+            "O3DuringFilt": GeckoBoolStructAccessor(
+                self.struct, "O3DuringFilt", 57, 0, "ALL"
             ),
-            GDSBDJ: GeckoBoolStructAccessor(
-                self.struct, GDSBDJ, XUJUTY, LJUIKF, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                58,
+                None,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoTimeStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoTimeStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoTimeStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoTimeStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoTimeStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoBoolStructAccessor(
-                self.struct, MNHTBJ, QLNMHX, BSIRYX, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 59, "ALL"
             ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, QLNMHX, JTACCP, JEUTOP, None, JTACCP, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 60, "ALL"
             ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, AOAWBS, LIUXFE, RXCHWD, None, TYEKCW, QBMJVH
+            "O3TogglePeriod": GeckoByteStructAccessor(
+                self.struct, "O3TogglePeriod", 61, "ALL"
             ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, IRYXBQ, LIUXFE, QBMJVH
+            "SaniLevel": GeckoByteStructAccessor(self.struct, "SaniLevel", 45, "ALL"),
+            "SaniOnTime": GeckoByteStructAccessor(self.struct, "SaniOnTime", 46, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 13, 2, ["C", "F"], None, 2, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 15, "ALL"),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 12, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                85,
+                3,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 14, 4, "ALL"
+            ),
+            "OverSetpointEnable": GeckoBoolStructAccessor(
+                self.struct, "OverSetpointEnable", 14, 5, "ALL"
+            ),
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 64, "ALL"
+            ),
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 85, 1, ["60HZ", "50HZ"], None, 2, "ALL"
+            ),
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 85, 2, ["240Vac", "230VAC"], None, 2, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 87, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 88, None
+            ),
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 89, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 90, "ALL"
+            ),
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 91, "ALL"
+            ),
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 92, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 93, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 94, "ALL"
+            ),
+            "CE_2x20Allowed": GeckoBoolStructAccessor(
+                self.struct, "CE_2x20Allowed", 62, 6, "ALL"
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                62,
+                1,
+                [
+                    "IgnoreUD",
+                    "ExitQuietAndRestoreAllUD",
+                    "NA",
+                    "ExitQuietAndCancelOtherUD",
+                ],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                62,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                13,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "FanActiveOnAmbiantOT": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnAmbiantOT", 13, 5, "ALL"
+            ),
+            "FanSetAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc", 17, "ALL"
+            ),
+            "FanClrAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc", 18, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 13, 6, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 19, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 13, 7, "ALL"
+            ),
+            "FanSetForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc", 20, "ALL"
+            ),
+            "FanClrForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc", 21, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 22, "ALL"
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 14, 1, ["None", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanAsCoolingDevice": GeckoBoolStructAccessor(
+                self.struct, "FanAsCoolingDevice", 14, 3, "ALL"
+            ),
+            "Pump1AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump1AsVSP", 5, 0, "ALL"
+            ),
+            "Pump3AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump3AsVSP", 5, 2, "ALL"
+            ),
+            "VSPCheckfloSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPCheckfloSpeed", 6, "ALL"
+            ),
+            "VSPFilterSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilterSpeed", 7, "ALL"
+            ),
+            "VSPSpeedLevel0": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel0", 8, "ALL"
+            ),
+            "VSPSpeedLevel1": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel1", 9, "ALL"
+            ),
+            "VSPSpeedLevel2": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel2", 10, "ALL"
+            ),
+            "VSPSpeedLevel3": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel3", 11, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                1,
+                0,
+                ["LastPumpKey", "NextFreePumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 1, 1, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 28, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 29, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 31, "ALL"),
+            "OnzenStart": GeckoTimeStructAccessor(self.struct, "OnzenStart", 37, "ALL"),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 39, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 41, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 65, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 67, "ALL"),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 62, 3, "ALL"
+            ),
+            "EconProgStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgStatus",
+                62,
+                4,
+                ["Disabled", "NotActive", "NA", "Active"],
+                None,
+                4,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 85, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "AmbiantOTEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOTEnable", 14, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-6.py
+++ b/src/geckolib/driver/packs/inxm-cfg-6.py
@@ -12,969 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 25
-ACQFFT = 18
-AFIKJP = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 69, 110, 97, 98, 108, 101]
-)
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-AJVDQL = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-AKQXPI = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-AMJMAO = "".join(chr(c) for c in [83, 97, 110, 105, 79, 110, 84, 105, 109, 101])
-AOAWBS = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AONPYY = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ASSAKQ = "".join(chr(c) for c in [70, 98, 76, 105])
-AWBSIR = "".join(chr(c) for c in [67])
-BDJQRJ = 28
-BFEGZU = "".join(chr(c) for c in [76, 73])
-BIAMJM = "".join(chr(c) for c in [83, 97, 110, 105, 76, 101, 118, 101, 108])
-BJEUTO = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-BLKXSJ = "".join(chr(c) for c in [72, 105])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-BQNRXC = 82
-BQSNQL = 89
-BSKSOK = 111
-BSSUHB = 5
-BVWVUB = 7
-BWJYKL = 119
-BXTIAC = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        115,
-        67,
-        111,
-        111,
-        108,
-        105,
-        110,
-        103,
-        68,
-        101,
-        118,
-        105,
-        99,
-        101,
-    ]
-)
-BXYBQS = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-BYGDSB = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 50]
-)
-CBFEGZ = 105
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-CHWDAF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CPQIPO = 26
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-CRTFMN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [70, 105, 98, 101, 114, 84, 105, 109, 101, 79, 117, 116]
-)
-CXQIEF = 96
-DJQRJJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-DNIBXT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-DNQGVU = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52])
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-DSBDJQ = 11
-DUBSSU = 22
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 0
-EFXQGL = 98
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-EJNIBX = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-EKVKZI = 94
-ELHBQN = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114])
-EUTOPH = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-EXLSXU = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-FCRTFM = 41
-FEFJTA = 23
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 84, 111, 103, 103, 108, 101, 80, 101, 114, 105, 111, 100]
-)
-FJTACC = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 80])
-FMNHTB = 67
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-FTTIDU = 20
-FWRKIN = "".join(chr(c) for c in [54, 48, 72, 90])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-FYLJUI = 3
-GDSBDJ = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 51]
-)
-GLRAHE = 104
-GQPLSP = "".join(
-    chr(c) for c in [79, 51, 70, 111, 108, 108, 111, 119, 80, 117, 109, 112]
-)
-GSELHB = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-GTYIYW = "".join(chr(c) for c in [67, 108, 101, 97, 110, 70, 105, 108, 116, 101, 114])
-GVUNXN = 73
-GYOUSP = 53
-GZUQEX = 106
-HBQNRX = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114])
-HBVWVU = "".join(
-    chr(c) for c in [86, 83, 80, 70, 105, 108, 116, 101, 114, 83, 112, 101, 101, 100]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 108
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUGTYI = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-HWDAFI = "".join(chr(c) for c in [65, 109, 80, 109])
-HXEKVK = 93
-IACQFF = "".join(
-    chr(c)
-    for c in [70, 97, 110, 67, 108, 114, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-IAMJMA = 45
-IBXTIA = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-IBXYBQ = 87
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-IDNIBX = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        84,
-    ]
-)
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-IFJBIA = 59
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IJUGSE = 78
-IKFWRK = 64
-ILXWAJ = "".join(
-    chr(c) for c in [82, 101, 115, 116, 111, 114, 101, 65, 108, 108, 85, 68]
-)
-INEJNI = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 5
-IRYXBQ = 12
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114])
-IUXFEF = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-IVDNQG = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51])
-IVLASS = "".join(chr(c) for c in [])
-IYWSKW = "".join(chr(c) for c in [67, 104, 97, 110, 103, 101, 87, 97, 116, 101, 114])
-JBIAMJ = 61
-JEUTOP = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-JHIUSO = 118
-JIGYOU = 52
-JJJVYF = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-JJVYFC = 37
-JMAOAW = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-JMCBFE = 117
-JQRJJJ = 29
-JRJHIU = 103
-JTACCP = 24
-JUGSEL = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        79,
-        118,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-JUTYEK = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-JVDQLA = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-JWMNZM = 48
-JYMOUN = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-KCWAON = 2
-KFWRKI = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-KINEJN = 1
-KLGQPL = 55
-KMLOIJ = 76
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-KQXPIC = "".join(chr(c) for c in [83, 65, 78, 73])
-KSOKPH = 112
-KVKZIL = "".join(
-    chr(c) for c in [67, 69, 95, 50, 120, 50, 48, 65, 108, 108, 111, 119, 101, 100]
-)
-KWIVDN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50])
-KXSJWM = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-KZILXW = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-LAIIDN = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-LASSAK = "".join(chr(c) for c in [70, 98, 77, 116, 114])
-LHBQNR = 81
-LIUXFE = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 50])
-LJUIKF = 14
-LNMHXE = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-LOIJUG = 77
-LRAHEO = "".join(chr(c) for c in [72, 84, 82])
-LSPFTS = 57
-LSXUJU = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-LXWAJV = "".join(
-    chr(c) for c in [67, 97, 110, 99, 101, 108, 79, 116, 104, 101, 114, 85, 68]
-)
-MAOAWB = 15
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-MHXEKV = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 46
-MJVHFT = 95
-MLOIJU = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-MNZMJI = 50
-NBLKXS = "".join(chr(c) for c in [76, 111])
-NEJNIB = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-NHTBJE = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-NIBXTI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-NIBXYB = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-NKMLOI = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56])
-NMHXEK = 92
-NPYYLI = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-NQGVUN = 72
-NQJYMO = 6
-NQLNMH = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114])
-NRXCHW = 83
-NXNKML = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55])
-NZMJIG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-OAWBSI = 13
-OCTHBS = 109
-OIJUGS = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-OKPHUO = 100
-ONPYYL = 63
-OOQNRS = 114
-OPHUGT = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114])
-OUNBLK = 7
-OUSPBW = 49
-OUYNQJ = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = 60
-PHUGTY = "".join(chr(c) for c in [75, 54, 48, 48, 70, 111, 114, 77, 97, 121])
-PHUOJR = 101
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [79, 51, 68, 117, 114, 105, 110, 103, 70, 105, 108, 116]
-)
-POUYNQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-PQIPOU = 4
-PYYLIU = 27
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 107
-QFFTTI = 19
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-QGVUNX = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53])
-QIEFXQ = 97
-QIPOUY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        80,
-        79,
-        84,
-        76,
-        105,
-        109,
-        105,
-        116,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-QLNMHX = 91
-QNRSJM = 115
-QNRXCH = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-QPLSPF = 56
-QRJJJV = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-QSNQLN = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-QXPICX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJJJVY = 31
-RSJMCB = 116
-RTFMNH = 65
-RXCHWD = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-RYXBQF = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-SAKQXP = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-SBDJQR = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-SELHBQ = 80
-SIFJBI = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-SIRYXB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-SJMCBF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-SJWMNZ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114])
-SNQLNM = 90
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114])
-SPBWJY = 54
-SPFTSI = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SSAKQX = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SSUHBV = "".join(chr(c) for c in [80, 117, 109, 112, 51, 65, 115, 86, 83, 80])
-SUHBVW = "".join(
-    chr(c)
-    for c in [86, 83, 80, 67, 104, 101, 99, 107, 102, 108, 111, 83, 112, 101, 101, 100]
-)
-SXUJUT = 4
-TACCPQ = "".join(chr(c) for c in [67, 80, 65, 108, 119, 97, 121, 115, 79, 78])
-TBJEUT = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-TFMNHT = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-THBSKS = 110
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 17
-TIDUBS = 21
-TSIFJB = 58
-TTIDUB = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-TYEKCW = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-TYIYWS = "".join(chr(c) for c in [80, 72])
-UBSSUH = "".join(chr(c) for c in [80, 117, 109, 112, 49, 65, 115, 86, 83, 80])
-UBYGDS = 9
-UGSELH = 79
-UGTYIY = 69
-UHBVWV = 6
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-UJUTYE = 2
-UNBLKX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-UNXNKM = 74
-UOJRJH = 102
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-USOOQN = 113
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-UTYEKC = 1
-UYNQJY = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-VDNQGV = 71
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 62
-VLASSA = "".join(chr(c) for c in [70, 65, 78])
-VUBYGD = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 49]
-)
-VUNXNK = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54])
-VWVUBY = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 48]
-)
-VYFCRT = 39
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-WAONPY = 3
-WBSIRY = "".join(chr(c) for c in [70])
-WDAFIK = "".join(chr(c) for c in [50, 52, 104])
-WIVDNQ = 70
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-WRKINE = "".join(chr(c) for c in [53, 48, 72, 90])
-WSKWIV = "".join(
-    chr(c) for c in [82, 101, 112, 108, 97, 99, 101, 70, 105, 108, 116, 101, 114]
-)
-WVUBYG = 8
-XBQFYL = "".join(chr(c) for c in [78, 111])
-XCHWDA = 84
-XEKVKZ = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-XFEFJT = "".join(chr(c) for c in [67, 108, 101, 97, 110, 80, 49])
-XLSXUJ = 86
-XNKMLO = 75
-XPICXQ = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-XQGLRA = 99
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-XSJWMN = 47
-XTIACQ = "".join(
-    chr(c)
-    for c in [70, 97, 110, 83, 101, 116, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-XUJUTY = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-XYBQSN = 88
-YBQSNQ = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-YEKCWA = "".join(chr(c) for c in [79, 119, 110])
-YFCRTF = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-YGDSBD = 10
-YIYWSK = "".join(chr(c) for c in [67, 104, 101, 99, 107, 71, 70, 67, 73])
-YKLGQP = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-YLIUXF = "".join(chr(c) for c in [78, 111, 116, 85, 115, 101, 100, 49])
-YLJUIK = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-YMOUNB = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 111, 118, 101, 114])
-YXBQFY = 85
-YYLIUX = "".join(chr(c) for c in [83, 116, 97, 114, 116, 68, 117, 114, 70, 114, 101])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-ZMJIGY = 51
-BSIRYX = [AWBSIR, WBSIRY]
-DAFIKJ = [HWDAFI, WDAFIK]
-EKCWAO = [TYEKCW, YEKCWA]
-FEGZUQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    BFEGZU,
-]
-FIKJPU = [
-    BMJVHF,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    QGLRAH,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    MCBFEG,
-    EGZUQE,
-    UQEXLS,
-]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-HTBJEU = [JVHFTH, NHTBJE]
-IIDNIB = [QLAIID, LAIIDN, AIIDNI, IVLASS]
-IKJPUN = [BFEGZU]
-JNIBXY = [NEJNIB, EJNIBX]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KJPUNR = []
-LGQPLS = [PIPIVL, WJYKLG]
-LKXSJW = [NBLKXS, BLKXSJ]
-MOUNBL = [JYMOUN, YMOUNB]
-PICXQI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-]
-QFYLJU = [XBQFYL, BQFYLJ]
-RAHEOC = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    LRAHEO,
-]
-RKINEJ = [FWRKIN, WRKINE]
-SKWIVD = [GTYIYW, TYIYWS, YIYWSK, IYWSKW, YWSKWI, WSKWIV]
-TOPHUG = [EUTOPH, UTOPHU]
-UXFEFJ = [YYLIUX, YLIUXF, LIUXFE, IUXFEF]
-VDQLAI = [AJVDQL, JVDQLA]
-XWAJVD = [ZILXWA, ILXWAJ, JVHFTH, LXWAJV]
-YNQJYM = [OUYNQJ, UYNQJY]
-ZUQEXL = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    BFEGZU,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -982,234 +19,769 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return NQJYMO
+        return 6
 
     @property
     def output_keys(self):
-        return FIKJPU
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHtr",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "Direct",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, PICXQI, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, PICXQI, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                95,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, PICXQI, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                96,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, PICXQI, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                97,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, PICXQI, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                98,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, None, RAHEOC, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                99,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, PICXQI, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                104,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, PICXQI, None, None, QBMJVH
+            "Out1ACur": GeckoByteStructAccessor(self.struct, "Out1ACur", 108, "ALL"),
+            "Out1BCur": GeckoByteStructAccessor(self.struct, "Out1BCur", 109, "ALL"),
+            "Out2ACur": GeckoByteStructAccessor(self.struct, "Out2ACur", 110, "ALL"),
+            "Out2BCur": GeckoByteStructAccessor(self.struct, "Out2BCur", 111, "ALL"),
+            "Out3ACur": GeckoByteStructAccessor(self.struct, "Out3ACur", 112, "ALL"),
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                100,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, PICXQI, None, None, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                101,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, PICXQI, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                102,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                103,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, FEGZUQ, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                118,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, ZUQEXL, None, None, QBMJVH
+            "Out4ACur": GeckoByteStructAccessor(self.struct, "Out4ACur", 113, "ALL"),
+            "Out5ACur": GeckoByteStructAccessor(self.struct, "Out5ACur", 114, "ALL"),
+            "Out6ACur": GeckoByteStructAccessor(self.struct, "Out6ACur", 115, "ALL"),
+            "Out7ACur": GeckoByteStructAccessor(self.struct, "Out7ACur", 116, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 117, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                105,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, ZUQEXL, None, None, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                106,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, KCWAON, EKCWAO, None, KCWAON, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                107,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, UXFEFJ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 86, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 4, "ALL"
             ),
-            XFEFJT: GeckoBoolStructAccessor(
-                self.struct, XFEFJT, FEFJTA, EFJTAC, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 2, "ALL"
             ),
-            FJTACC: GeckoBoolStructAccessor(
-                self.struct, FJTACC, JTACCP, EFJTAC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 1, 2, ["Shared", "Own"], None, 2, "ALL"
             ),
-            TACCPQ: GeckoBoolStructAccessor(
-                self.struct, TACCPQ, ACCPQI, EFJTAC, QBMJVH
+            "FiberTimeOut": GeckoByteStructAccessor(
+                self.struct, "FiberTimeOut", 3, "ALL"
             ),
-            CCPQIP: GeckoBoolStructAccessor(
-                self.struct, CCPQIP, CPQIPO, PQIPOU, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 63, "ALL"
             ),
-            QIPOUY: GeckoBoolStructAccessor(
-                self.struct, QIPOUY, CPQIPO, IPOUYN, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                27,
+                None,
+                ["StartDurFre", "NotUsed1", "NotUsed2", "PurgeOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, CPQIPO, NQJYMO, YNQJYM, None, KCWAON, QBMJVH
+            "CleanP1": GeckoBoolStructAccessor(self.struct, "CleanP1", 23, 0, "ALL"),
+            "CleanCP": GeckoBoolStructAccessor(self.struct, "CleanCP", 24, 0, "ALL"),
+            "CPAlwaysON": GeckoBoolStructAccessor(
+                self.struct, "CPAlwaysON", 25, 0, "ALL"
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, CPQIPO, OUNBLK, MOUNBL, None, KCWAON, QBMJVH
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 26, 4, "ALL"
             ),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, CPQIPO, EFJTAC, LKXSJW, None, KCWAON, QBMJVH
+            "FiltCPOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltCPOTOption", 26, 5, "ALL"
             ),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 26, 6, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, LGQPLS, None, None, QBMJVH
+            "FiltCPOTLimitOption": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltCPOTLimitOption",
+                26,
+                7,
+                ["AlwaysEnabled", "WithSPOver95F"],
+                None,
+                2,
+                "ALL",
             ),
-            GQPLSP: GeckoBoolStructAccessor(
-                self.struct, GQPLSP, QPLSPF, EFJTAC, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 26, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            PLSPFT: GeckoBoolStructAccessor(
-                self.struct, PLSPFT, LSPFTS, EFJTAC, QBMJVH
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 47, "ALL"
             ),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, YNQJYM, None, None, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 48, "ALL"
             ),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoByteStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, QBMJVH),
-            JMAOAW: GeckoTempStructAccessor(self.struct, JMAOAW, MAOAWB, QBMJVH),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, KCWAON, BSIRYX, None, KCWAON, QBMJVH
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 50, "ALL"
             ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, LGQPLS, None, None, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 51, "ALL"
             ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, FYLJUI, QFYLJU, None, KCWAON, QBMJVH
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 52, "ALL"
             ),
-            YLJUIK: GeckoBoolStructAccessor(
-                self.struct, YLJUIK, LJUIKF, PQIPOU, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 53, "ALL"
             ),
-            JUIKFW: GeckoBoolStructAccessor(
-                self.struct, JUIKFW, LJUIKF, IPOUYN, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 49, "ALL"
             ),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, QBMJVH),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, YXBQFY, KINEJN, RKINEJ, None, KCWAON, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 54, "ALL"
             ),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, YXBQFY, KCWAON, JNIBXY, None, KCWAON, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                119,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, None),
-            YBQSNQ: GeckoByteStructAccessor(self.struct, YBQSNQ, BQSNQL, None),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, QBMJVH),
-            NQLNMH: GeckoByteStructAccessor(self.struct, NQLNMH, QLNMHX, QBMJVH),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoBoolStructAccessor(
-                self.struct, KVKZIL, VKZILX, NQJYMO, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 55, None, ["CP", "P1"], None, None, "ALL"
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, VKZILX, KINEJN, XWAJVD, None, PQIPOU, QBMJVH
+            "O3FollowPump": GeckoBoolStructAccessor(
+                self.struct, "O3FollowPump", 56, 0, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, VKZILX, EFJTAC, VDQLAI, None, KCWAON, QBMJVH
+            "O3DuringFilt": GeckoBoolStructAccessor(
+                self.struct, "O3DuringFilt", 57, 0, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, OAWBSI, FYLJUI, IIDNIB, None, PQIPOU, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 60, "ALL"
             ),
-            IDNIBX: GeckoBoolStructAccessor(
-                self.struct, IDNIBX, OAWBSI, IPOUYN, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                58,
+                None,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            DNIBXT: GeckoBoolStructAccessor(
-                self.struct, DNIBXT, OAWBSI, NQJYMO, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 59, "ALL"
             ),
-            NIBXTI: GeckoBoolStructAccessor(
-                self.struct, NIBXTI, OAWBSI, OUNBLK, QBMJVH
+            "O3TogglePeriod": GeckoByteStructAccessor(
+                self.struct, "O3TogglePeriod", 61, "ALL"
             ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, LJUIKF, KINEJN, JYKLGQ, None, PQIPOU, QBMJVH
+            "SaniLevel": GeckoByteStructAccessor(self.struct, "SaniLevel", 45, "ALL"),
+            "SaniOnTime": GeckoByteStructAccessor(self.struct, "SaniOnTime", 46, "ALL"),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 15, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 13, 2, ["C", "F"], None, 2, "ALL"
             ),
-            BXTIAC: GeckoBoolStructAccessor(
-                self.struct, BXTIAC, LJUIKF, FYLJUI, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 12, None, ["CP", "P1"], None, None, "ALL"
             ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoByteStructAccessor(self.struct, CQFFTT, QFFTTI, QBMJVH),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, QBMJVH),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, QBMJVH),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, BSSUHB, EFJTAC, QBMJVH
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                85,
+                3,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
             ),
-            SSUHBV: GeckoBoolStructAccessor(
-                self.struct, SSUHBV, BSSUHB, KCWAON, QBMJVH
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 14, 4, "ALL"
             ),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoTimeStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoTimeStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoTimeStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoTimeStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoTimeStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, VKZILX, PQIPOU, HTBJEU, None, KCWAON, QBMJVH
+            "OverSetpointEnable": GeckoBoolStructAccessor(
+                self.struct, "OverSetpointEnable", 14, 5, "ALL"
             ),
-            TBJEUT: GeckoBoolStructAccessor(
-                self.struct, TBJEUT, VKZILX, IPOUYN, QBMJVH
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 64, "ALL"
             ),
-            BJEUTO: GeckoBoolStructAccessor(
-                self.struct, BJEUTO, VKZILX, FYLJUI, QBMJVH
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 85, 1, ["60HZ", "50HZ"], None, 2, "ALL"
             ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, UTYEKC, EFJTAC, TOPHUG, None, KCWAON, QBMJVH
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 85, 2, ["240Vac", "230VAC"], None, 2, "ALL"
             ),
-            OPHUGT: GeckoBoolStructAccessor(
-                self.struct, OPHUGT, UTYEKC, KINEJN, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 87, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 88, None
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, YXBQFY, EFJTAC, DAFIKJ, None, KCWAON, QBMJVH
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 89, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 90, "ALL"
             ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, LJUIKF, EFJTAC, QBMJVH
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 91, "ALL"
+            ),
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 92, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 93, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 94, "ALL"
+            ),
+            "CE_2x20Allowed": GeckoBoolStructAccessor(
+                self.struct, "CE_2x20Allowed", 62, 6, "ALL"
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                62,
+                1,
+                ["IgnoreUD", "RestoreAllUD", "NA", "CancelOtherUD"],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                62,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                13,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "FanActiveOnAmbiantOT": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnAmbiantOT", 13, 5, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 13, 6, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 13, 7, "ALL"
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 14, 1, ["NA", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanAsCoolingDevice": GeckoBoolStructAccessor(
+                self.struct, "FanAsCoolingDevice", 14, 3, "ALL"
+            ),
+            "FanSetAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc", 17, "ALL"
+            ),
+            "FanClrAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc", 18, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 19, "ALL"
+            ),
+            "FanSetForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc", 20, "ALL"
+            ),
+            "FanClrForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc", 21, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 22, "ALL"
+            ),
+            "Pump1AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump1AsVSP", 5, 0, "ALL"
+            ),
+            "Pump3AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump3AsVSP", 5, 2, "ALL"
+            ),
+            "VSPCheckfloSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPCheckfloSpeed", 6, "ALL"
+            ),
+            "VSPFilterSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilterSpeed", 7, "ALL"
+            ),
+            "VSPSpeedLevel0": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel0", 8, "ALL"
+            ),
+            "VSPSpeedLevel1": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel1", 9, "ALL"
+            ),
+            "VSPSpeedLevel2": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel2", 10, "ALL"
+            ),
+            "VSPSpeedLevel3": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel3", 11, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 28, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 29, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 31, "ALL"),
+            "OnzenStart": GeckoTimeStructAccessor(self.struct, "OnzenStart", 37, "ALL"),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 39, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 41, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 65, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 67, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                62,
+                4,
+                ["NA", "Available"],
+                None,
+                2,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 62, 5, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 62, 3, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                1,
+                0,
+                ["LastPumpKey", "FreePumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 1, 1, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 85, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "AmbiantOHEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHEnable", 14, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-7.py
+++ b/src/geckolib/driver/packs/inxm-cfg-7.py
@@ -12,941 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 4
-ACQFFT = "".join(
-    chr(c)
-    for c in [70, 97, 110, 83, 101, 116, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-AFIKJP = "".join(chr(c) for c in [65, 109, 80, 109])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-AKQXPI = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-AMJMAO = 44
-AOAWBS = 15
-AONPYY = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ASSAKQ = "".join(chr(c) for c in [70, 98, 76, 105])
-AWBSIR = 13
-BDJQRJ = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 51]
-)
-BFEGZU = "".join(chr(c) for c in [76, 73])
-BIAMJM = 57
-BJEUTO = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-BLKXSJ = 46
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = "".join(chr(c) for c in [78, 111])
-BQNRXC = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-BQSNQL = 86
-BSIRYX = "".join(chr(c) for c in [70])
-BSKSOK = 109
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-BVWVUB = "".join(
-    chr(c)
-    for c in [86, 83, 80, 67, 104, 101, 99, 107, 102, 108, 111, 83, 112, 101, 101, 100]
-)
-BWJYKL = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-BXTIAC = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-BXYBQS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-BYGDSB = 8
-CBFEGZ = 103
-CCPQIP = "".join(chr(c) for c in [67, 112, 79, 116, 79, 112, 116, 105, 111, 110])
-CHWDAF = 81
-CPQIPO = 23
-CQBMJV = 0
-CQFFTT = 17
-CRTFMN = 38
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [70, 105, 98, 101, 114, 84, 105, 109, 101, 79, 117, 116]
-)
-CXQIEF = 94
-DAFIKJ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-DJQRJJ = 11
-DNQGVU = 68
-DQLAII = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-DSBDJQ = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 50]
-)
-DUBSSU = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-EFXQGL = 96
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-EJNIBX = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-EKVKZI = 91
-ELHBQN = 77
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114])
-EUTOPH = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-EXLSXU = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-FCRTFM = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-FEFJTA = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-FFTTID = 18
-FIKJPU = "".join(chr(c) for c in [50, 52, 104])
-FJBIAM = 56
-FMNHTB = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-FWRKIN = 62
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-GDSBDJ = 9
-GLRAHE = 102
-GQPLSP = 54
-GSELHB = 76
-GTYIYW = "".join(chr(c) for c in [75, 54, 48, 48, 70, 111, 114, 77, 97, 121])
-GVUNXN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52])
-GYOUSP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-GZUQEX = 104
-HBQNRX = 78
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114])
-HBVWVU = "".join(chr(c) for c in [80, 117, 109, 112, 51, 65, 115, 86, 83, 80])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 106
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HTBJEU = 65
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-HWDAFI = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-HXEKVK = 90
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        115,
-        67,
-        111,
-        111,
-        108,
-        105,
-        110,
-        103,
-        68,
-        101,
-        118,
-        105,
-        99,
-        101,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [83, 97, 110, 105, 76, 101, 118, 101, 108])
-IBXTIA = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-IDNIBX = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-IDUBSS = 20
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-IFJBIA = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-IGYOUS = 48
-IIDNIB = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-IJUGSE = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-IKFWRK = 5
-ILXWAJ = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-IRYXBQ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114])
-IVLASS = "".join(chr(c) for c in [])
-IYWSKW = "".join(chr(c) for c in [67, 108, 101, 97, 110, 70, 105, 108, 116, 101, 114])
-JBIAMJ = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-JHIUSO = 116
-JIGYOU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-JJJVYF = 28
-JJVYFC = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JMAOAW = 45
-JMCBFE = 115
-JNIBXY = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-JQRJJJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JRJHIU = 101
-JTACCP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-JUGSEL = 75
-JUIKFW = 14
-JUTYEK = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-JVDQLA = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = 30
-JWMNZM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-JYKLGQ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-JYMOUN = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KCWAON = 2
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [53, 48, 72, 90])
-KJPUNR = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 69, 110, 97, 98, 108, 101]
-)
-KMLOIJ = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-KQXPIC = "".join(chr(c) for c in [83, 65, 78, 73])
-KSOKPH = 110
-KVKZIL = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-KWIVDN = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 111, 118, 101, 114])
-KXSJWM = 47
-KZILXW = "".join(
-    chr(c) for c in [67, 69, 95, 50, 120, 50, 48, 65, 108, 108, 111, 119, 101, 100]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 98, 77, 116, 114])
-LGQPLS = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-LHBQNR = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-LIUXFE = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-LJUIKF = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-LKXSJW = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-LNMHXE = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-LOIJUG = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56])
-LRAHEO = "".join(chr(c) for c in [72, 84, 82])
-LSPFTS = 59
-LSXUJU = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-LXWAJV = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-MAOAWB = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-MHXEKV = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-MJIGYO = 52
-MJMAOA = "".join(chr(c) for c in [83, 97, 110, 105, 79, 110, 84, 105, 109, 101])
-MJVHFT = 93
-MLOIJU = 73
-MNHTBJ = 63
-MNZMJI = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MOUNBL = "".join(chr(c) for c in [72, 105])
-NBLKXS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-NEJNIB = 1
-NHTBJE = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-NIBXTI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        84,
-    ]
-)
-NIBXYB = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-NKMLOI = 72
-NMHXEK = 89
-NPYYLI = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-NQGVUN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51])
-NQLNMH = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114])
-NRXCHW = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-NXNKML = 71
-NZMJIG = 51
-OAWBSI = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-OCTHBS = 107
-OIJUGS = 74
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-OKPHUO = 98
-ONPYYL = 61
-OOQNRS = 112
-OPHUGT = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114])
-OUSPBW = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-PFTSIF = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PHUGTY = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-PHUOJR = 99
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PQIPOU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-PYYLIU = 26
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 105
-QFFTTI = "".join(
-    chr(c)
-    for c in [70, 97, 110, 67, 108, 114, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-QFYLJU = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-QGVUNX = 69
-QIEFXQ = 95
-QIPOUY = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QJYMOU = 6
-QLNMHX = 88
-QNRSJM = 113
-QNRXCH = 79
-QRJJJV = 27
-QSNQLN = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-QXPICX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJJJVY = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-RKINEJ = "".join(chr(c) for c in [54, 48, 72, 90])
-RSJMCB = 114
-RTFMNH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RXCHWD = 80
-RYXBQF = 12
-SAKQXP = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-SBDJQR = 10
-SELHBQ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-SIFJBI = 58
-SJMCBF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-SJWMNZ = 49
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114])
-SKWIVD = "".join(chr(c) for c in [67, 104, 97, 110, 103, 101, 87, 97, 116, 101, 114])
-SNQLNM = 87
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114])
-SPBWJY = "".join(chr(c) for c in [80, 49])
-SPFTSI = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-SSAKQX = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SSUHBV = 22
-SUHBVW = "".join(chr(c) for c in [80, 117, 109, 112, 49, 65, 115, 86, 83, 80])
-SXUJUT = 4
-TACCPQ = 25
-TBJEUT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = 40
-THBSKS = 108
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-TOPHUG = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-TSIFJB = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-TTIDUB = 19
-TYEKCW = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-TYIYWS = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49])
-UBSSUH = 21
-UBYGDS = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 48]
-)
-UGSELH = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-UGTYIY = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-UHBVWV = 5
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        79,
-        118,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-UJUTYE = 2
-UNBLKX = 0
-UNXNKM = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53])
-UOJRJH = 100
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-USOOQN = 111
-USPBWJ = 117
-UTOPHU = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-UTYEKC = 1
-UXFEFJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-UYNQJY = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-VDNQGV = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50])
-VDQLAI = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 92
-VLASSA = "".join(chr(c) for c in [70, 65, 78])
-VUBYGD = 7
-VUNXNK = 70
-VWVUBY = 6
-VYFCRT = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(
-    chr(c) for c in [67, 97, 110, 99, 101, 108, 79, 116, 104, 101, 114, 85, 68]
-)
-WAONPY = 3
-WBSIRY = "".join(chr(c) for c in [67])
-WDAFIK = 82
-WIVDNQ = "".join(
-    chr(c) for c in [82, 101, 112, 108, 97, 99, 101, 70, 105, 108, 116, 101, 114]
-)
-WJYKLG = 55
-WMNZMJ = 50
-WRKINE = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-WSKWIV = "".join(chr(c) for c in [67, 104, 101, 99, 107, 71, 70, 67, 73])
-WVUBYG = "".join(
-    chr(c) for c in [86, 83, 80, 70, 105, 108, 116, 101, 114, 83, 112, 101, 101, 100]
-)
-XBQFYL = 83
-XCHWDA = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-XEKVKZ = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-XFEFJT = 24
-XLSXUJ = 84
-XNKMLO = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54])
-XPICXQ = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-XQGLRA = 97
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-XSJWMN = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-XTIACQ = 7
-XUJUTY = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-XWAJVD = "".join(
-    chr(c) for c in [82, 101, 115, 116, 111, 114, 101, 65, 108, 108, 85, 68]
-)
-XYBQSN = 85
-YBQSNQ = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-YEKCWA = "".join(chr(c) for c in [79, 119, 110])
-YFCRTF = 36
-YGDSBD = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 49]
-)
-YIYWSK = 67
-YKLGQP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-YLIUXF = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-YLJUIK = 3
-YMOUNB = "".join(chr(c) for c in [76, 111])
-YNQJYM = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-YOUSPB = 53
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [80, 72])
-YXBQFY = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-YYLIUX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 60
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-AJVDQL = [LXWAJV, XWAJVD, JVHFTH, WAJVDQ]
-DNIBXT = [AIIDNI, IIDNIB, IDNIBX, IVLASS]
-EKCWAO = [TYEKCW, YEKCWA]
-FEGZUQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    BFEGZU,
-]
-FJTACC = [FEFJTA, EFJTAC]
-FTSIFJ = [SPFTSI, PFTSIF]
-FYLJUI = [BQFYLJ, QFYLJU]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-HUGTYI = [OPHUGT, PHUGTY]
-IBXYBQ = [JNIBXY, NIBXYB]
-IKJPUN = [AFIKJP, FIKJPU]
-INEJNI = [RKINEJ, KINEJN]
-IUXFEF = [YYLIUX, YLIUXF, LIUXFE]
-IVDNQG = [IYWSKW, YWSKWI, WSKWIV, SKWIVD, KWIVDN, WIVDNQ]
-JEUTOP = [JVHFTH, BJEUTO]
-JPUNRJ = [
-    BMJVHF,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    QGLRAH,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    MCBFEG,
-    EGZUQE,
-    UQEXLS,
-]
-KLGQPL = [JYKLGQ, YKLGQP]
-NQJYMO = [UYNQJY, YNQJYM]
-OUNBLK = [YMOUNB, MOUNBL]
-PBWJYK = [JVHFTH, SPBWJY, PIPIVL]
-PICXQI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-]
-POUYNQ = [PQIPOU, QIPOUY, IPOUYN]
-PUNRJZ = [BFEGZU]
-QLAIID = [VDQLAI, DQLAII]
-QPLSPF = [PIPIVL, SPBWJY]
-RAHEOC = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    LRAHEO,
-]
-SIRYXB = [WBSIRY, BSIRYX]
-UNRJZT = []
-ZUQEXL = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    BFEGZU,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-    XPICXQ,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -954,224 +19,782 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return XTIACQ
+        return 7
 
     @property
     def output_keys(self):
-        return JPUNRJ
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHtr",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "Direct",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, PICXQI, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, PICXQI, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                93,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, PICXQI, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                94,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, PICXQI, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                95,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, PICXQI, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                96,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, None, RAHEOC, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                97,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, PICXQI, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                102,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, PICXQI, None, None, QBMJVH
+            "Out1ACur": GeckoByteStructAccessor(self.struct, "Out1ACur", 106, "ALL"),
+            "Out1BCur": GeckoByteStructAccessor(self.struct, "Out1BCur", 107, "ALL"),
+            "Out2ACur": GeckoByteStructAccessor(self.struct, "Out2ACur", 108, "ALL"),
+            "Out2BCur": GeckoByteStructAccessor(self.struct, "Out2BCur", 109, "ALL"),
+            "Out3ACur": GeckoByteStructAccessor(self.struct, "Out3ACur", 110, "ALL"),
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                98,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, PICXQI, None, None, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                99,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, PICXQI, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                100,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                101,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, FEGZUQ, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                116,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, ZUQEXL, None, None, QBMJVH
+            "Out4ACur": GeckoByteStructAccessor(self.struct, "Out4ACur", 111, "ALL"),
+            "Out5ACur": GeckoByteStructAccessor(self.struct, "Out5ACur", 112, "ALL"),
+            "Out6ACur": GeckoByteStructAccessor(self.struct, "Out6ACur", 113, "ALL"),
+            "Out7ACur": GeckoByteStructAccessor(self.struct, "Out7ACur", 114, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 115, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                103,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, ZUQEXL, None, None, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                104,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, KCWAON, EKCWAO, None, KCWAON, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                105,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "FAN",
+                    "FbMtr",
+                    "FbLi",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, IUXFEF, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 84, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 4, "ALL"
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, FJTACC, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 2, "ALL"
             ),
-            JTACCP: GeckoBoolStructAccessor(
-                self.struct, JTACCP, TACCPQ, ACCPQI, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 1, 2, ["Shared", "Own"], None, 2, "ALL"
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, POUYNQ, None, None, QBMJVH
+            "FiberTimeOut": GeckoByteStructAccessor(
+                self.struct, "FiberTimeOut", 3, "ALL"
             ),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, TACCPQ, QJYMOU, NQJYMO, None, KCWAON, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 61, "ALL"
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, TACCPQ, UNBLKX, OUNBLK, None, KCWAON, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                26,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, PBWJYK, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                24,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, KLGQPL, None, None, QBMJVH
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 25, 4, "ALL"
             ),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, QPLSPF, None, None, QBMJVH
+            "CpOtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "CpOtOption",
+                23,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, FTSIFJ, None, None, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 25, 6, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, NQJYMO, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 25, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            JBIAMJ: GeckoByteStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoByteStructAccessor(self.struct, MJMAOA, JMAOAW, QBMJVH),
-            MAOAWB: GeckoTempStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, KCWAON, SIRYXB, None, KCWAON, QBMJVH
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 46, "ALL"
             ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, QPLSPF, None, None, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 47, "ALL"
             ),
-            YXBQFY: GeckoEnumStructAccessor(
-                self.struct, YXBQFY, XBQFYL, YLJUIK, FYLJUI, None, KCWAON, QBMJVH
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 49, "ALL"
             ),
-            LJUIKF: GeckoBoolStructAccessor(
-                self.struct, LJUIKF, JUIKFW, ACCPQI, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 50, "ALL"
             ),
-            UIKFWR: GeckoBoolStructAccessor(
-                self.struct, UIKFWR, JUIKFW, IKFWRK, QBMJVH
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 51, "ALL"
             ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, XBQFYL, NEJNIB, INEJNI, None, KCWAON, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 52, "ALL"
             ),
-            EJNIBX: GeckoEnumStructAccessor(
-                self.struct, EJNIBX, XBQFYL, KCWAON, IBXYBQ, None, KCWAON, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 48, "ALL"
             ),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, None),
-            YBQSNQ: GeckoByteStructAccessor(self.struct, YBQSNQ, BQSNQL, None),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, None),
-            NQLNMH: GeckoByteStructAccessor(self.struct, NQLNMH, QLNMHX, QBMJVH),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoByteStructAccessor(self.struct, KVKZIL, VKZILX, QBMJVH),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, ZILXWA, QJYMOU, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 53, "ALL"
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, ZILXWA, NEJNIB, AJVDQL, None, ACCPQI, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                117,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, ZILXWA, UNBLKX, QLAIID, None, KCWAON, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                55,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AWBSIR, YLJUIK, DNIBXT, None, ACCPQI, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 54, None, ["CP", "P1"], None, None, "ALL"
             ),
-            NIBXTI: GeckoBoolStructAccessor(
-                self.struct, NIBXTI, AWBSIR, IKFWRK, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                59,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXTIA: GeckoBoolStructAccessor(
-                self.struct, IBXTIA, AWBSIR, QJYMOU, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 58, "ALL"
             ),
-            BXTIAC: GeckoBoolStructAccessor(
-                self.struct, BXTIAC, AWBSIR, XTIACQ, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                56,
+                None,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, JUIKFW, NEJNIB, PBWJYK, None, ACCPQI, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 57, "ALL"
             ),
-            IACQFF: GeckoBoolStructAccessor(
-                self.struct, IACQFF, JUIKFW, YLJUIK, QBMJVH
+            "SaniLevel": GeckoByteStructAccessor(self.struct, "SaniLevel", 44, "ALL"),
+            "SaniOnTime": GeckoByteStructAccessor(self.struct, "SaniOnTime", 45, "ALL"),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 15, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 13, 2, ["C", "F"], None, 2, "ALL"
             ),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, QBMJVH),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, QBMJVH),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, UHBVWV, UNBLKX, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 12, None, ["CP", "P1"], None, None, "ALL"
             ),
-            HBVWVU: GeckoBoolStructAccessor(
-                self.struct, HBVWVU, UHBVWV, KCWAON, QBMJVH
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                83,
+                3,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
             ),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, QBMJVH),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, QBMJVH),
-            BDJQRJ: GeckoByteStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, QBMJVH),
-            RJJJVY: GeckoTimeStructAccessor(self.struct, RJJJVY, JJJVYF, QBMJVH),
-            JJVYFC: GeckoTimeStructAccessor(self.struct, JJVYFC, JVYFCR, QBMJVH),
-            VYFCRT: GeckoTimeStructAccessor(self.struct, VYFCRT, YFCRTF, QBMJVH),
-            FCRTFM: GeckoTimeStructAccessor(self.struct, FCRTFM, CRTFMN, QBMJVH),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoTimeStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoTimeStructAccessor(self.struct, NHTBJE, HTBJEU, QBMJVH),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, ZILXWA, ACCPQI, JEUTOP, None, KCWAON, QBMJVH
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 14, 4, "ALL"
             ),
-            EUTOPH: GeckoBoolStructAccessor(
-                self.struct, EUTOPH, ZILXWA, IKFWRK, QBMJVH
+            "OverSetpointEnable": GeckoBoolStructAccessor(
+                self.struct, "OverSetpointEnable", 14, 5, "ALL"
             ),
-            UTOPHU: GeckoBoolStructAccessor(
-                self.struct, UTOPHU, ZILXWA, YLJUIK, QBMJVH
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 62, "ALL"
             ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, UTYEKC, UNBLKX, HUGTYI, None, KCWAON, QBMJVH
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 83, 1, ["60HZ", "50HZ"], None, 2, "ALL"
             ),
-            UGTYIY: GeckoBoolStructAccessor(
-                self.struct, UGTYIY, UTYEKC, NEJNIB, QBMJVH
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 83, 2, ["240Vac", "230VAC"], None, 2, "ALL"
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, XBQFYL, UNBLKX, IKJPUN, None, KCWAON, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 85, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 86, None
             ),
-            KJPUNR: GeckoBoolStructAccessor(
-                self.struct, KJPUNR, JUIKFW, UNBLKX, QBMJVH
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 87, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 88, "ALL"
+            ),
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 89, "ALL"
+            ),
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 90, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 91, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 92, "ALL"
+            ),
+            "CE_2x20Allowed": GeckoBoolStructAccessor(
+                self.struct, "CE_2x20Allowed", 60, 6, "ALL"
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                60,
+                1,
+                ["IgnoreUD", "RestoreAllUD", "NA", "CancelOtherUD"],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                60,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                13,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "FanActiveOnAmbiantOT": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnAmbiantOT", 13, 5, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 13, 6, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 13, 7, "ALL"
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 14, 1, ["NA", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanAsCoolingDevice": GeckoBoolStructAccessor(
+                self.struct, "FanAsCoolingDevice", 14, 3, "ALL"
+            ),
+            "FanSetAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc", 17, "ALL"
+            ),
+            "FanClrAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc", 18, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 19, "ALL"
+            ),
+            "FanSetForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc", 20, "ALL"
+            ),
+            "FanClrForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc", 21, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 22, "ALL"
+            ),
+            "Pump1AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump1AsVSP", 5, 0, "ALL"
+            ),
+            "Pump3AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump3AsVSP", 5, 2, "ALL"
+            ),
+            "VSPCheckfloSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPCheckfloSpeed", 6, "ALL"
+            ),
+            "VSPFilterSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilterSpeed", 7, "ALL"
+            ),
+            "VSPSpeedLevel0": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel0", 8, "ALL"
+            ),
+            "VSPSpeedLevel1": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel1", 9, "ALL"
+            ),
+            "VSPSpeedLevel2": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel2", 10, "ALL"
+            ),
+            "VSPSpeedLevel3": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel3", 11, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 27, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 28, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 30, "ALL"),
+            "OnzenStart": GeckoTimeStructAccessor(self.struct, "OnzenStart", 36, "ALL"),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 38, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 40, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 63, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 65, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                60,
+                4,
+                ["NA", "Available"],
+                None,
+                2,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 60, 5, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 60, 3, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                1,
+                0,
+                ["LastPumpKey", "FreePumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 1, 1, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 83, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "AmbiantOHEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHEnable", 14, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-8.py
+++ b/src/geckolib/driver/packs/inxm-cfg-8.py
@@ -12,939 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-ACQFFT = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        68,
-        101,
-        108,
-        97,
-        121,
-        65,
-        102,
-        116,
-        101,
-        114,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-AFIKJP = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114])
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        84,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-AMJMAO = 15
-AOAWBS = "".join(chr(c) for c in [70])
-AONPYY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-ASSAKQ = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-AWBSIR = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-BDJQRJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-BIAMJM = 45
-BJEUTO = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-BLKXSJ = 49
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-BQNRXC = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-BQSNQL = 88
-BSIRYX = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-BSKSOK = 110
-BSSUHB = "".join(chr(c) for c in [80, 117, 109, 112, 51, 65, 115, 86, 83, 80])
-BVWVUB = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 48]
-)
-BXTIAC = "".join(
-    chr(c)
-    for c in [70, 97, 110, 83, 101, 116, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-BXYBQS = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-BYGDSB = 10
-CCPQIP = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-CHWDAF = "".join(chr(c) for c in [65, 109, 80, 109])
-CQBMJV = 0
-CQFFTT = 19
-CRTFMN = 63
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CXQIEF = 95
-DAFIKJ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 69, 110, 97, 98, 108, 101]
-)
-DJQRJJ = 28
-DNIBXT = 7
-DNQGVU = 70
-DQLAII = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-DSBDJQ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-DUBSSU = "".join(chr(c) for c in [80, 117, 109, 112, 49, 65, 115, 86, 83, 80])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 4
-EFXQGL = 97
-EJNIBX = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-EKCWAO = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-EKVKZI = 60
-ELHBQN = 79
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114])
-EUTOPH = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-EXLSXU = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-FCRTFM = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-FEFJTA = 25
-FEGZUQ = 104
-FFTTID = 20
-FJBIAM = 44
-FJTACC = "".join(chr(c) for c in [67, 112, 79, 116, 79, 112, 116, 105, 111, 110])
-FMNHTB = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 56
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        67,
-        108,
-        114,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        79,
-        118,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GDSBDJ = 11
-GQPLSP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-GSELHB = 78
-GTYIYW = "".join(chr(c) for c in [80, 72])
-GVUNXN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54])
-GYOUSP = "".join(chr(c) for c in [80, 49])
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-HBQNRX = 80
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114])
-HBVWVU = 7
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 107
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 111
-HTBJEU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-HUGTYI = 67
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-HWDAFI = "".join(chr(c) for c in [50, 52, 104])
-HXEKVK = 92
-IACQFF = 18
-IAMJMA = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-IBXTIA = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        115,
-        67,
-        111,
-        111,
-        108,
-        105,
-        110,
-        103,
-        68,
-        101,
-        118,
-        105,
-        99,
-        101,
-    ]
-)
-IBXYBQ = 86
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-IDNIBX = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        70,
-        70,
-        79,
-        112,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-IDUBSS = 22
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-IFJBIA = "".join(chr(c) for c in [83, 97, 110, 105, 76, 101, 118, 101, 108])
-IGYOUS = 117
-IIDNIB = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        79,
-        110,
-        80,
-        117,
-        109,
-        112,
-        82,
-        117,
-        110,
-    ]
-)
-IJUGSE = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-IKFWRK = "".join(chr(c) for c in [54, 48, 72, 90])
-INEJNI = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-IRYXBQ = "".join(chr(c) for c in [78, 111])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114])
-IUXFEF = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-IVDNQG = 69
-IVLASS = "".join(chr(c) for c in [])
-IYWSKW = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 111, 118, 101, 114])
-JBIAMJ = "".join(chr(c) for c in [83, 97, 110, 105, 79, 110, 84, 105, 109, 101])
-JEUTOP = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114])
-JIGYOU = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-JJJVYF = 36
-JJVYFC = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-JMAOAW = 13
-JMCBFE = 103
-JNIBXY = 85
-JPUNRJ = 8
-JQRJJJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JRJHIU = 116
-JTACCP = 23
-JUGSEL = 77
-JUIKFW = 62
-JUTYEK = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JVDQLA = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = 38
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-JYKLGQ = 54
-JYMOUN = 0
-KCWAON = 61
-KFWRKI = "".join(chr(c) for c in [53, 48, 72, 90])
-KINEJN = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-KLGQPL = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-KMLOIJ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-KQXPIC = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-KSOKPH = 98
-KVKZIL = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-KWIVDN = 68
-KXSJWM = 50
-KZILXW = "".join(
-    chr(c) for c in [82, 101, 115, 116, 111, 114, 101, 65, 108, 108, 85, 68]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 59
-LHBQNR = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-LIUXFE = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-LKXSJW = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-LNMHXE = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-LOIJUG = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-LSXUJU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-LXWAJV = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = "".join(chr(c) for c in [76, 73])
-MHXEKV = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-MJIGYO = 53
-MJMAOA = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-MJVHFT = 93
-MLOIJU = 75
-MNHTBJ = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-MOUNBL = 46
-NBLKXS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-NIBXTI = "".join(chr(c) for c in [70, 97, 110, 80, 117, 109, 112])
-NIBXYB = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-NKMLOI = 74
-NMHXEK = 91
-NPYYLI = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-NQGVUN = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53])
-NQJYMO = "".join(chr(c) for c in [72, 105])
-NQLNMH = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-NRSJMC = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-NRXCHW = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-NXNKML = 73
-NZMJIG = 48
-OCTHBS = 108
-OIJUGS = 76
-OJRJHI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-OKPHUO = 99
-ONPYYL = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-OOQNRS = 113
-OPHUGT = "".join(chr(c) for c in [75, 54, 48, 48, 70, 111, 114, 77, 97, 121])
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114])
-OUNBLK = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-OUSPBW = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-OUYNQJ = 6
-PBWJYK = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-PFTSIF = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-PHUGTY = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49])
-PHUOJR = 100
-PICXQI = 94
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PQIPOU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 84
-QFFTTI = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        83,
-        101,
-        116,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        84,
-        101,
-        109,
-        112,
-        65,
-        100,
-        99,
-    ]
-)
-QFYLJU = 14
-QGLRAH = "".join(chr(c) for c in [72, 84, 82])
-QGVUNX = 71
-QIEFXQ = 96
-QIPOUY = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-QLAIID = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-QLNMHX = 90
-QNRSJM = 114
-QNRXCH = 81
-QPLSPF = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-QRJJJV = 30
-QSNQLN = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-RAHEOC = 106
-RJJJVY = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-RKINEJ = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-RSJMCB = 115
-RTFMNH = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-RXCHWD = 82
-RYXBQF = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-SAKQXP = "".join(chr(c) for c in [83, 65, 78, 73])
-SBDJQR = 27
-SELHBQ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-SIFJBI = 57
-SIRYXB = 83
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-SJWMNZ = 51
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-SKWIVD = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50])
-SNQLNM = 89
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114])
-SPBWJY = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-SPFTSI = 58
-SSAKQX = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-SSUHBV = "".join(
-    chr(c)
-    for c in [86, 83, 80, 67, 104, 101, 99, 107, 102, 108, 111, 83, 112, 101, 101, 100]
-)
-SUHBVW = 6
-SXUJUT = 2
-TACCPQ = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TBJEUT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-TFMNHT = 65
-THBSKS = 109
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(
-    chr(c)
-    for c in [70, 97, 110, 67, 108, 114, 65, 79, 84, 84, 101, 109, 112, 65, 100, 99]
-)
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        70,
-        97,
-        110,
-        70,
-        111,
-        114,
-        99,
-        101,
-        79,
-        102,
-        102,
-        73,
-        110,
-        104,
-        105,
-        98,
-        105,
-        116,
-        68,
-        101,
-        108,
-        97,
-        121,
-    ]
-)
-TOPHUG = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TSIFJB = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-TTIDUB = 21
-TYIYWS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 71, 70, 67, 73])
-UBSSUH = 5
-UBYGDS = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 50]
-)
-UGSELH = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-UGTYIY = "".join(chr(c) for c in [67, 108, 101, 97, 110, 70, 105, 108, 116, 101, 114])
-UHBVWV = "".join(
-    chr(c) for c in [86, 83, 80, 70, 105, 108, 116, 101, 114, 83, 112, 101, 101, 100]
-)
-UIKFWR = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-UJUTYE = 1
-UNBLKX = 47
-UNXNKM = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55])
-UOJRJH = 101
-UQEXLS = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-USOOQN = 112
-USPBWJ = 55
-UTYEKC = "".join(chr(c) for c in [79, 119, 110])
-UYNQJY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-VDNQGV = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52])
-VDQLAI = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-VLASSA = "".join(chr(c) for c in [70, 65, 78])
-VUBYGD = 9
-VUNXNK = 72
-VWVUBY = 8
-VYFCRT = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-WAONPY = 26
-WBSIRY = 12
-WIVDNQ = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51])
-WJYKLG = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-WMNZMJ = 52
-WRKINE = 1
-WVUBYG = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 49]
-)
-XBQFYL = 3
-XCHWDA = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XEKVKZ = "".join(
-    chr(c) for c in [67, 69, 95, 50, 120, 50, 48, 65, 108, 108, 111, 119, 101, 100]
-)
-XFEFJT = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-XLSXUJ = 4
-XNKMLO = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-XQGLRA = 102
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-XSJWMN = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-XTIACQ = 17
-XUJUTY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-XWAJVD = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-XYBQSN = 87
-YBQSNQ = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-YEKCWA = 2
-YFCRTF = 40
-YGDSBD = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 51]
-)
-YIYWSK = "".join(chr(c) for c in [67, 104, 97, 110, 103, 101, 87, 97, 116, 101, 114])
-YLIUXF = 24
-YLJUIK = 5
-YMOUNB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-YNQJYM = "".join(chr(c) for c in [76, 111])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [82, 101, 112, 108, 97, 99, 101, 70, 105, 108, 116, 101, 114]
-)
-YYLIUX = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(
-    chr(c) for c in [67, 97, 110, 99, 101, 108, 79, 116, 104, 101, 114, 85, 68]
-)
-ZMJIGY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ZUQEXL = 105
-AJVDQL = [XWAJVD, WAJVDQ]
-BWJYKL = [SPBWJY, PBWJYK]
-CBFEGZ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    MCBFEG,
-]
-CPQIPO = [TACCPQ, ACCPQI, CCPQIP]
-EGZUQE = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    MCBFEG,
-    VLASSA,
-    IVLASS,
-    IVLASS,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-FIKJPU = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    SJMCBF,
-    BFEGZU,
-    GZUQEX,
-]
-FWRKIN = [IKFWRK, KFWRKI]
-GLRAHE = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    QGLRAH,
-]
-IKJPUN = [MCBFEG]
-ILXWAJ = [VKZILX, KZILXW, JVHFTH, ZILXWA]
-KJPUNR = []
-LAIIDN = [VDQLAI, DQLAII, QLAIID, IVLASS]
-NEJNIB = [KINEJN, INEJNI]
-NHTBJE = [JVHFTH, MNHTBJ]
-OAWBSI = [MAOAWB, AOAWBS]
-PLSPFT = [GQPLSP, QPLSPF]
-POUYNQ = [QIPOUY, IPOUYN]
-PYYLIU = [AONPYY, ONPYYL, NPYYLI]
-QJYMOU = [YNQJYM, NQJYMO]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-    IVLASS,
-    IVLASS,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-RJHIUS = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-TYEKCW = [JUTYEK, UTYEKC]
-UTOPHU = [JEUTOP, EUTOPH]
-UXFEFJ = [LIUXFE, IUXFEF]
-WDAFIK = [CHWDAF, HWDAFI]
-WSKWIV = [UGTYIY, GTYIYW, TYIYWS, YIYWSK, IYWSKW, YWSKWI]
-YKLGQP = [PIPIVL, GYOUSP]
-YOUSPB = [JVHFTH, GYOUSP, PIPIVL]
-YXBQFY = [IRYXBQ, RYXBQF]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -952,226 +19,782 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JPUNRJ
+        return 8
 
     @property
     def output_keys(self):
-        return FIKJPU
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHtr",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "Direct",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                93,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                94,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                95,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                96,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, GLRAHE, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                97,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, QXPICX, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                102,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, QXPICX, None, None, QBMJVH
+            "Out1ACur": GeckoByteStructAccessor(self.struct, "Out1ACur", 106, "ALL"),
+            "Out1BCur": GeckoByteStructAccessor(self.struct, "Out1BCur", 107, "ALL"),
+            "Out2ACur": GeckoByteStructAccessor(self.struct, "Out2ACur", 108, "ALL"),
+            "Out2BCur": GeckoByteStructAccessor(self.struct, "Out2BCur", 109, "ALL"),
+            "Out3ACur": GeckoByteStructAccessor(self.struct, "Out3ACur", 110, "ALL"),
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                98,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, QXPICX, None, None, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                99,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, QXPICX, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                100,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, RJHIUS, None, None, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                101,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, QBMJVH),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, QBMJVH),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, CBFEGZ, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                116,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, EGZUQE, None, None, QBMJVH
+            "Out4ACur": GeckoByteStructAccessor(self.struct, "Out4ACur", 111, "ALL"),
+            "Out5ACur": GeckoByteStructAccessor(self.struct, "Out5ACur", 112, "ALL"),
+            "Out6ACur": GeckoByteStructAccessor(self.struct, "Out6ACur", 113, "ALL"),
+            "Out7ACur": GeckoByteStructAccessor(self.struct, "Out7ACur", 114, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 115, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                103,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, EGZUQE, None, None, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                104,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, YEKCWA, TYEKCW, None, YEKCWA, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                105,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "FAN",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, PYYLIU, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 84, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 4, "ALL"
             ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, None, UXFEFJ, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 2, "ALL"
             ),
-            XFEFJT: GeckoBoolStructAccessor(
-                self.struct, XFEFJT, FEFJTA, EFJTAC, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 1, 2, ["Shared", "Own"], None, 2, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CPQIPO, None, None, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 61, "ALL"
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, FEFJTA, OUYNQJ, POUYNQ, None, YEKCWA, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                26,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, FEFJTA, JYMOUN, QJYMOU, None, YEKCWA, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                24,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoByteStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, YOUSPB, None, None, QBMJVH
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 25, 4, "ALL"
             ),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, BWJYKL, None, None, QBMJVH
+            "CpOtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "CpOtOption",
+                23,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            WJYKLG: GeckoEnumStructAccessor(
-                self.struct, WJYKLG, JYKLGQ, None, YKLGQP, None, None, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 25, 6, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            KLGQPL: GeckoEnumStructAccessor(
-                self.struct, KLGQPL, LGQPLS, None, PLSPFT, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 25, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, POUYNQ, None, None, QBMJVH
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 46, "ALL"
             ),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoByteStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoTempStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, YEKCWA, OAWBSI, None, YEKCWA, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 47, "ALL"
             ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, YKLGQP, None, None, QBMJVH
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 49, "ALL"
             ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, XBQFYL, YXBQFY, None, YEKCWA, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 50, "ALL"
             ),
-            BQFYLJ: GeckoBoolStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, EFJTAC, QBMJVH
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 51, "ALL"
             ),
-            FYLJUI: GeckoBoolStructAccessor(
-                self.struct, FYLJUI, QFYLJU, YLJUIK, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 52, "ALL"
             ),
-            LJUIKF: GeckoByteStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, SIRYXB, WRKINE, FWRKIN, None, YEKCWA, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 48, "ALL"
             ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, SIRYXB, YEKCWA, NEJNIB, None, YEKCWA, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 53, "ALL"
             ),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, None),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, None),
-            YBQSNQ: GeckoByteStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, QBMJVH),
-            NQLNMH: GeckoByteStructAccessor(self.struct, NQLNMH, QLNMHX, QBMJVH),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, OUYNQJ, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                117,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, EKVKZI, WRKINE, ILXWAJ, None, EFJTAC, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                55,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, EKVKZI, JYMOUN, AJVDQL, None, YEKCWA, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 54, None, ["CP", "P1"], None, None, "ALL"
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, JMAOAW, XBQFYL, LAIIDN, None, EFJTAC, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                59,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            AIIDNI: GeckoBoolStructAccessor(
-                self.struct, AIIDNI, JMAOAW, YLJUIK, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 58, "ALL"
             ),
-            IIDNIB: GeckoBoolStructAccessor(
-                self.struct, IIDNIB, JMAOAW, OUYNQJ, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                56,
+                None,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            IDNIBX: GeckoBoolStructAccessor(
-                self.struct, IDNIBX, JMAOAW, DNIBXT, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 57, "ALL"
             ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, QFYLJU, WRKINE, YOUSPB, None, EFJTAC, QBMJVH
+            "SaniLevel": GeckoByteStructAccessor(self.struct, "SaniLevel", 44, "ALL"),
+            "SaniOnTime": GeckoByteStructAccessor(self.struct, "SaniOnTime", 45, "ALL"),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 15, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 13, 2, ["C", "F"], None, 2, "ALL"
             ),
-            IBXTIA: GeckoBoolStructAccessor(
-                self.struct, IBXTIA, QFYLJU, XBQFYL, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 12, None, ["CP", "P1"], None, None, "ALL"
             ),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, QBMJVH),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, QBMJVH),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, QBMJVH),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, QBMJVH),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoBoolStructAccessor(
-                self.struct, DUBSSU, UBSSUH, JYMOUN, QBMJVH
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                83,
+                3,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
             ),
-            BSSUHB: GeckoBoolStructAccessor(
-                self.struct, BSSUHB, UBSSUH, YEKCWA, QBMJVH
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 14, 4, "ALL"
             ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, QBMJVH),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, QBMJVH),
-            BDJQRJ: GeckoTimeStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoTimeStructAccessor(self.struct, JQRJJJ, QRJJJV, QBMJVH),
-            RJJJVY: GeckoTimeStructAccessor(self.struct, RJJJVY, JJJVYF, QBMJVH),
-            JJVYFC: GeckoTimeStructAccessor(self.struct, JJVYFC, JVYFCR, QBMJVH),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, QBMJVH),
-            FCRTFM: GeckoTimeStructAccessor(self.struct, FCRTFM, CRTFMN, QBMJVH),
-            RTFMNH: GeckoTimeStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, EKVKZI, EFJTAC, NHTBJE, None, YEKCWA, QBMJVH
+            "OverSetpointEnable": GeckoBoolStructAccessor(
+                self.struct, "OverSetpointEnable", 14, 5, "ALL"
             ),
-            HTBJEU: GeckoBoolStructAccessor(
-                self.struct, HTBJEU, EKVKZI, YLJUIK, QBMJVH
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 62, "ALL"
             ),
-            TBJEUT: GeckoBoolStructAccessor(
-                self.struct, TBJEUT, EKVKZI, XBQFYL, QBMJVH
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 83, 1, ["60HZ", "50HZ"], None, 2, "ALL"
             ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, UJUTYE, JYMOUN, UTOPHU, None, YEKCWA, QBMJVH
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 83, 2, ["240Vac", "230VAC"], None, 2, "ALL"
             ),
-            TOPHUG: GeckoBoolStructAccessor(
-                self.struct, TOPHUG, UJUTYE, WRKINE, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 85, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 86, None
             ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, SIRYXB, JYMOUN, WDAFIK, None, YEKCWA, QBMJVH
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 87, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 88, "ALL"
             ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, QFYLJU, JYMOUN, QBMJVH
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 89, "ALL"
             ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, FEFJTA, WRKINE, QBMJVH
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 90, "ALL"
+            ),
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 91, "ALL"
+            ),
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 92, "ALL"
+            ),
+            "CE_2x20Allowed": GeckoBoolStructAccessor(
+                self.struct, "CE_2x20Allowed", 60, 6, "ALL"
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                60,
+                1,
+                ["IgnoreUD", "RestoreAllUD", "NA", "CancelOtherUD"],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                60,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                13,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "FanActiveOnAmbiantOT": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnAmbiantOT", 13, 5, "ALL"
+            ),
+            "FanActiveOnPumpRun": GeckoBoolStructAccessor(
+                self.struct, "FanActiveOnPumpRun", 13, 6, "ALL"
+            ),
+            "FanForceOFFOption": GeckoBoolStructAccessor(
+                self.struct, "FanForceOFFOption", 13, 7, "ALL"
+            ),
+            "FanPump": GeckoEnumStructAccessor(
+                self.struct, "FanPump", 14, 1, ["NA", "P1", "CP"], None, 4, "ALL"
+            ),
+            "FanAsCoolingDevice": GeckoBoolStructAccessor(
+                self.struct, "FanAsCoolingDevice", 14, 3, "ALL"
+            ),
+            "FanSetAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetAOTTempAdc", 17, "ALL"
+            ),
+            "FanClrAOTTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrAOTTempAdc", 18, "ALL"
+            ),
+            "FanActiveDelayAfterPumpRun": GeckoByteStructAccessor(
+                self.struct, "FanActiveDelayAfterPumpRun", 19, "ALL"
+            ),
+            "FanSetForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanSetForceOffTempAdc", 20, "ALL"
+            ),
+            "FanClrForceOffTempAdc": GeckoByteStructAccessor(
+                self.struct, "FanClrForceOffTempAdc", 21, "ALL"
+            ),
+            "FanForceOffInhibitDelay": GeckoByteStructAccessor(
+                self.struct, "FanForceOffInhibitDelay", 22, "ALL"
+            ),
+            "Pump1AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump1AsVSP", 5, 0, "ALL"
+            ),
+            "Pump3AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump3AsVSP", 5, 2, "ALL"
+            ),
+            "VSPCheckfloSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPCheckfloSpeed", 6, "ALL"
+            ),
+            "VSPFilterSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilterSpeed", 7, "ALL"
+            ),
+            "VSPSpeedLevel0": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel0", 8, "ALL"
+            ),
+            "VSPSpeedLevel1": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel1", 9, "ALL"
+            ),
+            "VSPSpeedLevel2": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel2", 10, "ALL"
+            ),
+            "VSPSpeedLevel3": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel3", 11, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 27, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 28, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 30, "ALL"),
+            "OnzenStart": GeckoTimeStructAccessor(self.struct, "OnzenStart", 36, "ALL"),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 38, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 40, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 63, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 65, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                60,
+                4,
+                ["NA", "Available"],
+                None,
+                2,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 60, 5, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 60, 3, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                1,
+                0,
+                ["LastPumpKey", "FreePumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 1, 1, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 83, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "AmbiantOHEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHEnable", 14, 0, "ALL"
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 25, 1, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxm-cfg-9.py
+++ b/src/geckolib/driver/packs/inxm-cfg-9.py
@@ -12,988 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-ACMCVD = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-ACQFFT = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 50]
-)
-AFIKJP = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-AHEOCT = 107
-AIIDNI = 5
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        101,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-        79,
-        110,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [86, 65, 76, 86, 69])
-AKSTSE = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AONPYY = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-ASSAKQ = "".join(chr(c) for c in [83, 112, 76, 105, 102, 116])
-ATDZXN = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-AWBSIR = 12
-BDJQRJ = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-BFEGZU = 104
-BHZVOA = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 69
-BLKXSJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 67, 80, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49, 65])
-BQFYLJ = 14
-BQNRXC = "".join(chr(c) for c in [82, 69, 68])
-BQSNQL = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 50])
-BSIRYX = 83
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 52, 65])
-BSSUHB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-BVWVUB = 40
-BWJYKL = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-BXIBHZ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-BXTIAC = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 48]
-)
-BXYBQS = 87
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 73, 79, 50])
-CGETIX = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-CHWDAF = "".join(chr(c) for c in [67, 89, 65, 78])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121]
-)
-CQBMJV = 0
-CQFFTT = 10
-CRTFMN = "".join(chr(c) for c in [67, 104, 101, 99, 107, 71, 70, 67, 73])
-CTHBSK = 109
-CVDSSR = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 26
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 50, 66])
-DAFIKJ = 8
-DGKEAK = "".join(chr(c) for c in [77, 65, 65, 88])
-DJQRJJ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-DNIBXT = 6
-DNQGVU = 79
-DQLAII = "".join(chr(c) for c in [75, 101, 101, 112, 79, 102, 102])
-DSBDJQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-DUBSSU = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-DZXNQT = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-EAKSTS = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [67, 112, 79, 116, 79, 112, 116, 105, 111, 110])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 73, 79, 52])
-EJNIBX = 85
-EKCWAO = 61
-EKVKZI = "".join(
-    chr(c)
-    for c in [85, 68, 65, 99, 116, 105, 111, 110, 79, 110, 81, 117, 105, 101, 116]
-)
-EMCGET = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-EOCTHB = 108
-ETIXQV = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-EUTOPH = 70
-EXLSXU = 4
-FCRTFM = "".join(chr(c) for c in [80, 72])
-FEFJTA = 4
-FFTTID = 11
-FIKJPU = 119
-FJBIAM = "".join(chr(c) for c in [83, 97, 110, 105, 79, 110, 84, 105, 109, 101])
-FJTACC = 23
-FMNHTB = "".join(
-    chr(c) for c in [82, 101, 112, 108, 97, 99, 101, 70, 105, 108, 116, 101, 114]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(
-    chr(c) for c in [79, 51, 70, 105, 108, 116, 101, 114, 68, 101, 108, 97, 121]
-)
-FTTIDU = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-FWRKIN = 1
-FXQGLR = 102
-FYLJUI = 5
-FZDGKE = "".join(chr(c) for c in [76, 65])
-GETIXQ = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-GKEAKS = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 65, 67, 117, 114])
-GQPLSP = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-GSELHB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-GTYIYW = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56])
-GVUNXN = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55, 78, 98, 87, 101, 101, 107]
-)
-GZUQEX = 105
-HBQNRX = "".join(chr(c) for c in [79, 70, 70])
-HBSKSO = 110
-HBVWVU = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-HBXIBH = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 50, 65, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [79, 117, 116, 53, 65, 67, 117, 114])
-HTBJEU = 68
-HUGTYI = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 55])
-HUOJRJ = 101
-HWDAFI = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-HXEKVK = "".join(
-    chr(c) for c in [67, 69, 95, 50, 120, 50, 48, 65, 108, 108, 111, 119, 101, 100]
-)
-HZVOAC = 120
-IACQFF = 9
-IAMJMA = 15
-IBHZVO = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-IBXTIA = 7
-IBXYBQ = "".join(chr(c) for c in [66, 114, 83, 101, 116, 73, 110, 100, 101, 120])
-ICXQIE = 95
-IDNIBX = "".join(
-    chr(c)
-    for c in [86, 83, 80, 67, 104, 101, 99, 107, 102, 108, 111, 83, 112, 101, 101, 100]
-)
-IDUBSS = 28
-IEFXQG = 97
-IFJBIA = 44
-IGYOUS = "".join(chr(c) for c in [80, 49])
-IHBXIB = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-IIDNIB = "".join(chr(c) for c in [80, 117, 109, 112, 51, 65, 115, 86, 83, 80])
-IJUGSE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-IKFWRK = "".join(chr(c) for c in [53, 48, 72, 90])
-IKJPUN = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-ILXWAJ = "".join(
-    chr(c)
-    for c in [81, 117, 105, 101, 116, 65, 99, 116, 105, 111, 110, 79, 110, 85, 68]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IRYXBQ = "".join(
-    chr(c) for c in [70, 117, 108, 108, 80, 111, 119, 101, 114, 79, 110, 108, 121]
-)
-IUSOOQ = 112
-IVDNQG = 78
-IVLASS = "".join(chr(c) for c in [])
-IXQVXO = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-IYWSKW = 75
-JBIAMJ = 45
-JEUTOP = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52])
-JHIUSO = 111
-JIGYOU = 117
-JJJVYF = "".join(chr(c) for c in [75, 54, 48, 48, 70, 111, 114, 77, 97, 121])
-JJVYFC = 7
-JMAOAW = "".join(chr(c) for c in [67])
-JMCBFE = "".join(chr(c) for c in [76, 73])
-JNIBXY = "".join(
-    chr(c) for c in [66, 114, 78, 98, 83, 101, 116, 116, 105, 110, 103, 115]
-)
-JPUNRJ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-JQRJJJ = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-JTACCP = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-JUGSEL = 118
-JUIKFW = "".join(
-    chr(c) for c in [76, 105, 110, 101, 70, 114, 101, 113, 117, 101, 110, 99, 121]
-)
-JUTYEK = "".join(chr(c) for c in [79, 119, 110])
-JVDQLA = "".join(chr(c) for c in [78, 111, 65, 99, 116, 105, 111, 110])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49])
-JWMNZM = 52
-JYMOUN = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-JZTATD = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-KCWAON = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-KEAKST = "".join(chr(c) for c in [80, 68, 67])
-KINEJN = "".join(chr(c) for c in [50, 51, 48, 86, 65, 67])
-KJPUNR = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-KLGQPL = 59
-KMLOIJ = "".join(chr(c) for c in [50, 52, 104])
-KPHUOJ = 100
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 53, 65])
-KSTSEM = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-KVKZIL = "".join(chr(c) for c in [73, 103, 110, 111, 114, 101, 85, 68])
-KWIVDN = 77
-KXSJWM = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-KZILXW = "".join(
-    chr(c) for c in [67, 97, 110, 99, 101, 108, 79, 116, 104, 101, 114, 85, 68]
-)
-LAIIDN = "".join(chr(c) for c in [80, 117, 109, 112, 49, 65, 115, 86, 83, 80])
-LASSAK = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-LGQPLS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-LHBQNR = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-LIUXFE = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-LJUIKF = 62
-LKXSJW = 50
-LNMHXE = 91
-LOIJUG = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 69, 110, 97, 98, 108, 101]
-)
-LRAHEO = 106
-LSPFTS = 58
-LSXUJU = 2
-LXWAJV = "".join(chr(c) for c in [67, 97, 110, 99, 101, 108])
-MAOAWB = "".join(chr(c) for c in [70])
-MCGETI = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-MCVDSS = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-MFZDGK = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-MHXEKV = 92
-MJIGYO = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-MJMAOA = 13
-MJVHFT = 93
-MNZMJI = 48
-MOUNBL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 68, 101, 97, 100, 98, 97, 110, 100]
-)
-NBLKXS = 49
-NEJNIB = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-NHTBJE = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50])
-NIBXTI = "".join(
-    chr(c) for c in [86, 83, 80, 70, 105, 108, 116, 101, 114, 83, 112, 101, 101, 100]
-)
-NIBXYB = 86
-NKMLOI = "".join(chr(c) for c in [65, 109, 80, 109])
-NMHXEK = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 53])
-NQGVUN = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54, 78, 98, 87, 101, 101, 107]
-)
-NQLNMH = 90
-NQTMFZ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-NRJZTA = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-NRSJMC = 115
-NRXCHW = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-NXNKML = 82
-NZMJIG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-OACMCV = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 50, 66, 67, 117, 114])
-OIJUGS = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-OJRJHI = 116
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 54, 65])
-ONPYYL = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OOQNRS = "".join(chr(c) for c in [79, 117, 116, 55, 65, 67, 117, 114])
-OPHUGT = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 54])
-OQNRSJ = 114
-OUNBLK = 47
-OUSPBW = 55
-OUYNQJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-PFTSIF = 56
-PHUGTY = 72
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 55, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50, 65])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-POUYNQ = 6
-PQIPOU = "".join(chr(c) for c in [65, 110, 121, 85, 68])
-PUNRJZ = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-PYYLIU = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-QFFTTI = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 51]
-)
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        79,
-        118,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QGVUNX = 80
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 51, 65])
-QIPOUY = "".join(chr(c) for c in [80, 117, 109, 112, 85, 68])
-QJYMOU = 0
-QLNMHX = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 52])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-QNRXCH = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-QSNQLN = 89
-QTMFZD = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-QVXOIH = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 49, 66])
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 49, 66, 67, 117, 114])
-RJHIUS = "".join(chr(c) for c in [79, 117, 116, 52, 65, 67, 117, 114])
-RJJJVY = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-RJZTAT = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-RKINEJ = "".join(chr(c) for c in [50, 52, 48, 86, 97, 99])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-RTFMNH = "".join(chr(c) for c in [67, 104, 97, 110, 103, 101, 87, 97, 116, 101, 114])
-RXCHWD = "".join(chr(c) for c in [66, 76, 85, 69])
-SAKQXP = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-SELHBQ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-SEMCGE = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-SIFJBI = "".join(chr(c) for c in [83, 97, 110, 105, 76, 101, 118, 101, 108])
-SIRYXB = "".join(chr(c) for c in [78, 111])
-SJMCBF = 103
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SKSOKP = 98
-SKWIVD = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51, 78, 98, 87, 101, 101, 107]
-)
-SNQLNM = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 51])
-SOKPHU = 99
-SOOQNR = 113
-SPBWJY = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-SPFTSI = "".join(chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 66, 121])
-SRURAZ = 9
-SSAKQX = "".join(chr(c) for c in [83, 65, 78, 73])
-SSUHBV = 36
-STSEMC = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-SUHBVW = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-SXUJUT = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-TACCPQ = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-TATDZX = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-TBJEUT = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 51])
-TDZXNQ = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-TFMNHT = "".join(chr(c) for c in [67, 108, 101, 97, 110, 67, 111, 118, 101, 114])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 51, 65, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(
-    chr(c) for c in [86, 83, 80, 83, 112, 101, 101, 100, 76, 101, 118, 101, 108, 49]
-)
-TIDUBS = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-TIXQVX = "".join(chr(c) for c in [73, 100, 111, 108])
-TMFZDG = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-TOPHUG = 71
-TSEMCG = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-TSIFJB = 57
-TTIDUB = 27
-TYEKCW = 2
-TYIYWS = 74
-UBSSUH = 30
-UBYGDS = 65
-UGSELH = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-UGTYIY = 73
-UHBVWV = 38
-UIKFWR = "".join(chr(c) for c in [54, 48, 72, 90])
-UJUTYE = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UNBLKX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 67, 80, 79, 84, 65, 99, 116, 84, 101, 109, 112]
-)
-UNRJZT = "".join(chr(c) for c in [65, 108, 112, 115])
-UNXNKM = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 56, 78, 98, 87, 101, 101, 107]
-)
-UOJRJH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-UQEXLS = 84
-USOOQN = "".join(chr(c) for c in [79, 117, 116, 54, 65, 67, 117, 114])
-USPBWJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UTOPHU = "".join(chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53])
-UXFEFJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 79, 84, 79, 112, 116, 105, 111, 110]
-)
-UYNQJY = "".join(chr(c) for c in [76, 111])
-VDNQGV = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 53, 78, 98, 87, 101, 101, 107]
-)
-VDQLAI = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 77, 97, 120, 80, 111, 119, 101, 114]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [82, 101, 115, 116, 111, 114, 101, 65, 108, 108, 85, 68]
-)
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VOACMC = 121
-VUBYGD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 111, 112])
-VUNXNK = 81
-VWVUBY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-VXOIHB = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-VYFCRT = 67
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-WBSIRY = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 82, 101, 115, 116, 114, 105, 99, 116, 105, 111, 110]
-)
-WIVDNQ = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 52, 78, 98, 87, 101, 101, 107]
-)
-WJYKLG = 54
-WMNZMJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WRKINE = "".join(chr(c) for c in [76, 105, 110, 101, 86, 111, 108, 116, 97, 103, 101])
-WSKWIV = 76
-WVUBYG = 63
-XBQFYL = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 69, 110, 97, 98, 108, 101]
-)
-XCHWDA = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-XEKVKZ = 60
-XFEFJT = 25
-XLSXUJ = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-XNKMLO = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XNQTMF = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-XOIHBX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-XPICXQ = 94
-XQGLRA = "".join(chr(c) for c in [72, 84, 82])
-XQIEFX = 96
-XQVXOI = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-XSJWMN = 51
-XTIACQ = 8
-XUJUTY = 1
-XWAJVD = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-XYBQSN = "".join(chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 116, 49])
-YBQSNQ = 88
-YEKCWA = "".join(
-    chr(c) for c in [81, 117, 105, 101, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YFCRTF = "".join(chr(c) for c in [67, 108, 101, 97, 110, 70, 105, 108, 116, 101, 114])
-YGDSBD = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-YIYWSK = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 49, 78, 98, 87, 101, 101, 107]
-)
-YKLGQP = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-YLIUXF = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        66,
-        101,
-        108,
-        111,
-        119,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-    ]
-)
-YMOUNB = 46
-YNQJYM = "".join(chr(c) for c in [72, 105])
-YOUSPB = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [75, 54, 48, 48, 77, 115, 103, 50, 78, 98, 87, 101, 101, 107]
-)
-YXBQFY = 3
-YYLIUX = 24
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-ZMJIGY = 53
-ZTATDZ = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-ZUQEXL = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-ZVOACM = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-ZXNQTM = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-AOAWBS = [JMAOAW, MAOAWB]
-CCPQIP = [JTACCP, TACCPQ, ACCPQI]
-CMCVDS = [OACMCV, ACMCVD, IVLASS, IVLASS]
-DSSRUR = [JMCBFE]
-ELHBQN = [GSELHB, SELHBQ]
-FEGZUQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    JMCBFE,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-]
-GDSBDJ = [JVHFTH, YGDSBD]
-GYOUSP = [JVHFTH, IGYOUS, PIPIVL]
-INEJNI = [RKINEJ, KINEJN]
-IPOUYN = [PQIPOU, QIPOUY]
-IUXFEF = [YLIUXF, LIUXFE]
-JRJHIU = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-JYKLGQ = [PIPIVL, IGYOUS]
-KFWRKI = [UIKFWR, IKFWRK]
-KQXPIC = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-]
-MCBFEG = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    JMCBFE,
-]
-MLOIJU = [NKMLOI, KMLOIJ]
-MNHTBJ = [YFCRTF, FCRTFM, CRTFMN, RTFMNH, TFMNHT, FMNHTB]
-NPYYLI = [WAONPY, AONPYY, ONPYYL]
-NQJYMO = [UYNQJY, YNQJYM]
-OIHBXI = [
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-    ZTATDZ,
-    TATDZX,
-    ATDZXN,
-    TDZXNQ,
-    DZXNQT,
-    ZXNQTM,
-    XNQTMF,
-    NQTMFZ,
-    QTMFZD,
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    KSTSEM,
-    STSEMC,
-    TSEMCG,
-    SEMCGE,
-    EMCGET,
-    MCGETI,
-    CGETIX,
-    GETIXQ,
-    ETIXQV,
-    TIXQVX,
-    IXQVXO,
-    XQVXOI,
-    QVXOIH,
-    VXOIHB,
-    XOIHBX,
-]
-PBWJYK = [USPBWJ, SPBWJY]
-QGLRAH = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQGLRA,
-]
-QLAIID = [JVDQLA, VDQLAI, DQLAII, IVLASS]
-QPLSPF = [LGQPLS, GQPLSP]
-QRJJJV = [DJQRJJ, JQRJJJ]
-RYXBQF = [SIRYXB, IRYXBQ]
-SSRURA = []
-UTYEKC = [UJUTYE, JUTYEK]
-VDSSRU = [
-    BMJVHF,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    RSJMCB,
-    CBFEGZ,
-    EGZUQE,
-]
-WAJVDQ = [LXWAJV, XWAJVD]
-WDAFIK = [HBQNRX, BQNRXC, QNRXCH, NRXCHW, RXCHWD, XCHWDA, CHWDAF, HWDAFI]
-XIBHZV = [HBXIBH, BXIBHZ]
-ZILXWA = [KVKZIL, VKZILX, JVHFTH, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1001,230 +19,811 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return SRURAZ
+        return 9
 
     @property
     def output_keys(self):
-        return VDSSRU
+        return [
+            "Out1A",
+            "Out1B",
+            "Out2A",
+            "Out2B",
+            "Out3A",
+            "OutHtr",
+            "Out4A",
+            "Out5A",
+            "Out6A",
+            "Out7A",
+            "Direct",
+            "OutLi",
+            "OutIO2",
+            "OutIO4",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, KQXPIC, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, KQXPIC, None, None, QBMJVH
+            "Out1A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1A",
+                93,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, KQXPIC, None, None, QBMJVH
+            "Out1B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1B",
+                94,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, KQXPIC, None, None, QBMJVH
+            "Out2A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2A",
+                95,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, KQXPIC, None, None, QBMJVH
+            "Out2B": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2B",
+                96,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, QGLRAH, None, None, QBMJVH
+            "Out3A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3A",
+                97,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, KQXPIC, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                102,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, KQXPIC, None, None, QBMJVH
+            "Out1ACur": GeckoByteStructAccessor(self.struct, "Out1ACur", 106, "ALL"),
+            "Out1BCur": GeckoByteStructAccessor(self.struct, "Out1BCur", 107, "ALL"),
+            "Out2ACur": GeckoByteStructAccessor(self.struct, "Out2ACur", 108, "ALL"),
+            "Out2BCur": GeckoByteStructAccessor(self.struct, "Out2BCur", 109, "ALL"),
+            "Out3ACur": GeckoByteStructAccessor(self.struct, "Out3ACur", 110, "ALL"),
+            "Out4A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4A",
+                98,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, KQXPIC, None, None, QBMJVH
+            "Out5A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5A",
+                99,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, KQXPIC, None, None, QBMJVH
+            "Out6A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6A",
+                100,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, JRJHIU, None, None, QBMJVH
+            "Out7A": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7A",
+                101,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoByteStructAccessor(self.struct, RJHIUS, JHIUSO, QBMJVH),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, QBMJVH),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, MCBFEG, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                116,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, FEGZUQ, None, None, QBMJVH
+            "Out4ACur": GeckoByteStructAccessor(self.struct, "Out4ACur", 111, "ALL"),
+            "Out5ACur": GeckoByteStructAccessor(self.struct, "Out5ACur", 112, "ALL"),
+            "Out6ACur": GeckoByteStructAccessor(self.struct, "Out6ACur", 113, "ALL"),
+            "Out7ACur": GeckoByteStructAccessor(self.struct, "Out7ACur", 114, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 115, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                103,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                "ALL",
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, FEGZUQ, None, None, QBMJVH
+            "OutIO2": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO2",
+                104,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, QBMJVH),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, TYEKCW, UTYEKC, None, TYEKCW, QBMJVH
+            "OutIO4": GeckoEnumStructAccessor(
+                self.struct,
+                "OutIO4",
+                105,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "LI",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "TvLift",
+                    "SpLift",
+                    "SANI",
+                    "ONZEN",
+                    "VALVE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, NPYYLI, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 84, "ALL"),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 4, "ALL"
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, YYLIUX, None, IUXFEF, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 2, "ALL"
             ),
-            UXFEFJ: GeckoBoolStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, FEFJTA, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 1, 2, ["Shared", "Own"], None, 2, "ALL"
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, CCPQIP, None, None, QBMJVH
+            "QuietTimeOut": GeckoByteStructAccessor(
+                self.struct, "QuietTimeOut", 61, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, XFEFJT, POUYNQ, IPOUYN, None, TYEKCW, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                26,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, XFEFJT, QJYMOU, NQJYMO, None, TYEKCW, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                24,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoEnumStructAccessor(
-                self.struct, MJIGYO, JIGYOU, None, GYOUSP, None, None, QBMJVH
+            "FiltOTOption": GeckoBoolStructAccessor(
+                self.struct, "FiltOTOption", 25, 4, "ALL"
             ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, PBWJYK, None, None, QBMJVH
+            "CpOtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "CpOtOption",
+                23,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, JYKLGQ, None, None, QBMJVH
+            "FiltSuspendBy": GeckoEnumStructAccessor(
+                self.struct, "FiltSuspendBy", 25, 6, ["AnyUD", "PumpUD"], None, 2, "ALL"
             ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 25, 0, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoEnumStructAccessor(
-                self.struct, SPFTSI, PFTSIF, None, IPOUYN, None, None, QBMJVH
+            "FiltOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltOTActTemp", 46, "ALL"
             ),
-            FTSIFJ: GeckoByteStructAccessor(self.struct, FTSIFJ, TSIFJB, QBMJVH),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, TYEKCW, AOAWBS, None, TYEKCW, QBMJVH
+            "FiltOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltOTDeadband", 47, "ALL"
             ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, JYKLGQ, None, None, QBMJVH
+            "FiltCPOTActTemp": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTActTemp", 49, "ALL"
             ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, BSIRYX, YXBQFY, RYXBQF, None, TYEKCW, QBMJVH
+            "FiltCPOTDeadband": GeckoByteStructAccessor(
+                self.struct, "FiltCPOTDeadband", 50, "ALL"
             ),
-            XBQFYL: GeckoBoolStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, FEFJTA, QBMJVH
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 51, "ALL"
             ),
-            QFYLJU: GeckoBoolStructAccessor(
-                self.struct, QFYLJU, BQFYLJ, FYLJUI, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 52, "ALL"
             ),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, BSIRYX, FWRKIN, KFWRKI, None, TYEKCW, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 48, "ALL"
             ),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, BSIRYX, TYEKCW, INEJNI, None, TYEKCW, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 53, "ALL"
             ),
-            NEJNIB: GeckoByteStructAccessor(self.struct, NEJNIB, EJNIBX, None),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoByteStructAccessor(self.struct, IBXYBQ, BXYBQS, None),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoByteStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoByteStructAccessor(self.struct, QLNMHX, LNMHXE, QBMJVH),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, QBMJVH),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, POUYNQ, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                117,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, XEKVKZ, FWRKIN, ZILXWA, None, FEFJTA, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                55,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, XEKVKZ, QJYMOU, WAJVDQ, None, TYEKCW, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 54, None, ["CP", "P1"], None, None, "ALL"
             ),
-            AJVDQL: GeckoEnumStructAccessor(
-                self.struct, AJVDQL, MJMAOA, YXBQFY, QLAIID, None, FEFJTA, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                59,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            LAIIDN: GeckoBoolStructAccessor(
-                self.struct, LAIIDN, AIIDNI, QJYMOU, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 58, "ALL"
             ),
-            IIDNIB: GeckoBoolStructAccessor(
-                self.struct, IIDNIB, AIIDNI, TYEKCW, QBMJVH
+            "O3SuspendBy": GeckoEnumStructAccessor(
+                self.struct,
+                "O3SuspendBy",
+                56,
+                None,
+                ["AnyUD", "PumpUD"],
+                None,
+                None,
+                "ALL",
             ),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoByteStructAccessor(self.struct, NIBXTI, IBXTIA, QBMJVH),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, QBMJVH),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, QBMJVH),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, QBMJVH),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, QBMJVH),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoTimeStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoTimeStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoTimeStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoTimeStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoTimeStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoTimeStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, XEKVKZ, FEFJTA, GDSBDJ, None, TYEKCW, QBMJVH
+            "O3FilterDelay": GeckoByteStructAccessor(
+                self.struct, "O3FilterDelay", 57, "ALL"
             ),
-            DSBDJQ: GeckoBoolStructAccessor(
-                self.struct, DSBDJQ, XEKVKZ, FYLJUI, QBMJVH
+            "SaniLevel": GeckoByteStructAccessor(self.struct, "SaniLevel", 44, "ALL"),
+            "SaniOnTime": GeckoByteStructAccessor(self.struct, "SaniOnTime", 45, "ALL"),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 15, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 13, 2, ["C", "F"], None, 2, "ALL"
             ),
-            SBDJQR: GeckoBoolStructAccessor(
-                self.struct, SBDJQR, XEKVKZ, YXBQFY, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 12, None, ["CP", "P1"], None, None, "ALL"
             ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, XUJUTY, QJYMOU, QRJJJV, None, TYEKCW, QBMJVH
+            "HeatRestriction": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatRestriction",
+                83,
+                3,
+                ["No", "FullPowerOnly"],
+                None,
+                2,
+                "ALL",
             ),
-            RJJJVY: GeckoBoolStructAccessor(
-                self.struct, RJJJVY, XUJUTY, FWRKIN, QBMJVH
+            "ExtProbeEnable": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeEnable", 14, 4, "ALL"
             ),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, BSIRYX, QJYMOU, MLOIJU, None, TYEKCW, QBMJVH
+            "OverSetpointEnable": GeckoBoolStructAccessor(
+                self.struct, "OverSetpointEnable", 14, 5, "ALL"
             ),
-            LOIJUG: GeckoBoolStructAccessor(
-                self.struct, LOIJUG, BQFYLJ, QJYMOU, QBMJVH
+            "EconBelowSetpoint": GeckoByteStructAccessor(
+                self.struct, "EconBelowSetpoint", 62, "ALL"
             ),
-            OIJUGS: GeckoBoolStructAccessor(
-                self.struct, OIJUGS, XFEFJT, FWRKIN, QBMJVH
+            "LineFrequency": GeckoEnumStructAccessor(
+                self.struct, "LineFrequency", 83, 1, ["60HZ", "50HZ"], None, 2, "ALL"
             ),
-            IJUGSE: GeckoBoolStructAccessor(
-                self.struct, IJUGSE, JUGSEL, QJYMOU, QBMJVH
+            "LineVoltage": GeckoEnumStructAccessor(
+                self.struct, "LineVoltage", 83, 2, ["240Vac", "230VAC"], None, 2, "ALL"
             ),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, JUGSEL, JJVYFC, ELHBQN, None, TYEKCW, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 85, None),
+            "BrNbSettings": GeckoByteStructAccessor(
+                self.struct, "BrNbSettings", 86, None
             ),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, JUGSEL, FEFJTA, WDAFIK, None, DAFIKJ, QBMJVH
+            "BrSetIndex": GeckoByteStructAccessor(self.struct, "BrSetIndex", 87, None),
+            "BreakerSet1": GeckoByteStructAccessor(
+                self.struct, "BreakerSet1", 88, "ALL"
             ),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, JUGSEL, TYEKCW, XIBHZV, None, TYEKCW, QBMJVH
+            "BreakerSet2": GeckoByteStructAccessor(
+                self.struct, "BreakerSet2", 89, "ALL"
             ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, JUGSEL, YXBQFY, XIBHZV, None, TYEKCW, QBMJVH
+            "BreakerSet3": GeckoByteStructAccessor(
+                self.struct, "BreakerSet3", 90, "ALL"
             ),
-            BHZVOA: GeckoBoolStructAccessor(
-                self.struct, BHZVOA, HZVOAC, QJYMOU, QBMJVH
+            "BreakerSet4": GeckoByteStructAccessor(
+                self.struct, "BreakerSet4", 91, "ALL"
             ),
-            ZVOACM: GeckoEnumStructAccessor(
-                self.struct, ZVOACM, VOACMC, TYEKCW, CMCVDS, None, FEFJTA, QBMJVH
+            "BreakerSet5": GeckoByteStructAccessor(
+                self.struct, "BreakerSet5", 92, "ALL"
             ),
-            MCVDSS: GeckoByteStructAccessor(self.struct, MCVDSS, VOACMC, QBMJVH),
-            CVDSSR: GeckoBoolStructAccessor(
-                self.struct, CVDSSR, BSIRYX, FEFJTA, QBMJVH
+            "CE_2x20Allowed": GeckoBoolStructAccessor(
+                self.struct, "CE_2x20Allowed", 60, 6, "ALL"
+            ),
+            "UDActionOnQuiet": GeckoEnumStructAccessor(
+                self.struct,
+                "UDActionOnQuiet",
+                60,
+                1,
+                ["IgnoreUD", "RestoreAllUD", "NA", "CancelOtherUD"],
+                None,
+                4,
+                "ALL",
+            ),
+            "QuietActionOnUD": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnUD",
+                60,
+                0,
+                ["Cancel", "Pause"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuietActionOnHeater": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietActionOnHeater",
+                13,
+                3,
+                ["NoAction", "ForceMaxPower", "KeepOff", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "Pump1AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump1AsVSP", 5, 0, "ALL"
+            ),
+            "Pump3AsVSP": GeckoBoolStructAccessor(
+                self.struct, "Pump3AsVSP", 5, 2, "ALL"
+            ),
+            "VSPCheckfloSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPCheckfloSpeed", 6, "ALL"
+            ),
+            "VSPFilterSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilterSpeed", 7, "ALL"
+            ),
+            "VSPSpeedLevel0": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel0", 8, "ALL"
+            ),
+            "VSPSpeedLevel1": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel1", 9, "ALL"
+            ),
+            "VSPSpeedLevel2": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel2", 10, "ALL"
+            ),
+            "VSPSpeedLevel3": GeckoByteStructAccessor(
+                self.struct, "VSPSpeedLevel3", 11, "ALL"
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 27, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 28, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 30, "ALL"),
+            "OnzenStart": GeckoTimeStructAccessor(self.struct, "OnzenStart", 36, "ALL"),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 38, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 40, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 63, "ALL"),
+            "EconStop": GeckoTimeStructAccessor(self.struct, "EconStop", 65, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                60,
+                4,
+                ["NA", "Available"],
+                None,
+                2,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 60, 5, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 60, 3, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                1,
+                0,
+                ["LastPumpKey", "FreePumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOnOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffKeyEnable", 1, 1, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct, "TimeFormat", 83, 0, ["AmPm", "24h"], None, 2, "ALL"
+            ),
+            "AmbiantOHEnable": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHEnable", 14, 0, "ALL"
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 25, 1, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 118, 0, "ALL"
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                118,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                118,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                118,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                118,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 120, 0, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                121,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 121, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 83, 4, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inxm-log-2.py
+++ b/src/geckolib/driver/packs/inxm-log-2.py
@@ -12,841 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 313
-AHEOCT = 11
-AKQXPI = 296
-AMJMAO = "".join(chr(c) for c in [82, 72, 95, 82, 101, 103, 83, 108, 111, 112, 101])
-AOAWBS = "".join(
-    chr(c) for c in [82, 72, 95, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-AONPYY = 307
-ASSAKQ = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        54,
-        65,
-    ]
-)
-AWBSIR = "".join(
-    chr(c) for c in [82, 72, 95, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BFEGZU = "".join(chr(c) for c in [80, 50])
-BIAMJM = 257
-BLKXSJ = "".join(
-    chr(c) for c in [83, 87, 77, 80, 117, 114, 103, 101, 95, 83, 117, 115, 112]
-)
-BMJVHF = "".join(chr(c) for c in [66, 114, 77, 101, 110, 117])
-BQFYLJ = "".join(chr(c) for c in [82, 72, 95, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-BSIRYX = "".join(chr(c) for c in [82, 72, 95, 72, 87, 95, 72, 76])
-BSKSOK = "".join(chr(c) for c in [79, 78])
-BWJYKL = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-CCPQIP = "".join(chr(c) for c in [70, 105, 108, 116, 80, 117, 114, 103, 101])
-CPQIPO = 269
-CQBMJV = 256
-CTHBSK = "".join(chr(c) for c in [85, 68, 95, 80, 53])
-CVYYPI = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        50,
-        65,
-    ]
-)
-CWAONP = 303
-CXQIEF = "".join(chr(c) for c in [76, 79, 87])
-ECVYYP = 282
-EFJTAC = 310
-EFXQGL = 2
-EGZUQE = "".join(chr(c) for c in [80, 52])
-EKCWAO = 306
-EOCTHB = "".join(chr(c) for c in [85, 68, 95, 80, 52])
-EXLSXU = "".join(chr(c) for c in [79, 90, 79, 78, 69])
-FEFJTA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-FEGZUQ = "".join(chr(c) for c in [80, 51])
-FJBIAM = 263
-FJTACC = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-FTHECV = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        49,
-        65,
-    ]
-)
-FTSIFJ = "".join(chr(c) for c in [79, 72, 67, 111, 110, 100, 105, 116, 105, 111, 110])
-FWRKIN = "".join(chr(c) for c in [82, 72, 95, 70, 108, 111, 119, 67, 104, 101, 99, 107])
-FXQGLR = 4
-FYLJUI = "".join(chr(c) for c in [82, 72, 95, 72, 114, 75, 105, 110])
-GLRAHE = "".join(chr(c) for c in [71, 101, 99, 107, 111])
-GQPLSP = "".join(
-    chr(c)
-    for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116, 70, 108, 97, 103]
-)
-GYOUSP = 301
-GZUQEX = "".join(chr(c) for c in [80, 53])
-HBSKSO = "".join(chr(c) for c in [85, 68, 95, 66, 76, 79, 87, 69, 82])
-HECVYY = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        49,
-        66,
-    ]
-)
-HEOCTH = "".join(chr(c) for c in [82, 68])
-HFTHEC = 300
-HIUSOO = "".join(chr(c) for c in [32])
-HUOJRJ = "".join(chr(c) for c in [70, 73, 88, 67, 79, 76, 79, 82])
-IAMJMA = "".join(
-    chr(c)
-    for c in [82, 72, 95, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-ICXQIE = "".join(chr(c) for c in [79, 70, 70])
-IEFXQG = 14
-IFJBIA = "".join(chr(c) for c in [82, 72, 95, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-IGYOUS = "".join(
-    chr(c) for c in [69, 120, 116, 80, 114, 111, 98, 101, 65, 99, 116, 105, 118, 101]
-)
-IKFWRK = 260
-INEJNI = "".join(chr(c) for c in [76, 73])
-IPIVLA = 288
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        80,
-        117,
-        114,
-        103,
-        101,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        85,
-        68,
-    ]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [82, 72, 95, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-IUSOOQ = "".join(chr(c) for c in [81, 85, 73, 69, 84])
-IUXFEF = "".join(chr(c) for c in [78, 69, 87])
-IVLASS = 290
-JBIAMJ = "".join(chr(c) for c in [82, 72, 95, 67, 111, 109, 109, 69, 114, 114])
-JHIUSO = "".join(
-    chr(c) for c in [85, 68, 95, 81, 85, 73, 69, 84, 95, 80, 65, 85, 83, 69]
-)
-JIGYOU = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        69,
-        99,
-        111,
-        110,
-        111,
-        109,
-        121,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-JMAOAW = "".join(
-    chr(c) for c in [82, 72, 95, 68, 117, 116, 121, 67, 121, 99, 108, 101, 69, 114, 114]
-)
-JMCBFE = "".join(chr(c) for c in [80, 49])
-JNIBXY = 256
-JRJHIU = "".join(chr(c) for c in [85, 68, 95, 76, 73, 71, 72, 84, 49, 50, 48])
-JTACCP = 312
-JUIKFW = "".join(chr(c) for c in [82, 72, 95, 72, 87, 75, 105, 110, 101, 116, 105, 99])
-JUTYEK = 274
-JVHFTH = 6
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-JYMOUN = 268
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        86,
-        83,
-        80,
-        51,
-        95,
-        65,
-        118,
-        97,
-        110,
-        116,
-        80,
-        108,
-        97,
-        110,
-        83,
-        112,
-        101,
-        101,
-        100,
-    ]
-)
-KFWRKI = "".join(
-    chr(c)
-    for c in [82, 72, 95, 70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KLGQPL = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-KPHUOJ = "".join(chr(c) for c in [85, 68, 95, 65, 85, 88, 50])
-KQXPIC = "".join(
-    chr(c) for c in [67, 117, 114, 114, 101, 110, 116, 72, 101, 97, 116, 101, 114]
-)
-KSOKPH = 8
-KXSJWM = 265
-LASSAK = 292
-LGQPLS = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-LIUXFE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-LJUIKF = "".join(chr(c) for c in [82, 72, 95, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-LKXSJW = "".join(
-    chr(c)
-    for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 95, 71]
-)
-LRAHEO = "".join(chr(c) for c in [85, 68, 95, 80, 51])
-LSPFTS = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-LSXUJU = "".join(chr(c) for c in [76, 49, 50, 48])
-MAOAWB = 258
-MCBFEG = 316
-MJIGYO = 271
-MJMAOA = "".join(chr(c) for c in [82, 72, 95, 76, 111, 119, 70, 108, 111])
-MJVHFT = 279
-MNZMJI = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-MOUNBL = "".join(chr(c) for c in [77, 69, 68, 73, 85, 77])
-NBLKXS = "".join(chr(c) for c in [83, 87, 77, 80, 117, 114, 103, 101])
-NIBXYB = 511
-NPYYLI = 309
-NQJYMO = 267
-NRSJMC = 305
-NZMJIG = "".join(
-    chr(c)
-    for c in [
-        75,
-        105,
-        110,
-        101,
-        116,
-        105,
-        99,
-        80,
-        117,
-        114,
-        103,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-OAWBSI = "".join(chr(c) for c in [82, 72, 95, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-OCTHBS = 10
-OKPHUO = 5
-ONPYYL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-OOQNRS = "".join(chr(c) for c in [86, 83, 80, 49, 95, 85, 68, 83, 112, 101, 101, 100])
-OQNRSJ = 304
-OUNBLK = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUSPBW = 277
-OUYNQJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114, 79, 84])
-PBWJYK = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-        69,
-        114,
-        114,
-    ]
-)
-PFTSIF = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PHUOJR = "".join(chr(c) for c in [85, 68, 95, 70, 66, 95, 76, 84])
-PICXQI = 275
-PIPIVL = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        51,
-        65,
-    ]
-)
-PIVLAS = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        52,
-        65,
-    ]
-)
-PLSPFT = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-POUYNQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        108,
-        101,
-        97,
-        110,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        85,
-        68,
-    ]
-)
-PQIPOU = "".join(chr(c) for c in [70, 105, 108, 116, 67, 108, 101, 97, 110])
-PYYLIU = "".join(chr(c) for c in [85, 83, 69, 95, 73, 78, 84, 69, 82, 78, 65, 76])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [67, 80])
-QFYLJU = "".join(chr(c) for c in [82, 72, 95, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-QGLRAH = 12
-QIPOUY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        67,
-        108,
-        101,
-        97,
-        110,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-QJYMOU = "".join(chr(c) for c in [83, 87, 77, 95, 82, 105, 115, 107])
-QNRSJM = "".join(chr(c) for c in [86, 83, 80, 51, 95, 85, 68, 83, 112, 101, 101, 100])
-QPLSPF = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-QXPICX = 298
-RJHIUS = 1
-RKINEJ = "".join(
-    chr(c)
-    for c in [82, 72, 95, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-RSJMCB = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 101, 110, 115, 105, 116, 121]
-)
-RYXBQF = "".join(chr(c) for c in [82, 72, 95, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-SAKQXP = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        55,
-        65,
-    ]
-)
-SIFJBI = 261
-SIRYXB = "".join(
-    chr(c) for c in [82, 72, 95, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SJMCBF = 308
-SJWMNZ = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111, 119])
-SOKPHU = "".join(chr(c) for c in [85, 68, 95, 65, 85, 88, 49])
-SOOQNR = 0
-SPBWJY = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-SPFTSI = "".join(chr(c) for c in [114, 72, 73, 100])
-SSAKQX = 294
-SXUJUT = "".join(chr(c) for c in [70, 65, 78])
-TACCPQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-THBSKS = 9
-THECVY = 280
-TSIFJB = "".join(chr(c) for c in [82, 72, 95, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-TYEKCW = 302
-UIKFWR = "".join(
-    chr(c)
-    for c in [82, 72, 95, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101]
-)
-UJUTYE = "".join(chr(c) for c in [82, 72, 95, 68, 117, 116, 121, 67, 121, 99, 108, 101])
-UOJRJH = "".join(chr(c) for c in [83, 67, 65, 78])
-UQEXLS = "".join(chr(c) for c in [66, 76, 79, 87, 69, 82])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-UTYEKC = "".join(
-    chr(c)
-    for c in [
-        86,
-        83,
-        80,
-        49,
-        95,
-        65,
-        118,
-        97,
-        110,
-        116,
-        80,
-        108,
-        97,
-        110,
-        83,
-        112,
-        101,
-        101,
-        100,
-    ]
-)
-UXFEFJ = "".join(chr(c) for c in [70, 73, 76, 84, 69, 82])
-UYNQJY = "".join(chr(c) for c in [67, 80, 79, 84])
-VHFTHE = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101])
-VLASSA = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        53,
-        65,
-    ]
-)
-VYYPIP = 284
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        86,
-        83,
-        80,
-        51,
-        95,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        83,
-        112,
-        101,
-        101,
-        100,
-    ]
-)
-WBSIRY = "".join(chr(c) for c in [82, 72, 95, 72, 82, 95, 72, 76])
-WJYKLG = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-WMNZMJ = 270
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        82,
-        72,
-        95,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-XBQFYL = "".join(chr(c) for c in [82, 72, 95, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-XLSXUJ = 3
-XPICXQ = "".join(chr(c) for c in [85, 68, 95, 80, 49])
-XQGLRA = "".join(chr(c) for c in [85, 68, 95, 80, 50])
-XQIEFX = "".join(chr(c) for c in [72, 73, 71, 72])
-XSJWMN = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-XUJUTY = 7
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        86,
-        83,
-        80,
-        49,
-        95,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        83,
-        112,
-        101,
-        101,
-        100,
-    ]
-)
-YKLGQP = 278
-YLIUXF = "".join(chr(c) for c in [83, 84, 79, 80])
-YLJUIK = "".join(
-    chr(c) for c in [82, 72, 95, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-YMOUNB = "".join(chr(c) for c in [78, 79])
-YNQJYM = "".join(chr(c) for c in [83, 87, 77, 95, 65, 99, 116, 105, 118, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-YPIPIV = 286
-YXBQFY = 259
-YYLIUX = "".join(chr(c) for c in [73, 68, 76, 69])
-YYPIPI = "".join(
-    chr(c)
-    for c in [
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        79,
-        85,
-        84,
-        50,
-        66,
-    ]
-)
-ZCQBMJ = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-ZMJIGY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 116, 105, 118, 101]
-)
-ZUQEXL = 315
-CBFEGZ = [ICXQIE, XQIEFX, CXQIEF]
-EJNIBX = [
-    JYKLGQ,
-    JMAOAW,
-    WJYKLG,
-    SPBWJY,
-    GQPLSP,
-    USPBWJ,
-    FTSIFJ,
-    PLSPFT,
-    KLGQPL,
-    LGQPLS,
-    LSPFTS,
-    PBWJYK,
-    SIRYXB,
-    JBIAMJ,
-    BWJYKL,
-    PFTSIF,
-    YOUSPB,
-    QPLSPF,
-    SPFTSI,
-]
-KINEJN = []
-NEJNIB = [
-    JMCBFE,
-    BFEGZU,
-    FEGZUQ,
-    EGZUQE,
-    GZUQEX,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    SXUJUT,
-    UJUTYE,
-    UTYEKC,
-    YEKCWA,
-    KCWAON,
-    WAONPY,
-    INEJNI,
-]
-OJRJHI = [ICXQIE, HUOJRJ, UOJRJH]
-QIEFXQ = [ICXQIE, CXQIEF, XQIEFX]
-RAHEOC = [ICXQIE, XQIEFX]
-SKSOKP = [ICXQIE, BSKSOK]
-UNBLKX = [YMOUNB, CXQIEF, MOUNBL, XQIEFX, OUNBLK]
-USOOQN = [HIUSOO, IUSOOQ]
-XFEFJT = [PYYLIU, YYLIUX, YLIUXF, LIUXFE, IUXFEF, UXFEFJ]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -854,186 +19,389 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return EFXQGL
+        return 2
 
     @property
     def begin(self):
-        return JNIBXY
+        return 256
 
     @property
     def end(self):
-        return NIBXYB
+        return 511
 
     @property
     def all_device_keys(self):
-        return NEJNIB
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BLOWER",
+            "CP",
+            "OZONE",
+            "L120",
+            "FAN",
+            "RH_DutyCycle",
+            "VSP1_AvantPlanSpeed",
+            "VSP1_MinimumSpeed",
+            "VSP3_AvantPlanSpeed",
+            "VSP3_MinimumSpeed",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return KINEJN
+        return []
 
     @property
     def error_keys(self):
-        return EJNIBX
+        return [
+            "RH_DutyCycleErr",
+            "AmbiantOHLevel2",
+            "RH_CommErr",
+            "ThermistanceErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "RegOverHeatFlag",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "OHCondition",
+            "RelayStuck",
+            "LearnDetectionErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "RH_RegProbeErr",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoBoolStructAccessor(self.struct, BMJVHF, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoByteStructAccessor(self.struct, VHFTHE, HFTHEC, None),
-            FTHECV: GeckoWordStructAccessor(self.struct, FTHECV, THECVY, None),
-            HECVYY: GeckoWordStructAccessor(self.struct, HECVYY, ECVYYP, None),
-            CVYYPI: GeckoWordStructAccessor(self.struct, CVYYPI, VYYPIP, None),
-            YYPIPI: GeckoWordStructAccessor(self.struct, YYPIPI, YPIPIV, None),
-            PIPIVL: GeckoWordStructAccessor(self.struct, PIPIVL, IPIVLA, None),
-            PIVLAS: GeckoWordStructAccessor(self.struct, PIVLAS, IVLASS, None),
-            VLASSA: GeckoWordStructAccessor(self.struct, VLASSA, LASSAK, None),
-            ASSAKQ: GeckoWordStructAccessor(self.struct, ASSAKQ, SSAKQX, None),
-            SAKQXP: GeckoWordStructAccessor(self.struct, SAKQXP, AKQXPI, None),
-            KQXPIC: GeckoWordStructAccessor(self.struct, KQXPIC, QXPICX, QBMJVH),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, IEFXQG, QIEFXQ, EFXQGL, FXQGLR, QBMJVH
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, "ALL"),
+            "BrMenu": GeckoBoolStructAccessor(self.struct, "BrMenu", 279, 6, None),
+            "HeaterPhase": GeckoByteStructAccessor(
+                self.struct, "HeaterPhase", 300, None
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, PICXQI, QGLRAH, QIEFXQ, EFXQGL, FXQGLR, GLRAHE
+            "LearningCurrentOUT1A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT1A", 280, None
             ),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, PICXQI, AHEOCT, RAHEOC, EFXQGL, EFXQGL, HEOCTH
+            "LearningCurrentOUT1B": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT1B", 282, None
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, PICXQI, OCTHBS, RAHEOC, EFXQGL, EFXQGL, QBMJVH
+            "LearningCurrentOUT2A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT2A", 284, None
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, PICXQI, THBSKS, RAHEOC, EFXQGL, EFXQGL, QBMJVH
+            "LearningCurrentOUT2B": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT2B", 286, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, PICXQI, KSOKPH, SKSOKP, EFXQGL, EFXQGL, QBMJVH
+            "LearningCurrentOUT3A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT3A", 288, None
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, PICXQI, OKPHUO, SKSOKP, EFXQGL, EFXQGL, QBMJVH
+            "LearningCurrentOUT4A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT4A", 290, None
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PICXQI, FXQGLR, SKSOKP, EFXQGL, EFXQGL, QBMJVH
+            "LearningCurrentOUT5A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT5A", 292, None
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, PICXQI, EFXQGL, OJRJHI, EFXQGL, FXQGLR, QBMJVH
+            "LearningCurrentOUT6A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT6A", 294, None
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, PICXQI, RJHIUS, SKSOKP, EFXQGL, EFXQGL, QBMJVH
+            "LearningCurrentOUT7A": GeckoWordStructAccessor(
+                self.struct, "LearningCurrentOUT7A", 296, None
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, PICXQI, SOOQNR, USOOQN, EFXQGL, EFXQGL, QBMJVH
+            "CurrentHeater": GeckoWordStructAccessor(
+                self.struct, "CurrentHeater", 298, "ALL"
             ),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, QBMJVH),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, SOOQNR, CBFEGZ, None, FXQGLR, None
+            "UD_P1": GeckoEnumStructAccessor(
+                self.struct, "UD_P1", 275, 14, ["OFF", "LOW", "HIGH"], 2, 4, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, MCBFEG, EFXQGL, CBFEGZ, None, FXQGLR, None
+            "UD_P2": GeckoEnumStructAccessor(
+                self.struct, "UD_P2", 275, 12, ["OFF", "LOW", "HIGH"], 2, 4, "Gecko"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, MCBFEG, FXQGLR, CBFEGZ, None, FXQGLR, None
+            "UD_P3": GeckoEnumStructAccessor(
+                self.struct, "UD_P3", 275, 11, ["OFF", "HIGH"], 2, 2, "RD"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, MCBFEG, JVHFTH, CBFEGZ, None, FXQGLR, None
+            "UD_P4": GeckoEnumStructAccessor(
+                self.struct, "UD_P4", 275, 10, ["OFF", "HIGH"], 2, 2, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, SOOQNR, RAHEOC, None, EFXQGL, None
+            "UD_P5": GeckoEnumStructAccessor(
+                self.struct, "UD_P5", 275, 9, ["OFF", "HIGH"], 2, 2, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, ZUQEXL, RJHIUS, RAHEOC, None, EFXQGL, None
+            "UD_BLOWER": GeckoEnumStructAccessor(
+                self.struct, "UD_BLOWER", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, ZUQEXL, EFXQGL, SKSOKP, None, EFXQGL, None
+            "UD_AUX1": GeckoEnumStructAccessor(
+                self.struct, "UD_AUX1", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, ZUQEXL, XLSXUJ, SKSOKP, None, EFXQGL, None
+            "UD_AUX2": GeckoEnumStructAccessor(
+                self.struct, "UD_AUX2", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, ZUQEXL, FXQGLR, SKSOKP, None, EFXQGL, None
+            "UD_FB_LT": GeckoEnumStructAccessor(
+                self.struct,
+                "UD_FB_LT",
+                275,
+                2,
+                ["OFF", "FIXCOLOR", "SCAN"],
+                2,
+                4,
+                "ALL",
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, ZUQEXL, XUJUTY, SKSOKP, None, EFXQGL, None
+            "UD_LIGHT120": GeckoEnumStructAccessor(
+                self.struct, "UD_LIGHT120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, None),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, None),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, None),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, XFEFJT, None, JVHFTH, QBMJVH
+            "UD_QUIET_PAUSE": GeckoEnumStructAccessor(
+                self.struct, "UD_QUIET_PAUSE", 275, 0, [" ", "QUIET"], 2, 2, "ALL"
             ),
-            FEFJTA: GeckoTimeStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, XFEFJT, None, JVHFTH, QBMJVH
+            "VSP1_UDSpeed": GeckoByteStructAccessor(
+                self.struct, "VSP1_UDSpeed", 304, "ALL"
             ),
-            TACCPQ: GeckoTimeStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, XUJUTY, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, CPQIPO, OKPHUO, None),
-            QIPOUY: GeckoBoolStructAccessor(self.struct, QIPOUY, CPQIPO, FXQGLR, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, MJVHFT, EFXQGL, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, MJVHFT, XLSXUJ, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, MJVHFT, SOOQNR, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, MJVHFT, RJHIUS, None),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, None),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, UNBLKX, None, KSOKPH, None
+            "VSP3_UDSpeed": GeckoByteStructAccessor(
+                self.struct, "VSP3_UDSpeed", 305, "ALL"
             ),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, CPQIPO, XLSXUJ, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, EFXQGL, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, CPQIPO, RJHIUS, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, CPQIPO, SOOQNR, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, WMNZMJ, XUJUTY, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, WMNZMJ, JVHFTH, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, WMNZMJ, OKPHUO, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, MJIGYO, SOOQNR, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, MJIGYO, EFXQGL, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, SOOQNR, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, OKPHUO, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, OUSPBW, FXQGLR, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, OUSPBW, XLSXUJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, OUSPBW, EFXQGL, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, OUSPBW, RJHIUS, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, OUSPBW, SOOQNR, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, XUJUTY, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, YKLGQP, JVHFTH, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, YKLGQP, OKPHUO, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, YKLGQP, FXQGLR, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, YKLGQP, XLSXUJ, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, YKLGQP, EFXQGL, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, YKLGQP, RJHIUS, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, YKLGQP, SOOQNR, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, MJVHFT, FXQGLR, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, MJVHFT, OKPHUO, None),
-            TSIFJB: GeckoTempStructAccessor(self.struct, TSIFJB, SIFJBI, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, BIAMJM, XUJUTY, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, BIAMJM, XLSXUJ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, BIAMJM, EFXQGL, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, BIAMJM, SOOQNR, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, XUJUTY, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, MAOAWB, JVHFTH, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, MAOAWB, OKPHUO, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, MAOAWB, FXQGLR, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, MAOAWB, XLSXUJ, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, MAOAWB, EFXQGL, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, MAOAWB, RJHIUS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, MAOAWB, SOOQNR, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, XUJUTY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, JVHFTH, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, YXBQFY, OKPHUO, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, YXBQFY, FXQGLR, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YXBQFY, XLSXUJ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, YXBQFY, EFXQGL, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, YXBQFY, RJHIUS, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, YXBQFY, SOOQNR, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IKFWRK, FXQGLR, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, IKFWRK, XLSXUJ, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, IKFWRK, EFXQGL, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, IKFWRK, RJHIUS, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, IKFWRK, SOOQNR, None),
+            "LightIntensity": GeckoByteStructAccessor(
+                self.struct, "LightIntensity", 308, "ALL"
+            ),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 316, 0, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 316, 2, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 316, 4, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 316, 6, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 315, 0, ["OFF", "HIGH"], None, 2, None
+            ),
+            "BLOWER": GeckoEnumStructAccessor(
+                self.struct, "BLOWER", 315, 1, ["OFF", "HIGH"], None, 2, None
+            ),
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 315, 2, ["OFF", "ON"], None, 2, None
+            ),
+            "OZONE": GeckoEnumStructAccessor(
+                self.struct, "OZONE", 315, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 315, 4, ["OFF", "ON"], None, 2, None
+            ),
+            "FAN": GeckoEnumStructAccessor(
+                self.struct, "FAN", 315, 7, ["OFF", "ON"], None, 2, None
+            ),
+            "RH_DutyCycle": GeckoByteStructAccessor(
+                self.struct, "RH_DutyCycle", 274, None
+            ),
+            "VSP1_AvantPlanSpeed": GeckoByteStructAccessor(
+                self.struct, "VSP1_AvantPlanSpeed", 302, None
+            ),
+            "VSP1_MinimumSpeed": GeckoByteStructAccessor(
+                self.struct, "VSP1_MinimumSpeed", 306, None
+            ),
+            "VSP3_AvantPlanSpeed": GeckoByteStructAccessor(
+                self.struct, "VSP3_AvantPlanSpeed", 303, None
+            ),
+            "VSP3_MinimumSpeed": GeckoByteStructAccessor(
+                self.struct, "VSP3_MinimumSpeed", 307, None
+            ),
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                309,
+                None,
+                ["USE_INTERNAL", "IDLE", "STOP", "START", "NEW", "FILTER"],
+                None,
+                6,
+                "ALL",
+            ),
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 310, "ALL"
+            ),
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                312,
+                None,
+                ["USE_INTERNAL", "IDLE", "STOP", "START", "NEW", "FILTER"],
+                None,
+                6,
+                "ALL",
+            ),
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 313, "ALL"
+            ),
+            "FiltPurge": GeckoBoolStructAccessor(
+                self.struct, "FiltPurge", 269, 7, None
+            ),
+            "FiltClean": GeckoBoolStructAccessor(
+                self.struct, "FiltClean", 269, 5, None
+            ),
+            "FiltCleanSuspended": GeckoBoolStructAccessor(
+                self.struct, "FiltCleanSuspended", 269, 4, None
+            ),
+            "FiltPurgeSuspendUD": GeckoBoolStructAccessor(
+                self.struct, "FiltPurgeSuspendUD", 279, 2, None
+            ),
+            "FiltCleanSuspendUD": GeckoBoolStructAccessor(
+                self.struct, "FiltCleanSuspendUD", 279, 3, None
+            ),
+            "FilterOT": GeckoBoolStructAccessor(self.struct, "FilterOT", 279, 0, None),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "SWM_Active": GeckoByteStructAccessor(self.struct, "SWM_Active", 267, None),
+            "SWM_Risk": GeckoEnumStructAccessor(
+                self.struct,
+                "SWM_Risk",
+                268,
+                None,
+                ["NO", "LOW", "MEDIUM", "HIGH", "EXTREME"],
+                None,
+                8,
+                None,
+            ),
+            "SWMPurge": GeckoBoolStructAccessor(self.struct, "SWMPurge", 269, 3, None),
+            "SWMPurge_Susp": GeckoBoolStructAccessor(
+                self.struct, "SWMPurge_Susp", 269, 2, None
+            ),
+            "DisplayedTemp_G": GeckoTempStructAccessor(
+                self.struct, "DisplayedTemp_G", 265, None
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CheckFlow": GeckoBoolStructAccessor(
+                self.struct, "CheckFlow", 269, 0, None
+            ),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KineticPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KineticPurgeActive", 270, 5, None
+            ),
+            "EconomyActive": GeckoBoolStructAccessor(
+                self.struct, "EconomyActive", 271, 0, None
+            ),
+            "ProgEconomyActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconomyActive", 271, 2, None
+            ),
+            "ExtProbeActive": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeActive", 301, 0, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnDetectionErr": GeckoBoolStructAccessor(
+                self.struct, "LearnDetectionErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "RegOverHeatFlag": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeatFlag", 278, 4, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "OHCondition": GeckoBoolStructAccessor(
+                self.struct, "OHCondition", 279, 5, None
+            ),
+            "RH_WaterTemp": GeckoTempStructAccessor(
+                self.struct, "RH_WaterTemp", 261, None
+            ),
+            "RH_TriacTemp": GeckoTempStructAccessor(
+                self.struct, "RH_TriacTemp", 263, None
+            ),
+            "RH_CommErr": GeckoBoolStructAccessor(
+                self.struct, "RH_CommErr", 257, 7, None
+            ),
+            "RH_NotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RH_NotEnoughHeat", 257, 3, None
+            ),
+            "RH_RegSlope": GeckoBoolStructAccessor(
+                self.struct, "RH_RegSlope", 257, 2, None
+            ),
+            "RH_LowFlo": GeckoBoolStructAccessor(
+                self.struct, "RH_LowFlo", 257, 0, None
+            ),
+            "RH_DutyCycleErr": GeckoBoolStructAccessor(
+                self.struct, "RH_DutyCycleErr", 258, 7, None
+            ),
+            "RH_NoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RH_NoFloRetry", 258, 6, None
+            ),
+            "RH_NoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RH_NoFloTemp", 258, 5, None
+            ),
+            "RH_NoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RH_NoFloXTries", 258, 4, None
+            ),
+            "RH_HR_HL": GeckoBoolStructAccessor(self.struct, "RH_HR_HL", 258, 3, None),
+            "RH_HW_HL": GeckoBoolStructAccessor(self.struct, "RH_HW_HL", 258, 2, None),
+            "RH_RegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RH_RegProbeErr", 258, 1, None
+            ),
+            "RH_RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RH_RegOverHeat", 258, 0, None
+            ),
+            "RH_HrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RH_HrTriacPr", 259, 7, None
+            ),
+            "RH_HrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RH_HrTriacOH", 259, 6, None
+            ),
+            "RH_SWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RH_SWTriacOH", 259, 5, None
+            ),
+            "RH_HwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RH_HwTriacOH", 259, 4, None
+            ),
+            "RH_HrKin": GeckoBoolStructAccessor(self.struct, "RH_HrKin", 259, 3, None),
+            "RH_HrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RH_HrKinNoFlo", 259, 2, None
+            ),
+            "RH_SwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RH_SwKinTemp", 259, 1, None
+            ),
+            "RH_HWKinetic": GeckoBoolStructAccessor(
+                self.struct, "RH_HWKinetic", 259, 0, None
+            ),
+            "RH_HeaterDisable": GeckoBoolStructAccessor(
+                self.struct, "RH_HeaterDisable", 260, 4, None
+            ),
+            "RH_FlowDetected": GeckoBoolStructAccessor(
+                self.struct, "RH_FlowDetected", 260, 3, None
+            ),
+            "RH_FlowCheck": GeckoBoolStructAccessor(
+                self.struct, "RH_FlowCheck", 260, 2, None
+            ),
+            "RH_HeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RH_HeaterSuspended", 260, 1, None
+            ),
+            "RH_FloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RH_FloCheckReady", 260, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxm-log-4.py
+++ b/src/geckolib/driver/packs/inxm-log-4.py
@@ -12,732 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACQFFT = "".join(
-    chr(c)
-    for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-AHEOCT = 294
-AIIDNI = "".join(chr(c) for c in [82, 104, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-AJVDQL = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AKQXPI = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101, 83, 105, 103, 110]
-)
-AKSTSE = 472
-AMJMAO = "".join(chr(c) for c in [67, 80, 79, 84])
-AOAWBS = 268
-AONPYY = "".join(chr(c) for c in [80, 51])
-ASSAKQ = "".join(chr(c) for c in [75, 54, 48, 48, 85, 112, 108, 111, 97, 100])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-AWBSIR = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-BDJQRJ = "".join(chr(c) for c in [54, 52, 75])
-BFEGZU = "".join(chr(c) for c in [78, 65])
-BIAMJM = 279
-BJEUTO = 331
-BLKXSJ = 348
-BMJVHF = 263
-BQFYLJ = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-BQNRXC = 454
-BQSNQL = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-BSIRYX = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-BSKSOK = "".join(chr(c) for c in [79, 70, 70])
-BSSUHB = "".join(chr(c) for c in [105, 110, 88, 69])
-BVWVUB = "".join(chr(c) for c in [105, 110, 88, 77])
-BWJYKL = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-BXTIAC = 260
-BXYBQS = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-CBFEGZ = "".join(chr(c) for c in [70, 73, 88])
-CCPQIP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 79, 110])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 57])
-CPQIPO = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-CQBMJV = 261
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-CRTFMN = 325
-CTHBSK = 298
-CVYYPI = "".join(chr(c) for c in [72, 50])
-CXQIEF = "".join(chr(c) for c in [79, 85, 84, 50, 65, 82, 101, 97, 100])
-DAFIKJ = 458
-DGKEAK = 470
-DNIBXT = "".join(chr(c) for c in [82, 104, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-DNQGVU = "".join(chr(c) for c in [75, 54, 48, 48, 73, 68])
-DQLAII = 259
-DSBDJQ = "".join(chr(c) for c in [51, 50, 75])
-DUBSSU = 321
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-ECVYYP = "".join(chr(c) for c in [72, 49])
-EFJTAC = "".join(chr(c) for c in [70, 65, 78])
-EFXQGL = "".join(chr(c) for c in [79, 85, 84, 51, 65, 82, 101, 97, 100])
-EJNIBX = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-EKCWAO = "".join(chr(c) for c in [72, 73, 71, 72])
-EKVKZI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-ELHBQN = "".join(chr(c) for c in [67, 70, 71, 53])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EOCTHB = 296
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-EUTOPH = 332
-EXLSXU = "".join(chr(c) for c in [85, 100, 76, 105])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-FEFJTA = "".join(chr(c) for c in [76, 49, 50, 48])
-FEGZUQ = "".join(chr(c) for c in [83, 67, 65, 78])
-FFTTID = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-FIKJPU = 459
-FJBIAM = "".join(
-    chr(c) for c in [67, 108, 101, 97, 110, 83, 117, 115, 112, 101, 110, 100, 101, 100]
-)
-FJTACC = 7
-FMNHTB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-FTHECV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTSIFJ = 352
-FTTIDU = 319
-FWRKIN = 271
-FXQGLR = 288
-FYLJUI = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-FZDGKE = 469
-GDSBDJ = "".join(chr(c) for c in [49, 54, 75])
-GETIXQ = 476
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-GLRAHE = "".join(chr(c) for c in [79, 85, 84, 53, 65, 82, 101, 97, 100])
-GQPLSP = 314
-GSELHB = "".join(chr(c) for c in [67, 70, 71, 52])
-GVUNXN = 345
-GYOUSP = 308
-GZUQEX = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 54])
-HBSKSO = 275
-HBVWVU = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-HECVYY = "".join(chr(c) for c in [83, 50])
-HEOCTH = "".join(chr(c) for c in [79, 85, 84, 55, 65, 82, 101, 97, 100])
-HFTHEC = 353
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 52])
-HTBJEU = 329
-HUGTYI = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HUOJRJ = "".join(chr(c) for c in [65, 76, 76])
-HWDAFI = 457
-HXEKVK = 257
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        82,
-        104,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [70, 105, 108, 116, 79, 84])
-IBHZVO = 479
-IBXTIA = "".join(
-    chr(c)
-    for c in [82, 104, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101, 100]
-)
-IBXYBQ = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-ICXQIE = 282
-IDNIBX = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-IDUBSS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-IEFXQG = 286
-IFJBIA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-IGYOUS = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IIDNIB = "".join(chr(c) for c in [82, 104, 72, 114, 75, 105, 110])
-IJUGSE = 450
-IKFWRK = "".join(
-    chr(c) for c in [75, 105, 110, 80, 117, 114, 103, 101, 65, 99, 116, 105, 118, 101]
-)
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-ILXWAJ = "".join(chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-INEJNI = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-IPIVLA = "".join(chr(c) for c in [76, 101, 97, 114, 110, 105, 110, 103])
-IRYXBQ = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IUSOOQ = 10
-IUXFEF = "".join(chr(c) for c in [67, 80])
-IVDNQG = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 70, 117, 108, 108]
-)
-IVLASS = "".join(chr(c) for c in [80, 104, 97, 115, 101, 83, 101, 108, 101, 99, 116])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-IYWSKW = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 118])
-JBIAMJ = "".join(
-    chr(c) for c in [67, 108, 101, 97, 110, 83, 117, 115, 112, 101, 110, 100, 85, 68]
-)
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-JHIUSO = 11
-JJVYFC = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-JMAOAW = 267
-JMCBFE = "".join(chr(c) for c in [85, 100, 83, 112, 107, 114, 76, 105, 102, 116])
-JNIBXY = "".join(
-    chr(c) for c in [76, 101, 97, 114, 110, 80, 104, 97, 115, 101, 69, 114, 114]
-)
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-JQRJJJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-JRJHIU = "".join(chr(c) for c in [85, 100, 80, 51])
-JTACCP = "".join(chr(c) for c in [70, 98])
-JUGSEL = "".join(chr(c) for c in [67, 70, 71, 51])
-JUIKFW = 270
-JUTYEK = "".join(chr(c) for c in [85, 100, 86, 83, 80, 51])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-JVHFTH = 256
-JVYFCR = 323
-JWMNZM = 307
-JYKLGQ = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-JYMOUN = 301
-JZTATD = 463
-KCWAON = "".join(chr(c) for c in [76, 79, 87])
-KEAKST = 471
-KFWRKI = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-KINEJN = 277
-KJPUNR = 460
-KLGQPL = 313
-KMLOIJ = 448
-KPHUOJ = 2
-KQXPIC = 300
-KSOKPH = "".join(chr(c) for c in [72, 73])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-KVKZIL = "".join(chr(c) for c in [82, 104, 76, 111, 119, 70, 108, 111])
-KWIVDN = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 49, 75, 87]
-)
-KXSJWM = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-KZILXW = 258
-LAIIDN = "".join(chr(c) for c in [82, 104, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-LASSAK = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-LGQPLS = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-LHBQNR = 453
-LIUXFE = "".join(chr(c) for c in [66, 76])
-LJUIKF = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-LKXSJW = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-LNMHXE = "".join(chr(c) for c in [114, 72, 73, 100])
-LOIJUG = 449
-LRAHEO = 292
-LSPFTS = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LSXUJU = "".join(chr(c) for c in [77, 69, 68])
-LXWAJV = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-MAOAWB = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-MCBFEG = "".join(chr(c) for c in [85, 100, 70, 98])
-MCGETI = 475
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-MHXEKV = "".join(chr(c) for c in [82, 104, 67, 111, 109, 109, 69, 114, 114])
-MJIGYO = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-MJMAOA = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJVHFT = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-MLOIJU = "".join(chr(c) for c in [67, 70, 71, 49])
-MNHTBJ = 328
-MNZMJI = "".join(chr(c) for c in [83, 84, 79, 80])
-MOUNBL = 305
-NBLKXS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NEJNIB = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NIBXTI = "".join(chr(c) for c in [82, 104, 72, 87, 75, 105, 110])
-NIBXYB = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-NKMLOI = "".join(chr(c) for c in [67, 70, 71, 48])
-NMHXEK = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-NPYYLI = 6
-NQGVUN = 343
-NQJYMO = 274
-NQLNMH = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-NQTMFZ = 467
-NRJZTA = 462
-NRSJMC = 8
-NRXCHW = 455
-NXNKML = "".join(chr(c) for c in [75, 54, 48, 48, 80, 114, 111, 116, 111, 99, 111, 108])
-NZMJIG = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-OAWBSI = "".join(chr(c) for c in [78, 79])
-OCTHBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 82, 101, 97, 100])
-OIHBXI = "".join(chr(c) for c in [76, 73])
-OIJUGS = "".join(chr(c) for c in [67, 70, 71, 50])
-OJRJHI = 12
-OKPHUO = 14
-ONPYYL = "".join(chr(c) for c in [80, 52])
-OOQNRS = "".join(chr(c) for c in [85, 100, 66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-OQNRSJ = "".join(chr(c) for c in [79, 78])
-OUNBLK = "".join(chr(c) for c in [86, 83, 80, 51, 70, 114, 111, 110, 116])
-OUSPBW = 316
-OUYNQJ = "".join(chr(c) for c in [83, 97, 110, 105])
-PBWJYK = 310
-PFTSIF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PHUGTY = 357
-PHUOJR = 4
-PICXQI = "".join(chr(c) for c in [79, 85, 84, 49, 66, 82, 101, 97, 100])
-PIPIVL = "".join(chr(c) for c in [76, 101, 97, 114, 110, 70, 97, 105, 108])
-PIVLAS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 108, 101, 99, 116]
-)
-PLSPFT = 350
-POUYNQ = "".join(chr(c) for c in [83, 112, 107, 114, 76, 105, 102, 116])
-PQIPOU = "".join(chr(c) for c in [68, 79, 87, 78])
-PUNRJZ = 461
-PYYLIU = "".join(chr(c) for c in [80, 53])
-QBMJVH = "".join(chr(c) for c in [82, 104, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-QEXLSX = 0
-QFFTTI = 317
-QFYLJU = 349
-QGLRAH = 290
-QGVUNX = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 118])
-QIEFXQ = "".join(chr(c) for c in [79, 85, 84, 50, 66, 82, 101, 97, 100])
-QIPOUY = "".join(chr(c) for c in [85, 80])
-QJYMOU = "".join(chr(c) for c in [86, 115, 112, 49, 70, 114, 111, 110, 116])
-QLAIID = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-QLNMHX = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 55])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QRJJJV = "".join(chr(c) for c in [85, 76])
-QSNQLN = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-QXPICX = "".join(chr(c) for c in [79, 85, 84, 49, 65, 82, 101, 97, 100])
-RAHEOC = "".join(chr(c) for c in [79, 85, 84, 54, 65, 82, 101, 97, 100])
-RJJJVY = "".join(chr(c) for c in [67, 69])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-RKINEJ = "".join(
-    chr(c) for c in [70, 114, 101, 113, 68, 101, 116, 101, 99, 69, 114, 114]
-)
-RSJMCB = "".join(chr(c) for c in [85, 100, 84, 118, 76, 105, 102, 116])
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 56])
-RYXBQF = 272
-SBDJQR = "".join(chr(c) for c in [52, 56, 75])
-SELHBQ = 452
-SEMCGE = 474
-SIFJBI = 269
-SIRYXB = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-SJMCBF = 5
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-SKSOKP = "".join(chr(c) for c in [76, 79])
-SKWIVD = 338
-SNQLNM = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SOOQNR = 9
-SPBWJY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-SPFTSI = 351
-SSAKQX = "".join(chr(c) for c in [80, 111, 119, 101, 114, 117, 112])
-SSUHBV = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-STSEMC = 473
-SUHBVW = "".join(chr(c) for c in [77, 73, 65])
-TACCPQ = 354
-TATDZX = 464
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TDZXNQ = 465
-TFMNHT = 327
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 49])
-THECVY = "".join(chr(c) for c in [83, 49])
-TIACQF = "".join(chr(c) for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107])
-TIDUBS = 320
-TIXQVX = 477
-TMFZDG = 468
-TOPHUG = 333
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-TSIFJB = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-TYEKCW = "".join(chr(c) for c in [80, 49])
-TYIYWS = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 73, 68])
-UBSSUH = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-UGSELH = 451
-UGTYIY = "".join(chr(c) for c in [70, 117, 108, 108])
-UHBVWV = "".join(chr(c) for c in [68, 74, 83, 52])
-UIKFWR = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-UJUTYE = 303
-UNBLKX = 302
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-UNXNKM = 346
-UOJRJH = "".join(chr(c) for c in [85, 100, 80, 50])
-UQEXLS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116])
-USOOQN = "".join(chr(c) for c in [85, 100, 80, 53])
-USPBWJ = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-UTOPHU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-UTYEKC = 304
-UXFEFJ = "".join(chr(c) for c in [79, 51])
-UYNQJY = "".join(chr(c) for c in [79, 110, 122, 101, 110])
-VDNQGV = 341
-VDQLAI = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-VHFTHE = "".join(chr(c) for c in [77, 101, 110, 117])
-VKZILX = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121, 69, 114, 114])
-VLASSA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-VUBYGD = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-VUNXNK = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 108])
-VWVUBY = "".join(chr(c) for c in [75, 54, 48, 48])
-VXOIHB = 479
-VYFCRT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VYYPIP = "".join(chr(c) for c in [72, 51])
-WAJVDQ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-WAONPY = "".join(chr(c) for c in [80, 50])
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-WIVDNQ = 339
-WJYKLG = 311
-WMNZMJ = "".join(chr(c) for c in [73, 68, 76, 69])
-WRKINE = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-WSKWIV = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 108])
-WVUBYG = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-XBQFYL = 265
-XCHWDA = 456
-XEKVKZ = "".join(
-    chr(c)
-    for c in [82, 104, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-XFEFJT = 3
-XIBHZV = 256
-XLSXUJ = 306
-XNKMLO = 347
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-XPICXQ = 280
-XQGLRA = "".join(chr(c) for c in [79, 85, 84, 52, 65, 82, 101, 97, 100])
-XQIEFX = 284
-XQVXOI = 478
-XTIACQ = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XUJUTY = "".join(chr(c) for c in [85, 100, 86, 83, 80, 49])
-XWAJVD = "".join(chr(c) for c in [82, 104, 72, 114, 72, 76])
-XYBQSN = 278
-YBQSNQ = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-YEKCWA = 356
-YFCRTF = 324
-YGDSBD = 322
-YIYWSK = 335
-YKLGQP = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-YLJUIK = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-YMOUNB = "".join(chr(c) for c in [86, 115, 112, 49, 77, 105, 110])
-YNQJYM = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [70, 114])
-YWSKWI = 337
-YXBQFY = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-YYLIUX = 355
-YYPIPI = "".join(chr(c) for c in [72, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ZILXWA = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-ZMJIGY = "".join(chr(c) for c in [78, 69, 87])
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-ZUQEXL = 1
-ZXNQTM = 466
-ACCPQI = [BSKSOK, BSKSOK, CBFEGZ, FEGZUQ]
-BXIBHZ = [
-    BXYBQS,
-    IBXYBQ,
-    EJNIBX,
-    BQFYLJ,
-    NEJNIB,
-    NQLNMH,
-    YBQSNQ,
-    BQSNQL,
-    QLNMHX,
-    MHXEKV,
-    VKZILX,
-    JNIBXY,
-    NIBXYB,
-    NMHXEK,
-    INEJNI,
-    AJVDQL,
-    SNQLNM,
-    RKINEJ,
-    LNMHXE,
-    QSNQLN,
-]
-CWAONP = [BSKSOK, EKCWAO, KCWAON]
-DJQRJJ = [GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ]
-EGZUQE = [BSKSOK, CBFEGZ, BFEGZU, FEGZUQ]
-GTYIYW = [HUGTYI, UGTYIY]
-HBXIBH = [
-    THBSKS,
-    UOJRJH,
-    JRJHIU,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    RSJMCB,
-    JMCBFE,
-    MCBFEG,
-    GZUQEX,
-    UQEXLS,
-    EXLSXU,
-    XUJUTY,
-    JUTYEK,
-]
-IHBXIB = [
-    TYEKCW,
-    WAONPY,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    LIUXFE,
-    IUXFEF,
-    UXFEFJ,
-    FEFJTA,
-    EFJTAC,
-    JTACCP,
-    CCPQIP,
-    CPQIPO,
-    POUYNQ,
-    OUYNQJ,
-    UYNQJY,
-    YNQJYM,
-    QJYMOU,
-    YMOUNB,
-    OUNBLK,
-    OIHBXI,
-]
-IPOUYN = [PQIPOU, QIPOUY]
-JIGYOU = [WMNZMJ, MNZMJI, NZMJIG, ZMJIGY, MJIGYO]
-JJJVYF = [QRJJJV, RJJJVY]
-QNRSJM = [BSKSOK, OQNRSJ]
-RJHIUS = [BSKSOK, KSOKPH]
-SAKQXP = [
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-]
-SOKPHU = [BSKSOK, SKSOKP, KSOKPH]
-SXUJUT = [BSKSOK, SKSOKP, LSXUJU, KSOKPH]
-UBYGDS = [
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-]
-WBSIRY = [OAWBSI, SKSOKP, LSXUJU, KSOKPH, AWBSIR]
-XOIHBX = []
-XSJWMN = [LKXSJW, KXSJWM]
-YLIUXF = [BSKSOK, EKCWAO]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -745,253 +19,540 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return PHUOJR
+        return 4
 
     @property
     def begin(self):
-        return XIBHZV
+        return 256
 
     @property
     def end(self):
-        return IBHZVO
+        return 479
 
     @property
     def all_device_keys(self):
-        return IHBXIB
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "FAN",
+            "Fb",
+            "AlwayOn",
+            "TvLift",
+            "SpkrLift",
+            "Sani",
+            "Onzen",
+            "RhDuty",
+            "Vsp1Front",
+            "Vsp1Min",
+            "VSP3Front",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return HBXIBH
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdTvLift",
+            "UdSpkrLift",
+            "UdFb",
+            "UdL120",
+            "UdQuiet",
+            "UdLi",
+            "UdVSP1",
+            "UdVSP3",
+        ]
 
     @property
     def error_keys(self):
-        return BXIBHZ
+        return [
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "RhDutyErr",
+            "ThermistanceErr",
+            "LearnPhaseErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "TempNotValid",
+            "RhCommErr",
+            "FreqDetecErr",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoTempStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoByteStructAccessor(self.struct, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoEnumStructAccessor(
-                self.struct, VHFTHE, HFTHEC, None, SAKQXP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 261, None
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoWordStructAccessor(self.struct, QXPICX, XPICXQ, None),
-            PICXQI: GeckoWordStructAccessor(self.struct, PICXQI, ICXQIE, None),
-            CXQIEF: GeckoWordStructAccessor(self.struct, CXQIEF, XQIEFX, None),
-            QIEFXQ: GeckoWordStructAccessor(self.struct, QIEFXQ, IEFXQG, None),
-            EFXQGL: GeckoWordStructAccessor(self.struct, EFXQGL, FXQGLR, None),
-            XQGLRA: GeckoWordStructAccessor(self.struct, XQGLRA, QGLRAH, None),
-            GLRAHE: GeckoWordStructAccessor(self.struct, GLRAHE, LRAHEO, None),
-            RAHEOC: GeckoWordStructAccessor(self.struct, RAHEOC, AHEOCT, None),
-            HEOCTH: GeckoWordStructAccessor(self.struct, HEOCTH, EOCTHB, None),
-            OCTHBS: GeckoWordStructAccessor(self.struct, OCTHBS, CTHBSK, None),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, OKPHUO, SOKPHU, KPHUOJ, PHUOJR, HUOJRJ
+            "RhTriacTemp": GeckoTempStructAccessor(
+                self.struct, "RhTriacTemp", 263, None
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, HBSKSO, OJRJHI, SOKPHU, KPHUOJ, PHUOJR, HUOJRJ
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                353,
+                None,
+                [
+                    "NORMAL",
+                    "S1",
+                    "S2",
+                    "H1",
+                    "H2",
+                    "H3",
+                    "H4",
+                    "Fr",
+                    "LearnFail",
+                    "Learning",
+                    "BreakerSelect",
+                    "PhaseSelect",
+                    "ConfigSelect",
+                    "StickBank",
+                    "K600Upload",
+                    "Powerup",
+                ],
+                None,
+                None,
+                None,
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, HBSKSO, JHIUSO, RJHIUS, KPHUOJ, KPHUOJ, HUOJRJ
+            "HeaterPhaseSign": GeckoByteStructAccessor(
+                self.struct, "HeaterPhaseSign", 300, None
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HBSKSO, IUSOOQ, RJHIUS, KPHUOJ, KPHUOJ, HUOJRJ
+            "OUT1ARead": GeckoWordStructAccessor(self.struct, "OUT1ARead", 280, None),
+            "OUT1BRead": GeckoWordStructAccessor(self.struct, "OUT1BRead", 282, None),
+            "OUT2ARead": GeckoWordStructAccessor(self.struct, "OUT2ARead", 284, None),
+            "OUT2BRead": GeckoWordStructAccessor(self.struct, "OUT2BRead", 286, None),
+            "OUT3ARead": GeckoWordStructAccessor(self.struct, "OUT3ARead", 288, None),
+            "OUT4ARead": GeckoWordStructAccessor(self.struct, "OUT4ARead", 290, None),
+            "OUT5ARead": GeckoWordStructAccessor(self.struct, "OUT5ARead", 292, None),
+            "OUT6ARead": GeckoWordStructAccessor(self.struct, "OUT6ARead", 294, None),
+            "OUT7ARead": GeckoWordStructAccessor(self.struct, "OUT7ARead", 296, None),
+            "HeaterRead": GeckoWordStructAccessor(self.struct, "HeaterRead", 298, None),
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 275, 14, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HBSKSO, SOOQNR, RJHIUS, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 275, 12, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HBSKSO, NRSJMC, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 275, 11, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, HBSKSO, SJMCBF, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 275, 10, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, HBSKSO, PHUOJR, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 275, 9, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, HBSKSO, KPHUOJ, EGZUQE, KPHUOJ, PHUOJR, HUOJRJ
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, HBSKSO, ZUQEXL, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdTvLift": GeckoEnumStructAccessor(
+                self.struct, "UdTvLift", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            UQEXLS: GeckoBoolStructAccessor(
-                self.struct, UQEXLS, HBSKSO, QEXLSX, HUOJRJ
+            "UdSpkrLift": GeckoEnumStructAccessor(
+                self.struct, "UdSpkrLift", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, QEXLSX, SXUJUT, None, PHUOJR, HUOJRJ
+            "UdFb": GeckoEnumStructAccessor(
+                self.struct, "UdFb", 275, 2, ["OFF", "FIX", "NA", "SCAN"], 2, 4, "ALL"
             ),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, HUOJRJ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, HUOJRJ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, QEXLSX, CWAONP, None, PHUOJR, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, YEKCWA, KPHUOJ, CWAONP, None, PHUOJR, None
+            "UdQuiet": GeckoBoolStructAccessor(self.struct, "UdQuiet", 275, 0, "ALL"),
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 306, 0, ["OFF", "LO", "MED", "HI"], None, 4, "ALL"
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, YEKCWA, PHUOJR, CWAONP, None, PHUOJR, None
+            "UdVSP1": GeckoByteStructAccessor(self.struct, "UdVSP1", 303, "ALL"),
+            "UdVSP3": GeckoByteStructAccessor(self.struct, "UdVSP3", 304, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 356, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, YEKCWA, NPYYLI, CWAONP, None, PHUOJR, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 356, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, YYLIUX, QEXLSX, YLIUXF, None, KPHUOJ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 356, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, YYLIUX, ZUQEXL, QNRSJM, None, KPHUOJ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 356, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, YYLIUX, KPHUOJ, QNRSJM, None, KPHUOJ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 355, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, YYLIUX, XFEFJT, QNRSJM, None, KPHUOJ, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 355, 1, ["OFF", "ON"], None, 2, None
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, YYLIUX, PHUOJR, QNRSJM, None, KPHUOJ, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 355, 2, ["OFF", "ON"], None, 2, None
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YYLIUX, FJTACC, QNRSJM, None, KPHUOJ, None
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 355, 3, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, QEXLSX, ACCPQI, None, PHUOJR, None
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 355, 4, ["OFF", "ON"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, TACCPQ, KPHUOJ, QNRSJM, None, KPHUOJ, None
+            "FAN": GeckoEnumStructAccessor(
+                self.struct, "FAN", 355, 7, ["OFF", "ON"], None, 2, None
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, TACCPQ, XFEFJT, IPOUYN, None, KPHUOJ, None
+            "Fb": GeckoEnumStructAccessor(
+                self.struct, "Fb", 354, 0, ["OFF", "OFF", "FIX", "SCAN"], None, 4, None
             ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, TACCPQ, PHUOJR, IPOUYN, None, KPHUOJ, None
+            "AlwayOn": GeckoEnumStructAccessor(
+                self.struct, "AlwayOn", 354, 2, ["OFF", "ON"], None, 2, None
             ),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, TACCPQ, SJMCBF, QNRSJM, None, KPHUOJ, None
+            "TvLift": GeckoEnumStructAccessor(
+                self.struct, "TvLift", 354, 3, ["DOWN", "UP"], None, 2, None
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, TACCPQ, NPYYLI, QNRSJM, None, KPHUOJ, None
+            "SpkrLift": GeckoEnumStructAccessor(
+                self.struct, "SpkrLift", 354, 4, ["DOWN", "UP"], None, 2, None
             ),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, None),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, None),
-            YMOUNB: GeckoByteStructAccessor(self.struct, YMOUNB, MOUNBL, None),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, None),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, BLKXSJ, QEXLSX, XSJWMN, None, KPHUOJ, HUOJRJ
+            "Sani": GeckoEnumStructAccessor(
+                self.struct, "Sani", 354, 5, ["OFF", "ON"], None, 2, None
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, JIGYOU, None, None, HUOJRJ
+            "Onzen": GeckoEnumStructAccessor(
+                self.struct, "Onzen", 354, 6, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoTimeStructAccessor(self.struct, IGYOUS, GYOUSP, HUOJRJ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, HUOJRJ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, BLKXSJ, ZUQEXL, XSJWMN, None, KPHUOJ, HUOJRJ
+            "RhDuty": GeckoByteStructAccessor(self.struct, "RhDuty", 274, None),
+            "Vsp1Front": GeckoByteStructAccessor(self.struct, "Vsp1Front", 301, None),
+            "Vsp1Min": GeckoByteStructAccessor(self.struct, "Vsp1Min", 305, None),
+            "VSP3Front": GeckoByteStructAccessor(self.struct, "VSP3Front", 302, None),
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                348,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, JIGYOU, None, None, HUOJRJ
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                307,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BWJYKL: GeckoTimeStructAccessor(self.struct, BWJYKL, WJYKLG, HUOJRJ),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, BLKXSJ, KPHUOJ, XSJWMN, None, KPHUOJ, HUOJRJ
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 308, "ALL"
             ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, JIGYOU, None, None, HUOJRJ
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 316, "ALL"
             ),
-            LGQPLS: GeckoTimeStructAccessor(self.struct, LGQPLS, GQPLSP, HUOJRJ),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, HUOJRJ),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, HUOJRJ),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, HUOJRJ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, FJTACC, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, SIFJBI, SJMCBF, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, SIFJBI, PHUOJR, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, BIAMJM, XFEFJT, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, BIAMJM, QEXLSX, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, BIAMJM, ZUQEXL, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, None, None),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, AOAWBS, None, WBSIRY, None, None, None
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                348,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIFJBI, XFEFJT, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, SIFJBI, KPHUOJ, None),
-            IRYXBQ: GeckoTempStructAccessor(self.struct, IRYXBQ, RYXBQF, None),
-            YXBQFY: GeckoTempStructAccessor(self.struct, YXBQFY, XBQFYL, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, ZUQEXL, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, SIFJBI, ZUQEXL, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, SIFJBI, QEXLSX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, JUIKFW, FJTACC, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JUIKFW, NPYYLI, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JUIKFW, SJMCBF, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, QEXLSX, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, FWRKIN, KPHUOJ, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, KINEJN, NPYYLI, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, KINEJN, SJMCBF, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, KINEJN, PHUOJR, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, KINEJN, XFEFJT, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, KINEJN, KPHUOJ, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, KINEJN, ZUQEXL, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, KINEJN, QEXLSX, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, XYBQSN, FJTACC, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, XYBQSN, NPYYLI, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, XYBQSN, SJMCBF, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, XYBQSN, PHUOJR, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, XYBQSN, XFEFJT, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, XYBQSN, KPHUOJ, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, XYBQSN, ZUQEXL, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, XYBQSN, QEXLSX, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, BIAMJM, PHUOJR, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, HXEKVK, FJTACC, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, HXEKVK, XFEFJT, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, HXEKVK, KPHUOJ, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, HXEKVK, QEXLSX, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KZILXW, FJTACC, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, KZILXW, NPYYLI, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, KZILXW, SJMCBF, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, KZILXW, PHUOJR, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, KZILXW, XFEFJT, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, KZILXW, KPHUOJ, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, KZILXW, ZUQEXL, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, KZILXW, QEXLSX, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, DQLAII, FJTACC, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, DQLAII, NPYYLI, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, DQLAII, SJMCBF, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, DQLAII, PHUOJR, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, DQLAII, XFEFJT, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DQLAII, KPHUOJ, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, DQLAII, ZUQEXL, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, DQLAII, QEXLSX, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, PHUOJR, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, BXTIAC, XFEFJT, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, BXTIAC, KPHUOJ, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, BXTIAC, ZUQEXL, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, BXTIAC, QEXLSX, None),
-            CQFFTT: GeckoWordStructAccessor(self.struct, CQFFTT, QFFTTI, None),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, None),
-            IDUBSS: GeckoEnumStructAccessor(
-                self.struct, IDUBSS, DUBSSU, None, UBYGDS, None, None, None
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                310,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, QEXLSX, DJQRJJ, None, PHUOJR, None
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 311, "ALL"
             ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, YGDSBD, KPHUOJ, JJJVYF, None, KPHUOJ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                348,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoWordStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoWordStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoWordStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, GTYIYW, None, KPHUOJ, HUOJRJ
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                313,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TYIYWS: GeckoWordStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, None),
-            KWIVDN: GeckoWordStructAccessor(self.struct, KWIVDN, WIVDNQ, None),
-            IVDNQG: GeckoWordStructAccessor(self.struct, IVDNQG, VDNQGV, None),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 314, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 350, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 351, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 352, "ALL"
+            ),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 269, 7, None),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 269, 5, None),
+            "CleanSuspended": GeckoBoolStructAccessor(
+                self.struct, "CleanSuspended", 269, 4, None
+            ),
+            "CleanSuspendUD": GeckoBoolStructAccessor(
+                self.struct, "CleanSuspendUD", 279, 3, None
+            ),
+            "FiltOT": GeckoBoolStructAccessor(self.struct, "FiltOT", 279, 0, None),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 267, None, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                268,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 269, 3, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 269, 2, None
+            ),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 272, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 265, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 349, 1, None
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 269, 0, None),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KinPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KinPurgeActive", 270, 5, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 271, 0, None
+            ),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 271, 2, None
+            ),
+            "FreqDetecErr": GeckoBoolStructAccessor(
+                self.struct, "FreqDetecErr", 277, 6, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnPhaseErr": GeckoBoolStructAccessor(
+                self.struct, "LearnPhaseErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 278, 4, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "RhCommErr": GeckoBoolStructAccessor(
+                self.struct, "RhCommErr", 257, 7, None
+            ),
+            "RhNotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RhNotEnoughHeat", 257, 3, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 257, 2, None
+            ),
+            "RhLowFlo": GeckoBoolStructAccessor(self.struct, "RhLowFlo", 257, 0, None),
+            "RhDutyErr": GeckoBoolStructAccessor(
+                self.struct, "RhDutyErr", 258, 7, None
+            ),
+            "RhNoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloRetry", 258, 6, None
+            ),
+            "RhNoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloTemp", 258, 5, None
+            ),
+            "RhNoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloXTries", 258, 4, None
+            ),
+            "RhHrHL": GeckoBoolStructAccessor(self.struct, "RhHrHL", 258, 3, None),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 258, 2, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 258, 1, None
+            ),
+            "RhRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RhRegOverHeat", 258, 0, None
+            ),
+            "RhHrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacPr", 259, 7, None
+            ),
+            "RhHrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacOH", 259, 6, None
+            ),
+            "RhSWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhSWTriacOH", 259, 5, None
+            ),
+            "RhHwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHwTriacOH", 259, 4, None
+            ),
+            "RhHrKin": GeckoBoolStructAccessor(self.struct, "RhHrKin", 259, 3, None),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 259, 2, None
+            ),
+            "RhSwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RhSwKinTemp", 259, 1, None
+            ),
+            "RhHWKin": GeckoBoolStructAccessor(self.struct, "RhHWKin", 259, 0, None),
+            "RhHeaterDisabled": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterDisabled", 260, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 260, 3, None
+            ),
+            "RhFloCheck": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheck", 260, 2, None
+            ),
+            "RhHeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterSuspended", 260, 1, None
+            ),
+            "RhFloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheckReady", 260, 0, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 317, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 319, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 320, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                321,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                322,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 322, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 323, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 324, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 325, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 327, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 328, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 329, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 331, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 332, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 333, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                357,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "inThermID": GeckoWordStructAccessor(self.struct, "inThermID", 335, None),
+            "inThermRev": GeckoByteStructAccessor(self.struct, "inThermRev", 337, None),
+            "inThermRel": GeckoByteStructAccessor(self.struct, "inThermRel", 338, None),
+            "inThermCur1KW": GeckoWordStructAccessor(
+                self.struct, "inThermCur1KW", 339, None
+            ),
+            "inThermCurFull": GeckoWordStructAccessor(
+                self.struct, "inThermCurFull", 341, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxm-log-5.py
+++ b/src/geckolib/driver/packs/inxm-log-5.py
@@ -12,748 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [76, 73])
-ACQFFT = "".join(chr(c) for c in [82, 104, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-AFIKJP = 453
-AHEOCT = 294
-AIIDNI = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-AJVDQL = 257
-AKQXPI = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101, 83, 105, 103, 110]
-)
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-AMJMAO = 351
-AOAWBS = 269
-AONPYY = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ASSAKQ = "".join(chr(c) for c in [75, 54, 48, 48, 85, 112, 108, 111, 97, 100])
-ATDZXN = 459
-AWBSIR = "".join(
-    chr(c) for c in [67, 108, 101, 97, 110, 83, 117, 115, 112, 101, 110, 100, 101, 100]
-)
-BDJQRJ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BFEGZU = "".join(chr(c) for c in [78, 65])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-BIAMJM = 350
-BJEUTO = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-BLKXSJ = "".join(chr(c) for c in [79, 110, 122, 101, 110])
-BMJVHF = 263
-BQFYLJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BQNRXC = "".join(chr(c) for c in [67, 70, 71, 49])
-BQSNQL = "".join(
-    chr(c) for c in [70, 114, 101, 113, 68, 101, 116, 101, 99, 69, 114, 114]
-)
-BSIRYX = 279
-BSKSOK = "".join(chr(c) for c in [79, 70, 70])
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        82,
-        104,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-BVWVUB = 319
-BWJYKL = "".join(chr(c) for c in [78, 69, 87])
-BXIBHZ = 476
-BXTIAC = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BYGDSB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-CBFEGZ = "".join(chr(c) for c in [70, 73, 88])
-CCPQIP = "".join(chr(c) for c in [66, 76])
-CGETIX = 470
-CHWDAF = 451
-CPQIPO = "".join(chr(c) for c in [67, 80])
-CQBMJV = 261
-CQFFTT = "".join(chr(c) for c in [82, 104, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-CRTFMN = "".join(chr(c) for c in [54, 52, 75])
-CTHBSK = 298
-CVYYPI = "".join(chr(c) for c in [72, 50])
-CWAONP = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-CXQIEF = "".join(chr(c) for c in [79, 85, 84, 50, 65, 82, 101, 97, 100])
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 53])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-DJQRJJ = "".join(chr(c) for c in [105, 110, 88, 77])
-DNIBXT = "".join(chr(c) for c in [82, 104, 72, 114, 72, 76])
-DQLAII = "".join(chr(c) for c in [82, 104, 76, 111, 119, 70, 108, 111])
-DSBDJQ = "".join(chr(c) for c in [77, 73, 65])
-DSSRUR = 479
-DUBSSU = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-DZXNQT = 460
-EAKSTS = 466
-ECVYYP = "".join(chr(c) for c in [72, 49])
-EFJTAC = "".join(chr(c) for c in [80, 52])
-EFXQGL = "".join(chr(c) for c in [79, 85, 84, 51, 65, 82, 101, 97, 100])
-EJNIBX = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-EKCWAO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-EKVKZI = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-ELHBQN = 347
-EMCGET = 469
-EOCTHB = 296
-ETIXQV = 471
-EUTOPH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-EXLSXU = "".join(chr(c) for c in [85, 100, 76, 105])
-FCRTFM = "".join(chr(c) for c in [52, 56, 75])
-FEFJTA = "".join(chr(c) for c in [80, 51])
-FEGZUQ = "".join(chr(c) for c in [83, 67, 65, 78])
-FFTTID = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 54])
-FJBIAM = 314
-FJTACC = 6
-FMNHTB = "".join(chr(c) for c in [85, 76])
-FTHECV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTSIFJ = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-FTTIDU = "".join(chr(c) for c in [82, 104, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-FWRKIN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-FXQGLR = 288
-FYLJUI = "".join(chr(c) for c in [78, 79])
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-GDSBDJ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-GKEAKS = 465
-GLRAHE = "".join(chr(c) for c in [79, 85, 84, 53, 65, 82, 101, 97, 100])
-GQPLSP = 316
-GSELHB = 346
-GTYIYW = 329
-GVUNXN = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 118])
-GZUQEX = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HBQNRX = 448
-HBSKSO = 275
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-HECVYY = "".join(chr(c) for c in [83, 50])
-HEOCTH = "".join(chr(c) for c in [79, 85, 84, 55, 65, 82, 101, 97, 100])
-HFTHEC = 353
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 52])
-HTBJEU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-HUGTYI = 328
-HUOJRJ = "".join(chr(c) for c in [65, 76, 76])
-HWDAFI = "".join(chr(c) for c in [67, 70, 71, 52])
-HXEKVK = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-HZVOAC = 478
-IACQFF = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-IAMJMA = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-IBHZVO = 477
-IBXTIA = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IBXYBQ = "".join(
-    chr(c) for c in [75, 105, 110, 80, 117, 114, 103, 101, 65, 99, 116, 105, 118, 101]
-)
-ICXQIE = 282
-IDNIBX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-IDUBSS = 260
-IEFXQG = 286
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IGYOUS = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-IHBXIB = 475
-IIDNIB = "".join(chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-IJUGSE = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 118])
-IKFWRK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IKJPUN = 454
-ILXWAJ = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-INEJNI = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-IPIVLA = "".join(chr(c) for c in [76, 101, 97, 114, 110, 105, 110, 103])
-IPOUYN = "".join(chr(c) for c in [76, 49, 50, 48])
-IRYXBQ = "".join(chr(c) for c in [67, 80, 79, 84])
-IUSOOQ = 10
-IUXFEF = "".join(chr(c) for c in [76, 79, 87])
-IVDNQG = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-IVLASS = "".join(chr(c) for c in [80, 104, 97, 115, 101, 83, 101, 108, 101, 99, 116])
-IXQVXO = 472
-IYWSKW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-JEUTOP = 324
-JHIUSO = 11
-JIGYOU = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-JMAOAW = 352
-JMCBFE = "".join(chr(c) for c in [85, 100, 83, 112, 107, 114, 76, 105, 102, 116])
-JNIBXY = 270
-JPUNRJ = 455
-JQRJJJ = "".join(chr(c) for c in [75, 54, 48, 48])
-JRJHIU = "".join(chr(c) for c in [85, 100, 80, 51])
-JTACCP = "".join(chr(c) for c in [80, 53])
-JUGSEL = 345
-JUIKFW = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JUTYEK = "".join(chr(c) for c in [85, 100, 86, 83, 80, 51])
-JVDQLA = "".join(
-    chr(c)
-    for c in [82, 104, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-JVHFTH = 256
-JVYFCR = 322
-JWMNZM = "".join(chr(c) for c in [86, 115, 112, 49, 77, 105, 110])
-JYMOUN = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KCWAON = 359
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-KFWRKI = 272
-KINEJN = 349
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 55])
-KLGQPL = 308
-KMLOIJ = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 70, 117, 108, 108]
-)
-KPHUOJ = 2
-KQXPIC = 300
-KSOKPH = "".join(chr(c) for c in [72, 73])
-KSTSEM = 467
-KVKZIL = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-KWIVDN = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-KXSJWM = 274
-KZILXW = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-LAIIDN = 258
-LASSAK = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-LGQPLS = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-LHBQNR = "".join(chr(c) for c in [67, 70, 71, 48])
-LIUXFE = "".join(chr(c) for c in [72, 73, 71, 72])
-LKXSJW = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121])
-LNMHXE = "".join(
-    chr(c) for c in [76, 101, 97, 114, 110, 80, 104, 97, 115, 101, 69, 114, 114]
-)
-LOIJUG = "".join(chr(c) for c in [75, 54, 48, 48, 73, 68])
-LRAHEO = 292
-LSPFTS = 310
-LSXUJU = "".join(chr(c) for c in [77, 69, 68])
-LXWAJV = "".join(chr(c) for c in [114, 72, 73, 100])
-MAOAWB = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-MCBFEG = "".join(chr(c) for c in [85, 100, 70, 98])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-MFZDGK = 463
-MHXEKV = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-MJIGYO = 348
-MJMAOA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-MJVHFT = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-MLOIJU = 341
-MNHTBJ = "".join(chr(c) for c in [67, 69])
-MNZMJI = "".join(chr(c) for c in [86, 83, 80, 51, 70, 114, 111, 110, 116])
-MOUNBL = "".join(chr(c) for c in [85, 80])
-NBLKXS = "".join(chr(c) for c in [83, 97, 110, 105])
-NEJNIB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-NIBXTI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-NIBXYB = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-NKMLOI = 339
-NMHXEK = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-NPYYLI = "".join(chr(c) for c in [85, 100, 68, 114, 97, 105, 110])
-NQGVUN = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 73, 68])
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 57])
-NRSJMC = 8
-NRXCHW = "".join(chr(c) for c in [67, 70, 71, 50])
-NXNKML = 338
-NZMJIG = 302
-OAWBSI = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-OCTHBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 82, 101, 97, 100])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-OIJUGS = 343
-OJRJHI = 12
-OKPHUO = 14
-ONPYYL = 361
-OOQNRS = "".join(chr(c) for c in [85, 100, 66, 76])
-OPHUGT = 327
-OQNRSJ = "".join(chr(c) for c in [79, 78])
-OUSPBW = 307
-OUYNQJ = 7
-PBWJYK = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-PFTSIF = 311
-PHUGTY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-PHUOJR = 4
-PICXQI = "".join(chr(c) for c in [79, 85, 84, 49, 66, 82, 101, 97, 100])
-PIPIVL = "".join(chr(c) for c in [76, 101, 97, 114, 110, 70, 97, 105, 108])
-PIVLAS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 108, 101, 99, 116]
-)
-PLSPFT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-POUYNQ = "".join(chr(c) for c in [70, 65, 78])
-PQIPOU = "".join(chr(c) for c in [79, 51])
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 56])
-PYYLIU = 362
-QBMJVH = "".join(chr(c) for c in [82, 104, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-QEXLSX = 0
-QFFTTI = "".join(chr(c) for c in [82, 104, 72, 114, 75, 105, 110])
-QFYLJU = 268
-QGLRAH = 290
-QGVUNX = 335
-QIEFXQ = "".join(chr(c) for c in [79, 85, 84, 50, 66, 82, 101, 97, 100])
-QIPOUY = 3
-QJYMOU = "".join(chr(c) for c in [65, 108, 119, 97, 121, 79, 110])
-QLAIID = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121, 69, 114, 114])
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-QNRXCH = 449
-QPLSPF = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-QRJJJV = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-QSNQLN = 277
-QTMFZD = 462
-QVXOIH = 473
-QXPICX = "".join(chr(c) for c in [79, 85, 84, 49, 65, 82, 101, 97, 100])
-RAHEOC = "".join(chr(c) for c in [79, 85, 84, 54, 65, 82, 101, 97, 100])
-RJJJVY = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-RJZTAT = 457
-RKINEJ = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-RSJMCB = "".join(chr(c) for c in [85, 100, 84, 118, 76, 105, 102, 116])
-RXCHWD = 450
-RYXBQF = "".join(chr(c) for c in [68, 114, 97, 105, 110, 110, 105, 110, 103])
-SBDJQR = "".join(chr(c) for c in [68, 74, 83, 52])
-SELHBQ = "".join(chr(c) for c in [75, 54, 48, 48, 80, 114, 111, 116, 111, 99, 111, 108])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-SIFJBI = 313
-SIRYXB = "".join(chr(c) for c in [70, 105, 108, 116, 79, 84])
-SJMCBF = 5
-SJWMNZ = 301
-SKSOKP = "".join(chr(c) for c in [76, 79])
-SKWIVD = 333
-SNQLNM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-SOOQNR = 9
-SPBWJY = "".join(chr(c) for c in [83, 84, 79, 80])
-SPFTSI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-SSAKQX = "".join(chr(c) for c in [80, 111, 119, 101, 114, 117, 112])
-SSUHBV = "".join(
-    chr(c)
-    for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-TACCPQ = 355
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TBJEUT = 323
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TFMNHT = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 49])
-THECVY = "".join(chr(c) for c in [83, 49])
-TIACQF = 259
-TIDUBS = "".join(
-    chr(c)
-    for c in [82, 104, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101, 100]
-)
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-TOPHUG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TSEMCG = 468
-TSIFJB = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-TTIDUB = "".join(chr(c) for c in [82, 104, 72, 87, 75, 105, 110])
-TYEKCW = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-TYIYWS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-UBSSUH = "".join(chr(c) for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107])
-UBYGDS = 321
-UGSELH = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 108])
-UGTYIY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-UHBVWV = 317
-UIKFWR = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-UJUTYE = 303
-UNBLKX = "".join(chr(c) for c in [83, 112, 107, 114, 76, 105, 102, 116])
-UNRJZT = 456
-UNXNKM = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 108])
-UOJRJH = "".join(chr(c) for c in [85, 100, 80, 50])
-UQEXLS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116])
-USOOQN = "".join(chr(c) for c in [85, 100, 80, 53])
-USPBWJ = "".join(chr(c) for c in [73, 68, 76, 69])
-UTOPHU = 325
-UTYEKC = 304
-UYNQJY = "".join(chr(c) for c in [70, 98])
-VDNQGV = "".join(chr(c) for c in [70, 117, 108, 108])
-VDQLAI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-VDSSRU = 256
-VHFTHE = "".join(chr(c) for c in [77, 101, 110, 117])
-VKZILX = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-VLASSA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-VOACMC = 479
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-VUNXNK = 337
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-VYFCRT = "".join(chr(c) for c in [49, 54, 75])
-VYYPIP = "".join(chr(c) for c in [72, 51])
-WAJVDQ = "".join(chr(c) for c in [82, 104, 67, 111, 109, 109, 69, 114, 114])
-WAONPY = 360
-WBSIRY = "".join(
-    chr(c) for c in [67, 108, 101, 97, 110, 83, 117, 115, 112, 101, 110, 100, 85, 68]
-)
-WDAFIK = 452
-WIVDNQ = 357
-WJYKLG = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-WMNZMJ = 305
-WRKINE = 265
-WSKWIV = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-WVUBYG = 320
-XBQFYL = 267
-XCHWDA = "".join(chr(c) for c in [67, 70, 71, 51])
-XEKVKZ = 278
-XFEFJT = "".join(chr(c) for c in [80, 50])
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-XLSXUJ = 306
-XNKMLO = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 49, 75, 87]
-)
-XNQTMF = 461
-XOIHBX = 474
-XPICXQ = 280
-XQGLRA = "".join(chr(c) for c in [79, 85, 84, 52, 65, 82, 101, 97, 100])
-XQIEFX = 284
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-XSJWMN = "".join(chr(c) for c in [86, 115, 112, 49, 70, 114, 111, 110, 116])
-XTIACQ = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-XUJUTY = "".join(chr(c) for c in [85, 100, 86, 83, 80, 49])
-XWAJVD = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-XYBQSN = 271
-YBQSNQ = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YEKCWA = 358
-YFCRTF = "".join(chr(c) for c in [51, 50, 75])
-YGDSBD = "".join(chr(c) for c in [105, 110, 88, 69])
-YIYWSK = 331
-YKLGQP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YLIUXF = 356
-YLJUIK = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-YMOUNB = "".join(chr(c) for c in [68, 79, 87, 78])
-YNQJYM = 354
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [70, 114])
-YWSKWI = 332
-YXBQFY = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [72, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 464
-ZILXWA = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ZTATDZ = 458
-ZUQEXL = 1
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ACCPQI = [BSKSOK, LIUXFE]
-CMCVDS = [
-    YYLIUX,
-    XFEFJT,
-    FEFJTA,
-    EFJTAC,
-    JTACCP,
-    CCPQIP,
-    CPQIPO,
-    PQIPOU,
-    IPOUYN,
-    POUYNQ,
-    UYNQJY,
-    QJYMOU,
-    JYMOUN,
-    UNBLKX,
-    NBLKXS,
-    BLKXSJ,
-    LKXSJW,
-    XSJWMN,
-    JWMNZM,
-    MNZMJI,
-    ACMCVD,
-]
-CVDSSR = [
-    HXEKVK,
-    MHXEKV,
-    QLNMHX,
-    RKINEJ,
-    NQLNMH,
-    ZILXWA,
-    EKVKZI,
-    KVKZIL,
-    ILXWAJ,
-    WAJVDQ,
-    QLAIID,
-    LNMHXE,
-    NMHXEK,
-    XWAJVD,
-    SNQLNM,
-    IBXTIA,
-    KZILXW,
-    BQSNQL,
-    LXWAJV,
-    VKZILX,
-]
-DNQGVU = [IVDNQG, VDNQGV]
-EGZUQE = [BSKSOK, CBFEGZ, BFEGZU, FEGZUQ]
-GYOUSP = [JIGYOU, IGYOUS]
-JJJVYF = [
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-]
-JYKLGQ = [USPBWJ, SPBWJY, PBWJYK, BWJYKL, WJYKLG]
-LJUIKF = [FYLJUI, SKSOKP, LSXUJU, KSOKPH, YLJUIK]
-MCVDSS = [
-    THBSKS,
-    UOJRJH,
-    JRJHIU,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    RSJMCB,
-    JMCBFE,
-    MCBFEG,
-    GZUQEX,
-    UQEXLS,
-    EXLSXU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-]
-NHTBJE = [FMNHTB, MNHTBJ]
-NQJYMO = [BSKSOK, BSKSOK, CBFEGZ, FEGZUQ]
-OACMCV = []
-OUNBLK = [YMOUNB, MOUNBL]
-QNRSJM = [BSKSOK, OQNRSJ]
-RJHIUS = [BSKSOK, KSOKPH]
-RTFMNH = [VYFCRT, YFCRTF, FCRTFM, CRTFMN]
-SAKQXP = [
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-]
-SOKPHU = [BSKSOK, SKSOKP, KSOKPH]
-SXUJUT = [BSKSOK, SKSOKP, LSXUJU, KSOKPH]
-UXFEFJ = [BSKSOK, LIUXFE, IUXFEF]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -761,259 +19,563 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return SJMCBF
+        return 5
 
     @property
     def begin(self):
-        return VDSSRU
+        return 256
 
     @property
     def end(self):
-        return DSSRUR
+        return 479
 
     @property
     def all_device_keys(self):
-        return CMCVDS
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "FAN",
+            "Fb",
+            "AlwayOn",
+            "TvLift",
+            "SpkrLift",
+            "Sani",
+            "Onzen",
+            "RhDuty",
+            "Vsp1Front",
+            "Vsp1Min",
+            "VSP3Front",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return MCVDSS
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdTvLift",
+            "UdSpkrLift",
+            "UdFb",
+            "UdL120",
+            "UdQuiet",
+            "UdLi",
+            "UdVSP1",
+            "UdVSP3",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdDrain",
+        ]
 
     @property
     def error_keys(self):
-        return CVDSSR
+        return [
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "RhDutyErr",
+            "ThermistanceErr",
+            "LearnPhaseErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "TempNotValid",
+            "RhCommErr",
+            "FreqDetecErr",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoTempStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoByteStructAccessor(self.struct, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoEnumStructAccessor(
-                self.struct, VHFTHE, HFTHEC, None, SAKQXP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 261, None
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoWordStructAccessor(self.struct, QXPICX, XPICXQ, None),
-            PICXQI: GeckoWordStructAccessor(self.struct, PICXQI, ICXQIE, None),
-            CXQIEF: GeckoWordStructAccessor(self.struct, CXQIEF, XQIEFX, None),
-            QIEFXQ: GeckoWordStructAccessor(self.struct, QIEFXQ, IEFXQG, None),
-            EFXQGL: GeckoWordStructAccessor(self.struct, EFXQGL, FXQGLR, None),
-            XQGLRA: GeckoWordStructAccessor(self.struct, XQGLRA, QGLRAH, None),
-            GLRAHE: GeckoWordStructAccessor(self.struct, GLRAHE, LRAHEO, None),
-            RAHEOC: GeckoWordStructAccessor(self.struct, RAHEOC, AHEOCT, None),
-            HEOCTH: GeckoWordStructAccessor(self.struct, HEOCTH, EOCTHB, None),
-            OCTHBS: GeckoWordStructAccessor(self.struct, OCTHBS, CTHBSK, None),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, OKPHUO, SOKPHU, KPHUOJ, PHUOJR, HUOJRJ
+            "RhTriacTemp": GeckoTempStructAccessor(
+                self.struct, "RhTriacTemp", 263, None
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, HBSKSO, OJRJHI, SOKPHU, KPHUOJ, PHUOJR, HUOJRJ
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                353,
+                None,
+                [
+                    "NORMAL",
+                    "S1",
+                    "S2",
+                    "H1",
+                    "H2",
+                    "H3",
+                    "H4",
+                    "Fr",
+                    "LearnFail",
+                    "Learning",
+                    "BreakerSelect",
+                    "PhaseSelect",
+                    "ConfigSelect",
+                    "StickBank",
+                    "K600Upload",
+                    "Powerup",
+                ],
+                None,
+                None,
+                None,
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, HBSKSO, JHIUSO, RJHIUS, KPHUOJ, KPHUOJ, HUOJRJ
+            "HeaterPhaseSign": GeckoByteStructAccessor(
+                self.struct, "HeaterPhaseSign", 300, None
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HBSKSO, IUSOOQ, RJHIUS, KPHUOJ, KPHUOJ, HUOJRJ
+            "OUT1ARead": GeckoWordStructAccessor(self.struct, "OUT1ARead", 280, None),
+            "OUT1BRead": GeckoWordStructAccessor(self.struct, "OUT1BRead", 282, None),
+            "OUT2ARead": GeckoWordStructAccessor(self.struct, "OUT2ARead", 284, None),
+            "OUT2BRead": GeckoWordStructAccessor(self.struct, "OUT2BRead", 286, None),
+            "OUT3ARead": GeckoWordStructAccessor(self.struct, "OUT3ARead", 288, None),
+            "OUT4ARead": GeckoWordStructAccessor(self.struct, "OUT4ARead", 290, None),
+            "OUT5ARead": GeckoWordStructAccessor(self.struct, "OUT5ARead", 292, None),
+            "OUT6ARead": GeckoWordStructAccessor(self.struct, "OUT6ARead", 294, None),
+            "OUT7ARead": GeckoWordStructAccessor(self.struct, "OUT7ARead", 296, None),
+            "HeaterRead": GeckoWordStructAccessor(self.struct, "HeaterRead", 298, None),
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 275, 14, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HBSKSO, SOOQNR, RJHIUS, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 275, 12, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HBSKSO, NRSJMC, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 275, 11, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, HBSKSO, SJMCBF, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 275, 10, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, HBSKSO, PHUOJR, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 275, 9, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, HBSKSO, KPHUOJ, EGZUQE, KPHUOJ, PHUOJR, HUOJRJ
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, HBSKSO, ZUQEXL, QNRSJM, KPHUOJ, KPHUOJ, HUOJRJ
+            "UdTvLift": GeckoEnumStructAccessor(
+                self.struct, "UdTvLift", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            UQEXLS: GeckoBoolStructAccessor(
-                self.struct, UQEXLS, HBSKSO, QEXLSX, HUOJRJ
+            "UdSpkrLift": GeckoEnumStructAccessor(
+                self.struct, "UdSpkrLift", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, QEXLSX, SXUJUT, None, PHUOJR, HUOJRJ
+            "UdFb": GeckoEnumStructAccessor(
+                self.struct, "UdFb", 275, 2, ["OFF", "FIX", "NA", "SCAN"], 2, 4, "ALL"
             ),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, HUOJRJ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, HUOJRJ),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, HUOJRJ),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, HUOJRJ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, HUOJRJ),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, HUOJRJ),
-            NPYYLI: GeckoBoolStructAccessor(self.struct, NPYYLI, PYYLIU, None, HUOJRJ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, QEXLSX, UXFEFJ, None, PHUOJR, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            XFEFJT: GeckoEnumStructAccessor(
-                self.struct, XFEFJT, YLIUXF, KPHUOJ, UXFEFJ, None, PHUOJR, None
+            "UdQuiet": GeckoBoolStructAccessor(self.struct, "UdQuiet", 275, 0, "ALL"),
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 306, 0, ["OFF", "LO", "MED", "HI"], None, 4, "ALL"
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, YLIUXF, PHUOJR, UXFEFJ, None, PHUOJR, None
+            "UdVSP1": GeckoByteStructAccessor(self.struct, "UdVSP1", 303, "ALL"),
+            "UdVSP3": GeckoByteStructAccessor(self.struct, "UdVSP3", 304, "ALL"),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 358, "ALL"
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YLIUXF, FJTACC, UXFEFJ, None, PHUOJR, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 359, "ALL"
             ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, QEXLSX, ACCPQI, None, KPHUOJ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 360, "ALL"
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, TACCPQ, ZUQEXL, QNRSJM, None, KPHUOJ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 361, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, TACCPQ, KPHUOJ, QNRSJM, None, KPHUOJ, None
+            "UdDrain": GeckoBoolStructAccessor(
+                self.struct, "UdDrain", 362, None, "ALL"
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, TACCPQ, QIPOUY, QNRSJM, None, KPHUOJ, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 356, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, TACCPQ, PHUOJR, QNRSJM, None, KPHUOJ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 356, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, TACCPQ, OUYNQJ, QNRSJM, None, KPHUOJ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 356, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, QEXLSX, NQJYMO, None, PHUOJR, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 356, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, YNQJYM, KPHUOJ, QNRSJM, None, KPHUOJ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 355, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YNQJYM, QIPOUY, OUNBLK, None, KPHUOJ, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 355, 1, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, YNQJYM, PHUOJR, OUNBLK, None, KPHUOJ, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 355, 2, ["OFF", "ON"], None, 2, None
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, YNQJYM, SJMCBF, QNRSJM, None, KPHUOJ, None
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 355, 3, ["OFF", "ON"], None, 2, None
             ),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, YNQJYM, FJTACC, QNRSJM, None, KPHUOJ, None
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 355, 4, ["OFF", "ON"], None, 2, None
             ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, None),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, QEXLSX, GYOUSP, None, KPHUOJ, HUOJRJ
+            "FAN": GeckoEnumStructAccessor(
+                self.struct, "FAN", 355, 7, ["OFF", "ON"], None, 2, None
             ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, JYKLGQ, None, None, HUOJRJ
+            "Fb": GeckoEnumStructAccessor(
+                self.struct, "Fb", 354, 0, ["OFF", "OFF", "FIX", "SCAN"], None, 4, None
             ),
-            YKLGQP: GeckoTimeStructAccessor(self.struct, YKLGQP, KLGQPL, HUOJRJ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, HUOJRJ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, MJIGYO, ZUQEXL, GYOUSP, None, KPHUOJ, HUOJRJ
+            "AlwayOn": GeckoEnumStructAccessor(
+                self.struct, "AlwayOn", 354, 2, ["OFF", "ON"], None, 2, None
             ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, JYKLGQ, None, None, HUOJRJ
+            "TvLift": GeckoEnumStructAccessor(
+                self.struct, "TvLift", 354, 3, ["DOWN", "UP"], None, 2, None
             ),
-            SPFTSI: GeckoTimeStructAccessor(self.struct, SPFTSI, PFTSIF, HUOJRJ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, MJIGYO, KPHUOJ, GYOUSP, None, KPHUOJ, HUOJRJ
+            "SpkrLift": GeckoEnumStructAccessor(
+                self.struct, "SpkrLift", 354, 4, ["DOWN", "UP"], None, 2, None
             ),
-            TSIFJB: GeckoEnumStructAccessor(
-                self.struct, TSIFJB, SIFJBI, None, JYKLGQ, None, None, HUOJRJ
+            "Sani": GeckoEnumStructAccessor(
+                self.struct, "Sani", 354, 5, ["OFF", "ON"], None, 2, None
             ),
-            IFJBIA: GeckoTimeStructAccessor(self.struct, IFJBIA, FJBIAM, HUOJRJ),
-            JBIAMJ: GeckoByteStructAccessor(self.struct, JBIAMJ, BIAMJM, HUOJRJ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, HUOJRJ),
-            MJMAOA: GeckoByteStructAccessor(self.struct, MJMAOA, JMAOAW, HUOJRJ),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, OUYNQJ, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, AOAWBS, SJMCBF, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, AOAWBS, PHUOJR, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, QIPOUY, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, BSIRYX, QEXLSX, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, BSIRYX, ZUQEXL, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, BSIRYX, OUYNQJ, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, None, None),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, LJUIKF, None, None, None
+            "Onzen": GeckoEnumStructAccessor(
+                self.struct, "Onzen", 354, 6, ["OFF", "ON"], None, 2, None
             ),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, AOAWBS, QIPOUY, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, AOAWBS, KPHUOJ, None),
-            IKFWRK: GeckoTempStructAccessor(self.struct, IKFWRK, KFWRKI, None),
-            FWRKIN: GeckoTempStructAccessor(self.struct, FWRKIN, WRKINE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, KINEJN, ZUQEXL, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, AOAWBS, ZUQEXL, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, AOAWBS, QEXLSX, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, JNIBXY, OUYNQJ, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, JNIBXY, FJTACC, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, JNIBXY, SJMCBF, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, XYBQSN, QEXLSX, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, XYBQSN, KPHUOJ, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, QSNQLN, FJTACC, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, QSNQLN, SJMCBF, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QSNQLN, PHUOJR, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, QSNQLN, QIPOUY, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, QSNQLN, KPHUOJ, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, QSNQLN, ZUQEXL, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, QSNQLN, QEXLSX, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, XEKVKZ, OUYNQJ, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, XEKVKZ, FJTACC, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, XEKVKZ, SJMCBF, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, XEKVKZ, PHUOJR, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, XEKVKZ, QIPOUY, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, XEKVKZ, KPHUOJ, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, XEKVKZ, ZUQEXL, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, XEKVKZ, QEXLSX, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, BSIRYX, PHUOJR, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, OUYNQJ, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, AJVDQL, QIPOUY, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, AJVDQL, KPHUOJ, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, AJVDQL, QEXLSX, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LAIIDN, OUYNQJ, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, LAIIDN, FJTACC, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, LAIIDN, SJMCBF, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, LAIIDN, PHUOJR, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, LAIIDN, QIPOUY, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, LAIIDN, KPHUOJ, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, LAIIDN, ZUQEXL, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, LAIIDN, QEXLSX, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, TIACQF, OUYNQJ, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, TIACQF, FJTACC, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, TIACQF, SJMCBF, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, TIACQF, PHUOJR, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, TIACQF, QIPOUY, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, TIACQF, KPHUOJ, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, TIACQF, ZUQEXL, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, TIACQF, QEXLSX, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, IDUBSS, PHUOJR, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, IDUBSS, QIPOUY, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, IDUBSS, KPHUOJ, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, IDUBSS, ZUQEXL, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, IDUBSS, QEXLSX, None),
-            SUHBVW: GeckoWordStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, JJJVYF, None, None, None
+            "RhDuty": GeckoByteStructAccessor(self.struct, "RhDuty", 274, None),
+            "Vsp1Front": GeckoByteStructAccessor(self.struct, "Vsp1Front", 301, None),
+            "Vsp1Min": GeckoByteStructAccessor(self.struct, "Vsp1Min", 305, None),
+            "VSP3Front": GeckoByteStructAccessor(self.struct, "VSP3Front", 302, None),
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                348,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, JVYFCR, QEXLSX, RTFMNH, None, PHUOJR, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                307,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, JVYFCR, KPHUOJ, NHTBJE, None, KPHUOJ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 308, "ALL"
             ),
-            HTBJEU: GeckoByteStructAccessor(self.struct, HTBJEU, TBJEUT, None),
-            BJEUTO: GeckoByteStructAccessor(self.struct, BJEUTO, JEUTOP, None),
-            EUTOPH: GeckoWordStructAccessor(self.struct, EUTOPH, UTOPHU, None),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, None),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, None),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoWordStructAccessor(self.struct, WSKWIV, SKWIVD, None),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, DNQGVU, None, KPHUOJ, HUOJRJ
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 316, "ALL"
             ),
-            NQGVUN: GeckoWordStructAccessor(self.struct, NQGVUN, QGVUNX, None),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoWordStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoWordStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                348,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                310,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 311, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                348,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                313,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 314, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 350, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 351, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 352, "ALL"
+            ),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 269, 7, None),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 269, 5, None),
+            "CleanSuspended": GeckoBoolStructAccessor(
+                self.struct, "CleanSuspended", 269, 4, None
+            ),
+            "CleanSuspendUD": GeckoBoolStructAccessor(
+                self.struct, "CleanSuspendUD", 279, 3, None
+            ),
+            "FiltOT": GeckoBoolStructAccessor(self.struct, "FiltOT", 279, 0, None),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "Drainning": GeckoBoolStructAccessor(
+                self.struct, "Drainning", 279, 7, None
+            ),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 267, None, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                268,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 269, 3, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 269, 2, None
+            ),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 272, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 265, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 349, 1, None
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 269, 0, None),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KinPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KinPurgeActive", 270, 5, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 271, 0, None
+            ),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 271, 2, None
+            ),
+            "FreqDetecErr": GeckoBoolStructAccessor(
+                self.struct, "FreqDetecErr", 277, 6, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnPhaseErr": GeckoBoolStructAccessor(
+                self.struct, "LearnPhaseErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 278, 4, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "RhCommErr": GeckoBoolStructAccessor(
+                self.struct, "RhCommErr", 257, 7, None
+            ),
+            "RhNotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RhNotEnoughHeat", 257, 3, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 257, 2, None
+            ),
+            "RhLowFlo": GeckoBoolStructAccessor(self.struct, "RhLowFlo", 257, 0, None),
+            "RhDutyErr": GeckoBoolStructAccessor(
+                self.struct, "RhDutyErr", 258, 7, None
+            ),
+            "RhNoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloRetry", 258, 6, None
+            ),
+            "RhNoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloTemp", 258, 5, None
+            ),
+            "RhNoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloXTries", 258, 4, None
+            ),
+            "RhHrHL": GeckoBoolStructAccessor(self.struct, "RhHrHL", 258, 3, None),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 258, 2, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 258, 1, None
+            ),
+            "RhRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RhRegOverHeat", 258, 0, None
+            ),
+            "RhHrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacPr", 259, 7, None
+            ),
+            "RhHrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacOH", 259, 6, None
+            ),
+            "RhSWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhSWTriacOH", 259, 5, None
+            ),
+            "RhHwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHwTriacOH", 259, 4, None
+            ),
+            "RhHrKin": GeckoBoolStructAccessor(self.struct, "RhHrKin", 259, 3, None),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 259, 2, None
+            ),
+            "RhSwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RhSwKinTemp", 259, 1, None
+            ),
+            "RhHWKin": GeckoBoolStructAccessor(self.struct, "RhHWKin", 259, 0, None),
+            "RhHeaterDisabled": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterDisabled", 260, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 260, 3, None
+            ),
+            "RhFloCheck": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheck", 260, 2, None
+            ),
+            "RhHeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterSuspended", 260, 1, None
+            ),
+            "RhFloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheckReady", 260, 0, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 317, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 319, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 320, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                321,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                322,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 322, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 323, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 324, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 325, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 327, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 328, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 329, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 331, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 332, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 333, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                357,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "inThermID": GeckoWordStructAccessor(self.struct, "inThermID", 335, None),
+            "inThermRev": GeckoByteStructAccessor(self.struct, "inThermRev", 337, None),
+            "inThermRel": GeckoByteStructAccessor(self.struct, "inThermRel", 338, None),
+            "inThermCur1KW": GeckoWordStructAccessor(
+                self.struct, "inThermCur1KW", 339, None
+            ),
+            "inThermCurFull": GeckoWordStructAccessor(
+                self.struct, "inThermCurFull", 341, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxm-log-6.py
+++ b/src/geckolib/driver/packs/inxm-log-6.py
@@ -12,781 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [80, 50])
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-ACQFFT = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 48])
-AHEOCT = 294
-AIIDNI = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-AKQXPI = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101, 83, 105, 103, 110]
-)
-AKSTSE = 461
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-AOAWBS = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-AONPYY = "".join(chr(c) for c in [85, 100, 86, 83, 80, 51])
-ASSAKQ = "".join(chr(c) for c in [75, 54, 48, 48, 85, 112, 108, 111, 97, 100])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 54])
-AWBSIR = 313
-AZMKQT = "".join(chr(c) for c in [76, 73])
-BDJQRJ = 319
-BHZVOA = 472
-BIAMJM = 316
-BJEUTO = "".join(chr(c) for c in [49, 54, 75])
-BLKXSJ = "".join(chr(c) for c in [68, 79, 87, 78])
-BMJVHF = 263
-BQFYLJ = 352
-BQNRXC = 341
-BQSNQL = 270
-BSIRYX = 314
-BSKSOK = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-BSSUHB = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BVWVUB = "".join(chr(c) for c in [82, 104, 72, 114, 75, 105, 110])
-BWJYKL = "".join(chr(c) for c in [70, 85, 76, 76])
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-BXTIAC = 258
-BXYBQS = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        82,
-        104,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [79, 78])
-CCPQIP = "".join(chr(c) for c in [80, 51])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-CHWDAF = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 108])
-CMCVDS = 475
-CPQIPO = "".join(chr(c) for c in [80, 52])
-CQBMJV = 261
-CQFFTT = 259
-CRTFMN = "".join(chr(c) for c in [105, 110, 88, 77])
-CTHBSK = 298
-CVDSSR = 476
-CVYYPI = "".join(chr(c) for c in [72, 50])
-CWAONP = "".join(chr(c) for c in [85, 100, 86, 83, 80, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 50, 65, 82, 101, 97, 100])
-DAFIKJ = 347
-DGKEAK = 459
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-DNIBXT = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-DNQGVU = 329
-DQLAII = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-DSBDJQ = 317
-DSSRUR = 477
-DUBSSU = "".join(chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 55])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ECVYYP = "".join(chr(c) for c in [72, 49])
-EFJTAC = 356
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 51, 65, 82, 101, 97, 100])
-EGZUQE = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-EJNIBX = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-EKCWAO = "".join(chr(c) for c in [83, 67, 65, 78])
-EKVKZI = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-ELHBQN = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 49, 75, 87]
-)
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-EOCTHB = 296
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-EUTOPH = "".join(chr(c) for c in [52, 56, 75])
-FCRTFM = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-FEFJTA = "".join(chr(c) for c in [80, 49])
-FEGZUQ = 8
-FFTTID = "".join(chr(c) for c in [82, 104, 67, 111, 109, 109, 69, 114, 114])
-FIKJPU = 448
-FJBIAM = 308
-FJTACC = "".join(chr(c) for c in [72, 73, 71, 72])
-FMNHTB = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-FTHECV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTSIFJ = "".join(chr(c) for c in [78, 69, 87])
-FTTIDU = "".join(
-    chr(c)
-    for c in [82, 104, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-FWRKIN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-FXQGLR = 288
-FYLJUI = 269
-FZDGKE = 458
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-GETIXQ = 465
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 53, 65, 82, 101, 97, 100])
-GSELHB = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 108])
-GTYIYW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-GYOUSP = "".join(chr(c) for c in [86, 83, 80, 51, 70, 114, 111, 110, 116])
-GZUQEX = 1
-HBQNRX = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 70, 117, 108, 108]
-)
-HBSKSO = 362
-HBVWVU = "".join(chr(c) for c in [82, 104, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-HBXIBH = 470
-HECVYY = "".join(chr(c) for c in [83, 50])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 55, 65, 82, 101, 97, 100])
-HFTHEC = 353
-HIUSOO = 2
-HTBJEU = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-HUGTYI = "".join(chr(c) for c in [67, 69])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 80, 49])
-HWDAFI = 346
-HXEKVK = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-IACQFF = 257
-IAMJMA = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-IBXTIA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IBXYBQ = 272
-ICXQIE = 282
-IDNIBX = "".join(chr(c) for c in [114, 72, 73, 100])
-IDUBSS = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-IEFXQG = 286
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IGYOUS = 305
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IIDNIB = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-IJUGSE = 335
-IKFWRK = "".join(chr(c) for c in [67, 80, 79, 84])
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 49])
-ILXWAJ = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-INEJNI = 268
-IPIVLA = "".join(chr(c) for c in [76, 101, 97, 114, 110, 105, 110, 103])
-IPOUYN = 355
-IRYXBQ = 350
-IUSOOQ = 4
-IUXFEF = 360
-IVDNQG = 323
-IVLASS = "".join(chr(c) for c in [80, 104, 97, 115, 101, 83, 101, 108, 101, 99, 116])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-IYWSKW = 327
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [51, 50, 75])
-JHIUSO = 14
-JIGYOU = "".join(chr(c) for c in [86, 115, 112, 49, 77, 105, 110])
-JJJVYF = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-JJVYFC = "".join(chr(c) for c in [105, 110, 88, 69])
-JMAOAW = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-JMCBFE = 9
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 50])
-JQRJJJ = 320
-JRJHIU = "".join(chr(c) for c in [72, 73])
-JTACCP = "".join(chr(c) for c in [76, 79, 87])
-JUGSEL = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 118])
-JUIKFW = 279
-JUTYEK = "".join(chr(c) for c in [85, 100, 83, 112, 107, 114, 76, 105, 102, 116])
-JVDQLA = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-JVHFTH = 256
-JVYFCR = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JWMNZM = "".join(chr(c) for c in [79, 110, 122, 101, 110])
-JYKLGQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-JYMOUN = "".join(chr(c) for c in [70, 65, 78])
-JZTATD = 452
-KEAKST = 460
-KFWRKI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KINEJN = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-KJPUNR = 449
-KLGQPL = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-KMLOIJ = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-KQXPIC = 300
-KSOKPH = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-KVKZIL = 277
-KWIVDN = 324
-KZILXW = 278
-LAIIDN = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-LASSAK = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-LGQPLS = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-LHBQNR = 339
-LIUXFE = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-LJUIKF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-LKXSJW = "".join(chr(c) for c in [85, 80])
-LNMHXE = 271
-LRAHEO = 292
-LSPFTS = "".join(chr(c) for c in [73, 68, 76, 69])
-LSXUJU = "".join(chr(c) for c in [85, 100, 86, 97, 108, 118, 101])
-LXWAJV = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-MAOAWB = 311
-MCBFEG = "".join(chr(c) for c in [85, 100, 66, 76])
-MCGETI = 464
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-MHXEKV = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-MJIGYO = 301
-MJMAOA = 310
-MJVHFT = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-MLOIJU = "".join(chr(c) for c in [70, 117, 108, 108])
-MNHTBJ = "".join(chr(c) for c in [105, 110, 89, 84])
-MNZMJI = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121])
-MOUNBL = 354
-NBLKXS = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-NEJNIB = "".join(chr(c) for c in [78, 79])
-NIBXTI = 260
-NIBXYB = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-NKMLOI = 357
-NMHXEK = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-NPYYLI = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-NQGVUN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-NQJYMO = 3
-NQLNMH = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-NQTMFZ = 456
-NRJZTA = 451
-NRSJMC = "".join(chr(c) for c in [85, 100, 80, 52])
-NRXCHW = 343
-NXNKML = 333
-NZMJIG = 274
-OACMCV = 474
-OAWBSI = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 82, 101, 97, 100])
-OIHBXI = 469
-OIJUGS = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 73, 68])
-OJRJHI = "".join(chr(c) for c in [76, 79])
-OKPHUO = "".join(chr(c) for c in [79, 70, 70])
-ONPYYL = 304
-OOQNRS = "".join(chr(c) for c in [85, 100, 80, 51])
-OPHUGT = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-OUSPBW = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-OUYNQJ = "".join(chr(c) for c in [66, 76])
-PBWJYK = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-PFTSIF = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-PHUGTY = "".join(chr(c) for c in [85, 76])
-PHUOJR = "".join(chr(c) for c in [65, 76, 76])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 49, 66, 82, 101, 97, 100])
-PIPIVL = "".join(chr(c) for c in [76, 101, 97, 114, 110, 70, 97, 105, 108])
-PIVLAS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 108, 101, 99, 116]
-)
-PLSPFT = 307
-PQIPOU = 6
-PUNRJZ = 450
-PYYLIU = 358
-QBMJVH = "".join(chr(c) for c in [82, 104, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-QEXLSX = "".join(chr(c) for c in [77, 69, 68])
-QFFTTI = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-QFYLJU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-QGLRAH = 290
-QGVUNX = 331
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 66, 82, 101, 97, 100])
-QIPOUY = "".join(chr(c) for c in [80, 53])
-QJYMOU = "".join(chr(c) for c in [76, 49, 50, 48])
-QLAIID = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-QLNMHX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-QNRSJM = 11
-QNRXCH = "".join(chr(c) for c in [75, 54, 48, 48, 73, 68])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-QSNQLN = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-QTDKHT = 256
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 57])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 49, 65, 82, 101, 97, 100])
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 54, 65, 82, 101, 97, 100])
-RJJJVY = 321
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 52])
-RKINEJ = 267
-RSJMCB = 10
-RTFMNH = "".join(chr(c) for c in [75, 54, 48, 48])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-RXCHWD = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 118])
-RYXBQF = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-SELHBQ = 338
-SEMCGE = 463
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SJMCBF = "".join(chr(c) for c in [85, 100, 80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 97, 110, 105])
-SKSOKP = "".join(chr(c) for c in [81, 85, 73, 69, 84])
-SKWIVD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-SNQLNM = 349
-SOKPHU = "".join(chr(c) for c in [83, 79, 65, 75])
-SOOQNR = 12
-SPBWJY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-SPFTSI = "".join(chr(c) for c in [83, 84, 79, 80])
-SRURAZ = 478
-SSAKQX = "".join(chr(c) for c in [80, 111, 119, 101, 114, 117, 112])
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-SSUHBV = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-STSEMC = 462
-SUHBVW = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-SXUJUT = 7
-TATDZX = 453
-TBJEUT = 322
-TDKHTZ = 479
-TDZXNQ = 454
-TFMNHT = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-THBSKS = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-THECVY = "".join(chr(c) for c in [83, 49])
-TIACQF = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-TIDUBS = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121, 69, 114, 114])
-TIXQVX = 466
-TMFZDG = 457
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-TSIFJB = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-TTIDUB = "".join(chr(c) for c in [82, 104, 76, 111, 119, 70, 108, 111])
-TYEKCW = "".join(chr(c) for c in [70, 73, 88])
-TYIYWS = 325
-UBSSUH = "".join(chr(c) for c in [82, 104, 72, 114, 72, 76])
-UBYGDS = "".join(chr(c) for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107])
-UGSELH = 337
-UHBVWV = "".join(chr(c) for c in [82, 104, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-UJUTYE = 5
-UNBLKX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 79, 110])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 51])
-UNXNKM = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-UOJRJH = 275
-UQEXLS = 306
-URAZMK = 479
-USOOQN = "".join(chr(c) for c in [85, 100, 80, 50])
-USPBWJ = 363
-UTOPHU = "".join(chr(c) for c in [54, 52, 75])
-UTYEKC = "".join(chr(c) for c in [85, 100, 70, 98])
-UXFEFJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UYNQJY = "".join(chr(c) for c in [67, 80])
-VDNQGV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-VDQLAI = "".join(
-    chr(c) for c in [76, 101, 97, 114, 110, 80, 104, 97, 115, 101, 69, 114, 114]
-)
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-VHFTHE = "".join(chr(c) for c in [77, 101, 110, 117])
-VKZILX = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-VLASSA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-VUBYGD = "".join(
-    chr(c)
-    for c in [82, 104, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101, 100]
-)
-VUNXNK = 332
-VWVUBY = "".join(chr(c) for c in [82, 104, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-VXOIHB = 468
-VYFCRT = "".join(chr(c) for c in [77, 73, 65])
-VYYPIP = "".join(chr(c) for c in [72, 51])
-WAJVDQ = "".join(
-    chr(c) for c in [70, 114, 101, 113, 68, 101, 116, 101, 99, 69, 114, 114]
-)
-WAONPY = 303
-WBSIRY = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-WDAFIK = "".join(chr(c) for c in [75, 54, 48, 48, 80, 114, 111, 116, 111, 99, 111, 108])
-WIVDNQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-WMNZMJ = "".join(chr(c) for c in [86, 97, 108, 118, 101])
-WRKINE = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-WSKWIV = 328
-WVUBYG = "".join(chr(c) for c in [82, 104, 72, 87, 75, 105, 110])
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-XCHWDA = 345
-XEKVKZ = "".join(
-    chr(c) for c in [75, 105, 110, 80, 117, 114, 103, 101, 65, 99, 116, 105, 118, 101]
-)
-XFEFJT = 361
-XIBHZV = 471
-XLSXUJ = 0
-XNKMLO = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 56])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-XPICXQ = 280
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 52, 65, 82, 101, 97, 100])
-XQIEFX = 284
-XQVXOI = 467
-XSJWMN = "".join(chr(c) for c in [83, 112, 107, 114, 76, 105, 102, 116])
-XTIACQ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-XUJUTY = "".join(chr(c) for c in [85, 100, 84, 118, 76, 105, 102, 116])
-XWAJVD = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-XYBQSN = 265
-YBQSNQ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YEKCWA = "".join(chr(c) for c in [78, 65])
-YFCRTF = "".join(chr(c) for c in [68, 74, 83, 52])
-YGDSBD = "".join(
-    chr(c)
-    for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-YIYWSK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-YKLGQP = 348
-YLIUXF = 359
-YLJUIK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YMOUNB = "".join(chr(c) for c in [70, 98])
-YNQJYM = "".join(chr(c) for c in [79, 51])
-YOUSPB = 302
-YPIPIV = "".join(chr(c) for c in [70, 114])
-YWSKWI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-YXBQFY = 351
-YYLIUX = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-YYPIPI = "".join(chr(c) for c in [72, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-ZILXWA = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-ZMJIGY = "".join(chr(c) for c in [86, 115, 112, 49, 70, 114, 111, 110, 116])
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 53])
-ZUQEXL = "".join(chr(c) for c in [85, 100, 76, 105])
-ZVOACM = 473
-ZXNQTM = 455
-BFEGZU = [OKPHUO, CBFEGZ]
-EXLSXU = [OKPHUO, OJRJHI, QEXLSX, JRJHIU]
-GQPLSP = [KLGQPL, LGQPLS]
-JNIBXY = [NEJNIB, OJRJHI, QEXLSX, JRJHIU, EJNIBX]
-KCWAON = [OKPHUO, TYEKCW, YEKCWA, EKCWAO]
-KPHUOJ = [BSKSOK, SKSOKP, KSOKPH, SOKPHU, OKPHUO]
-KQTDKH = [
-    LAIIDN,
-    QLAIID,
-    JVDQLA,
-    QSNQLN,
-    AJVDQL,
-    ZILXWA,
-    AIIDNI,
-    IIDNIB,
-    XWAJVD,
-    FFTTID,
-    TIDUBS,
-    VDQLAI,
-    DQLAII,
-    ILXWAJ,
-    EKVKZI,
-    XTIACQ,
-    VKZILX,
-    WAJVDQ,
-    IDNIBX,
-    LXWAJV,
-]
-KXSJWM = [BLKXSJ, LKXSJW]
-LOIJUG = [KMLOIJ, MLOIJU]
-MKQTDK = [
-    HUOJRJ,
-    USOOQN,
-    OOQNRS,
-    NRSJMC,
-    SJMCBF,
-    MCBFEG,
-    EGZUQE,
-    ZUQEXL,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    UTYEKC,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YYLIUX,
-    LIUXFE,
-    UXFEFJ,
-]
-NHTBJE = [
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-]
-OQNRSJ = [OKPHUO, JRJHIU]
-OUNBLK = [OKPHUO, OKPHUO, TYEKCW, EKCWAO]
-POUYNQ = [OKPHUO, FJTACC]
-RAZMKQ = []
-RJHIUS = [OKPHUO, OJRJHI, JRJHIU]
-SAKQXP = [
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-]
-SIFJBI = [LSPFTS, SPFTSI, PFTSIF, FTSIFJ, TSIFJB]
-TACCPQ = [OKPHUO, FJTACC, JTACCP]
-TOPHUG = [BJEUTO, JEUTOP, EUTOPH, UTOPHU]
-UGTYIY = [PHUGTY, HUGTYI]
-WJYKLG = [SPBWJY, PBWJYK, BWJYKL]
-ZMKQTD = [
-    FEFJTA,
-    ACCPQI,
-    CCPQIP,
-    CPQIPO,
-    QIPOUY,
-    OUYNQJ,
-    UYNQJY,
-    YNQJYM,
-    QJYMOU,
-    JYMOUN,
-    YMOUNB,
-    UNBLKX,
-    NBLKXS,
-    XSJWMN,
-    SJWMNZ,
-    JWMNZM,
-    WMNZMJ,
-    MNZMJI,
-    ZMJIGY,
-    JIGYOU,
-    GYOUSP,
-    OUSPBW,
-    AZMKQT,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -794,267 +19,583 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return PQIPOU
+        return 6
 
     @property
     def begin(self):
-        return QTDKHT
+        return 256
 
     @property
     def end(self):
-        return TDKHTZ
+        return 479
 
     @property
     def all_device_keys(self):
-        return ZMKQTD
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "FAN",
+            "Fb",
+            "AlwayOn",
+            "TvLift",
+            "SpkrLift",
+            "Sani",
+            "Onzen",
+            "Valve",
+            "RhDuty",
+            "Vsp1Front",
+            "Vsp1Min",
+            "VSP3Front",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return MKQTDK
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdValve",
+            "UdTvLift",
+            "UdSpkrLift",
+            "UdFb",
+            "UdVSP1",
+            "UdVSP3",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return KQTDKH
+        return [
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "RhDutyErr",
+            "ThermistanceErr",
+            "LearnPhaseErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "TempNotValid",
+            "RhCommErr",
+            "FreqDetecErr",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoTempStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoByteStructAccessor(self.struct, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoEnumStructAccessor(
-                self.struct, VHFTHE, HFTHEC, None, SAKQXP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 261, None
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoWordStructAccessor(self.struct, QXPICX, XPICXQ, None),
-            PICXQI: GeckoWordStructAccessor(self.struct, PICXQI, ICXQIE, None),
-            CXQIEF: GeckoWordStructAccessor(self.struct, CXQIEF, XQIEFX, None),
-            QIEFXQ: GeckoWordStructAccessor(self.struct, QIEFXQ, IEFXQG, None),
-            EFXQGL: GeckoWordStructAccessor(self.struct, EFXQGL, FXQGLR, None),
-            XQGLRA: GeckoWordStructAccessor(self.struct, XQGLRA, QGLRAH, None),
-            GLRAHE: GeckoWordStructAccessor(self.struct, GLRAHE, LRAHEO, None),
-            RAHEOC: GeckoWordStructAccessor(self.struct, RAHEOC, AHEOCT, None),
-            HEOCTH: GeckoWordStructAccessor(self.struct, HEOCTH, EOCTHB, None),
-            OCTHBS: GeckoWordStructAccessor(self.struct, OCTHBS, CTHBSK, None),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, KPHUOJ, None, None, PHUOJR
+            "RhTriacTemp": GeckoTempStructAccessor(
+                self.struct, "RhTriacTemp", 263, None
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, JHIUSO, RJHIUS, HIUSOO, IUSOOQ, PHUOJR
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                353,
+                None,
+                [
+                    "NORMAL",
+                    "S1",
+                    "S2",
+                    "H1",
+                    "H2",
+                    "H3",
+                    "H4",
+                    "Fr",
+                    "LearnFail",
+                    "Learning",
+                    "BreakerSelect",
+                    "PhaseSelect",
+                    "ConfigSelect",
+                    "StickBank",
+                    "K600Upload",
+                    "Powerup",
+                ],
+                None,
+                None,
+                None,
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, UOJRJH, SOOQNR, RJHIUS, HIUSOO, IUSOOQ, PHUOJR
+            "HeaterPhaseSign": GeckoByteStructAccessor(
+                self.struct, "HeaterPhaseSign", 300, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, UOJRJH, QNRSJM, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "Out1ARead": GeckoWordStructAccessor(self.struct, "Out1ARead", 280, None),
+            "Out1BRead": GeckoWordStructAccessor(self.struct, "Out1BRead", 282, None),
+            "Out2ARead": GeckoWordStructAccessor(self.struct, "Out2ARead", 284, None),
+            "Out2BRead": GeckoWordStructAccessor(self.struct, "Out2BRead", 286, None),
+            "Out3ARead": GeckoWordStructAccessor(self.struct, "Out3ARead", 288, None),
+            "Out4ARead": GeckoWordStructAccessor(self.struct, "Out4ARead", 290, None),
+            "Out5ARead": GeckoWordStructAccessor(self.struct, "Out5ARead", 292, None),
+            "Out6ARead": GeckoWordStructAccessor(self.struct, "Out6ARead", 294, None),
+            "Out7ARead": GeckoWordStructAccessor(self.struct, "Out7ARead", 296, None),
+            "OutHtrRead": GeckoWordStructAccessor(self.struct, "OutHtrRead", 298, None),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                362,
+                None,
+                ["NOT_SET", "QUIET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, UOJRJH, RSJMCB, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 275, 14, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, UOJRJH, JMCBFE, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 275, 12, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, UOJRJH, FEGZUQ, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 275, 11, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, UOJRJH, GZUQEX, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 275, 10, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, UQEXLS, XLSXUJ, EXLSXU, None, IUSOOQ, PHUOJR
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 275, 9, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, UOJRJH, SXUJUT, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UOJRJH, UJUTYE, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UOJRJH, IUSOOQ, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 306, 0, ["OFF", "LO", "MED", "HI"], None, 4, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, UOJRJH, HIUSOO, KCWAON, HIUSOO, IUSOOQ, PHUOJR
+            "UdValve": GeckoEnumStructAccessor(
+                self.struct, "UdValve", 275, 7, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, PHUOJR),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, PHUOJR),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, PHUOJR),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, PHUOJR),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, PHUOJR),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, PHUOJR),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, XLSXUJ, TACCPQ, None, IUSOOQ, None
+            "UdTvLift": GeckoEnumStructAccessor(
+                self.struct, "UdTvLift", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, EFJTAC, HIUSOO, TACCPQ, None, IUSOOQ, None
+            "UdSpkrLift": GeckoEnumStructAccessor(
+                self.struct, "UdSpkrLift", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, EFJTAC, IUSOOQ, TACCPQ, None, IUSOOQ, None
+            "UdFb": GeckoEnumStructAccessor(
+                self.struct, "UdFb", 275, 2, ["OFF", "FIX", "NA", "SCAN"], 2, 4, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, EFJTAC, PQIPOU, TACCPQ, None, IUSOOQ, None
+            "UdVSP1": GeckoByteStructAccessor(self.struct, "UdVSP1", 303, "ALL"),
+            "UdVSP3": GeckoByteStructAccessor(self.struct, "UdVSP3", 304, "ALL"),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 358, "ALL"
             ),
-            QIPOUY: GeckoEnumStructAccessor(
-                self.struct, QIPOUY, IPOUYN, XLSXUJ, POUYNQ, None, HIUSOO, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 359, "ALL"
             ),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, IPOUYN, GZUQEX, BFEGZU, None, HIUSOO, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 360, "ALL"
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, IPOUYN, HIUSOO, BFEGZU, None, HIUSOO, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 361, "ALL"
             ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, IPOUYN, NQJYMO, BFEGZU, None, HIUSOO, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 356, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, IPOUYN, IUSOOQ, BFEGZU, None, HIUSOO, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 356, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, IPOUYN, SXUJUT, BFEGZU, None, HIUSOO, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 356, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, XLSXUJ, OUNBLK, None, IUSOOQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 356, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, MOUNBL, HIUSOO, BFEGZU, None, HIUSOO, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 355, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, MOUNBL, NQJYMO, KXSJWM, None, HIUSOO, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 355, 1, ["OFF", "ON"], None, 2, None
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, MOUNBL, IUSOOQ, KXSJWM, None, HIUSOO, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 355, 2, ["OFF", "ON"], None, 2, None
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, MOUNBL, UJUTYE, BFEGZU, None, HIUSOO, None
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 355, 3, ["OFF", "ON"], None, 2, None
             ),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, MOUNBL, PQIPOU, BFEGZU, None, HIUSOO, None
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 355, 4, ["OFF", "ON"], None, 2, None
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MOUNBL, SXUJUT, BFEGZU, None, HIUSOO, None
+            "FAN": GeckoEnumStructAccessor(
+                self.struct, "FAN", 355, 7, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, None),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, None),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, None),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, WJYKLG, None, None, PHUOJR
+            "Fb": GeckoEnumStructAccessor(
+                self.struct, "Fb", 354, 0, ["OFF", "OFF", "FIX", "SCAN"], None, 4, None
             ),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, XLSXUJ, GQPLSP, None, HIUSOO, PHUOJR
+            "AlwayOn": GeckoEnumStructAccessor(
+                self.struct, "AlwayOn", 354, 2, ["OFF", "ON"], None, 2, None
             ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, SIFJBI, None, None, PHUOJR
+            "TvLift": GeckoEnumStructAccessor(
+                self.struct, "TvLift", 354, 3, ["DOWN", "UP"], None, 2, None
             ),
-            IFJBIA: GeckoTimeStructAccessor(self.struct, IFJBIA, FJBIAM, PHUOJR),
-            JBIAMJ: GeckoByteStructAccessor(self.struct, JBIAMJ, BIAMJM, PHUOJR),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, YKLGQP, GZUQEX, GQPLSP, None, HIUSOO, PHUOJR
+            "SpkrLift": GeckoEnumStructAccessor(
+                self.struct, "SpkrLift", 354, 4, ["DOWN", "UP"], None, 2, None
             ),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, SIFJBI, None, None, PHUOJR
+            "Sani": GeckoEnumStructAccessor(
+                self.struct, "Sani", 354, 5, ["OFF", "ON"], None, 2, None
             ),
-            JMAOAW: GeckoTimeStructAccessor(self.struct, JMAOAW, MAOAWB, PHUOJR),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, YKLGQP, HIUSOO, GQPLSP, None, HIUSOO, PHUOJR
+            "Onzen": GeckoEnumStructAccessor(
+                self.struct, "Onzen", 354, 6, ["OFF", "ON"], None, 2, None
             ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SIFJBI, None, None, PHUOJR
+            "Valve": GeckoEnumStructAccessor(
+                self.struct, "Valve", 354, 7, ["OFF", "ON"], None, 2, None
             ),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, PHUOJR),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, PHUOJR),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, PHUOJR),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, PHUOJR),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, UJUTYE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, SXUJUT, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, JUIKFW, NQJYMO, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JUIKFW, XLSXUJ, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JUIKFW, GZUQEX, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FYLJUI, HIUSOO, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, FYLJUI, NQJYMO, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, None, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, None
+            "RhDuty": GeckoByteStructAccessor(self.struct, "RhDuty", 274, None),
+            "Vsp1Front": GeckoByteStructAccessor(self.struct, "Vsp1Front", 301, None),
+            "Vsp1Min": GeckoByteStructAccessor(self.struct, "Vsp1Min", 305, None),
+            "VSP3Front": GeckoByteStructAccessor(self.struct, "VSP3Front", 302, None),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                363,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            NIBXYB: GeckoTempStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoTempStructAccessor(self.struct, BXYBQS, XYBQSN, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, SXUJUT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, SNQLNM, GZUQEX, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, FYLJUI, XLSXUJ, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, LNMHXE, HIUSOO, None),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, LNMHXE, XLSXUJ, PHUOJR
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                348,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, FYLJUI, GZUQEX, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, BQSNQL, PQIPOU, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, BQSNQL, UJUTYE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, KVKZIL, UJUTYE, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KZILXW, NQJYMO, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, KZILXW, HIUSOO, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, JUIKFW, IUSOOQ, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, KZILXW, IUSOOQ, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, KZILXW, GZUQEX, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, KVKZIL, PQIPOU, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, KVKZIL, IUSOOQ, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, KVKZIL, NQJYMO, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, KVKZIL, HIUSOO, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, KVKZIL, GZUQEX, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, KVKZIL, XLSXUJ, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, KZILXW, SXUJUT, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, KZILXW, PQIPOU, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, KZILXW, UJUTYE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, KZILXW, XLSXUJ, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, NIBXTI, NQJYMO, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, HIUSOO, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, BXTIAC, GZUQEX, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, IACQFF, HIUSOO, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, CQFFTT, HIUSOO, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, BXTIAC, IUSOOQ, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, IACQFF, SXUJUT, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, IACQFF, NQJYMO, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, IACQFF, XLSXUJ, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, BXTIAC, SXUJUT, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, BXTIAC, PQIPOU, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, BXTIAC, UJUTYE, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, BXTIAC, NQJYMO, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, BXTIAC, XLSXUJ, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, CQFFTT, SXUJUT, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, CQFFTT, PQIPOU, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, CQFFTT, UJUTYE, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, CQFFTT, IUSOOQ, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, CQFFTT, NQJYMO, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, CQFFTT, GZUQEX, None),
-            WVUBYG: GeckoBoolStructAccessor(self.struct, WVUBYG, CQFFTT, XLSXUJ, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, NIBXTI, IUSOOQ, None),
-            UBYGDS: GeckoBoolStructAccessor(self.struct, UBYGDS, NIBXTI, HIUSOO, None),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, NIBXTI, GZUQEX, None),
-            YGDSBD: GeckoBoolStructAccessor(self.struct, YGDSBD, NIBXTI, XLSXUJ, None),
-            GDSBDJ: GeckoWordStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, NHTBJE, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                307,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, XLSXUJ, TOPHUG, None, IUSOOQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 308, "ALL"
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, TBJEUT, HIUSOO, UGTYIY, None, HIUSOO, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 316, "ALL"
             ),
-            GTYIYW: GeckoWordStructAccessor(self.struct, GTYIYW, TYIYWS, None),
-            YIYWSK: GeckoByteStructAccessor(self.struct, YIYWSK, IYWSKW, None),
-            YWSKWI: GeckoByteStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoByteStructAccessor(self.struct, SKWIVD, KWIVDN, None),
-            WIVDNQ: GeckoByteStructAccessor(self.struct, WIVDNQ, IVDNQG, None),
-            VDNQGV: GeckoWordStructAccessor(self.struct, VDNQGV, DNQGVU, None),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, None),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoWordStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NKMLOI, None, LOIJUG, None, HIUSOO, PHUOJR
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                348,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            OIJUGS: GeckoWordStructAccessor(self.struct, OIJUGS, IJUGSE, None),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, None),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, None),
-            ELHBQN: GeckoWordStructAccessor(self.struct, ELHBQN, LHBQNR, None),
-            HBQNRX: GeckoWordStructAccessor(self.struct, HBQNRX, BQNRXC, None),
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                310,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 311, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                348,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                313,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 314, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 350, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 351, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 352, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 269, 5, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 269, 7, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 279, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 279, 0, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 269, 2, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 269, 3, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 267, None, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                268,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 272, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 265, None
+            ),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 349, 1, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 269, 0, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 271, 2, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 271, 0, "ALL"
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KinPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KinPurgeActive", 270, 5, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 278, 4, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "FreqDetecErr": GeckoBoolStructAccessor(
+                self.struct, "FreqDetecErr", 277, 6, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnPhaseErr": GeckoBoolStructAccessor(
+                self.struct, "LearnPhaseErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 260, 3, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 258, 2, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 258, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 257, 2, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 259, 2, None
+            ),
+            "RhNoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloXTries", 258, 4, None
+            ),
+            "RhCommErr": GeckoBoolStructAccessor(
+                self.struct, "RhCommErr", 257, 7, None
+            ),
+            "RhNotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RhNotEnoughHeat", 257, 3, None
+            ),
+            "RhLowFlo": GeckoBoolStructAccessor(self.struct, "RhLowFlo", 257, 0, None),
+            "RhDutyErr": GeckoBoolStructAccessor(
+                self.struct, "RhDutyErr", 258, 7, None
+            ),
+            "RhNoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloRetry", 258, 6, None
+            ),
+            "RhNoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloTemp", 258, 5, None
+            ),
+            "RhHrHL": GeckoBoolStructAccessor(self.struct, "RhHrHL", 258, 3, None),
+            "RhRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RhRegOverHeat", 258, 0, None
+            ),
+            "RhHrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacPr", 259, 7, None
+            ),
+            "RhHrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacOH", 259, 6, None
+            ),
+            "RhSWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhSWTriacOH", 259, 5, None
+            ),
+            "RhHwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHwTriacOH", 259, 4, None
+            ),
+            "RhHrKin": GeckoBoolStructAccessor(self.struct, "RhHrKin", 259, 3, None),
+            "RhSwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RhSwKinTemp", 259, 1, None
+            ),
+            "RhHWKin": GeckoBoolStructAccessor(self.struct, "RhHWKin", 259, 0, None),
+            "RhHeaterDisabled": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterDisabled", 260, 4, None
+            ),
+            "RhFloCheck": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheck", 260, 2, None
+            ),
+            "RhHeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterSuspended", 260, 1, None
+            ),
+            "RhFloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheckReady", 260, 0, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 317, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 319, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 320, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                321,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                322,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 322, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 325, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 327, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 328, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 324, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 323, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 329, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 331, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 332, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 333, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                357,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "inThermID": GeckoWordStructAccessor(self.struct, "inThermID", 335, None),
+            "inThermRev": GeckoByteStructAccessor(self.struct, "inThermRev", 337, None),
+            "inThermRel": GeckoByteStructAccessor(self.struct, "inThermRel", 338, None),
+            "inThermCur1KW": GeckoWordStructAccessor(
+                self.struct, "inThermCur1KW", 339, None
+            ),
+            "inThermCurFull": GeckoWordStructAccessor(
+                self.struct, "inThermCurFull", 341, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxm-log-7.py
+++ b/src/geckolib/driver/packs/inxm-log-7.py
@@ -12,788 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [80, 50])
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-ACQFFT = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-AFIKJP = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 108])
-AHEOCT = 294
-AIIDNI = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-AJVDQL = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-AKQXPI = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101, 83, 105, 103, 110]
-)
-AKSTSE = 459
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-AOAWBS = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-AONPYY = "".join(chr(c) for c in [85, 100, 86, 83, 80, 51])
-ASSAKQ = "".join(chr(c) for c in [75, 54, 48, 48, 85, 112, 108, 111, 97, 100])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 52])
-AWBSIR = 313
-AZMKQT = 478
-BDJQRJ = "".join(
-    chr(c)
-    for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-BHZVOA = 470
-BIAMJM = 316
-BJEUTO = "".join(chr(c) for c in [105, 110, 89, 84])
-BLKXSJ = "".join(chr(c) for c in [68, 79, 87, 78])
-BMJVHF = 263
-BQFYLJ = 352
-BQNRXC = 338
-BQSNQL = 270
-BSIRYX = 314
-BSKSOK = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-BSSUHB = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121, 69, 114, 114])
-BVWVUB = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-BWJYKL = "".join(chr(c) for c in [70, 85, 76, 76])
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-BXTIAC = 260
-BXYBQS = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-BYGDSB = "".join(chr(c) for c in [82, 104, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-CBFEGZ = "".join(chr(c) for c in [79, 78])
-CCPQIP = "".join(chr(c) for c in [80, 51])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-CHWDAF = "".join(chr(c) for c in [75, 54, 48, 48, 73, 68])
-CMCVDS = 473
-CPQIPO = "".join(chr(c) for c in [80, 52])
-CQBMJV = 261
-CQFFTT = 257
-CRTFMN = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-CTHBSK = 298
-CVDSSR = 474
-CVYYPI = "".join(chr(c) for c in [72, 50])
-CWAONP = "".join(chr(c) for c in [85, 100, 86, 83, 80, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 50, 65, 82, 101, 97, 100])
-DAFIKJ = 345
-DGKEAK = 457
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-DNIBXT = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-DNQGVU = 324
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-DSBDJQ = "".join(chr(c) for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107])
-DSSRUR = 475
-DUBSSU = "".join(
-    chr(c)
-    for c in [82, 104, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 53])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-ECVYYP = "".join(chr(c) for c in [72, 49])
-EFJTAC = 356
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 51, 65, 82, 101, 97, 100])
-EGZUQE = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-EJNIBX = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-EKCWAO = "".join(chr(c) for c in [83, 67, 65, 78])
-EKVKZI = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-ELHBQN = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 118])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-EOCTHB = 296
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-EUTOPH = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-FCRTFM = "".join(chr(c) for c in [105, 110, 88, 69])
-FEFJTA = "".join(chr(c) for c in [80, 49])
-FEGZUQ = 8
-FFTTID = 259
-FIKJPU = 346
-FJBIAM = 308
-FJTACC = "".join(chr(c) for c in [72, 73, 71, 72])
-FMNHTB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-FTHECV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTSIFJ = "".join(chr(c) for c in [78, 69, 87])
-FTTIDU = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-FWRKIN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-FXQGLR = 288
-FYLJUI = 269
-FZDGKE = 456
-GDSBDJ = "".join(
-    chr(c)
-    for c in [82, 104, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101, 100]
-)
-GETIXQ = 463
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 53, 65, 82, 101, 97, 100])
-GSELHB = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 73, 68])
-GTYIYW = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-GYOUSP = "".join(chr(c) for c in [86, 83, 80, 51, 70, 114, 111, 110, 116])
-GZUQEX = 1
-HBQNRX = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 108])
-HBSKSO = 362
-HBVWVU = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-HBXIBH = 468
-HECVYY = "".join(chr(c) for c in [83, 50])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 55, 65, 82, 101, 97, 100])
-HFTHEC = 353
-HIUSOO = 2
-HTBJEU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-HTZBBE = 256
-HUGTYI = "".join(chr(c) for c in [54, 52, 75])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 80, 49])
-HWDAFI = 343
-HXEKVK = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-IACQFF = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IAMJMA = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IBXTIA = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IBXYBQ = 272
-ICXQIE = 282
-IDNIBX = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-IDUBSS = "".join(chr(c) for c in [82, 104, 67, 111, 109, 109, 69, 114, 114])
-IEFXQG = 286
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IGYOUS = 305
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IIDNIB = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-IJUGSE = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-IKFWRK = "".join(chr(c) for c in [67, 80, 79, 84])
-IKJPUN = "".join(chr(c) for c in [75, 54, 48, 48, 80, 114, 111, 116, 111, 99, 111, 108])
-ILXWAJ = 278
-INEJNI = 268
-IPIVLA = "".join(chr(c) for c in [76, 101, 97, 114, 110, 105, 110, 103])
-IPOUYN = 355
-IRYXBQ = 350
-IUSOOQ = 4
-IUXFEF = 360
-IVDNQG = 328
-IVLASS = "".join(chr(c) for c in [80, 104, 97, 115, 101, 83, 101, 108, 101, 99, 116])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-JHIUSO = 14
-JIGYOU = "".join(chr(c) for c in [86, 115, 112, 49, 77, 105, 110])
-JJJVYF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-JJVYFC = 320
-JMAOAW = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-JMCBFE = 9
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 48])
-JQRJJJ = 317
-JRJHIU = "".join(chr(c) for c in [72, 73])
-JTACCP = "".join(chr(c) for c in [76, 79, 87])
-JUGSEL = "".join(chr(c) for c in [70, 117, 108, 108])
-JUIKFW = 279
-JUTYEK = "".join(chr(c) for c in [85, 100, 83, 112, 107, 114, 76, 105, 102, 116])
-JVDQLA = "".join(
-    chr(c) for c in [70, 114, 101, 113, 68, 101, 116, 101, 99, 69, 114, 114]
-)
-JVHFTH = 256
-JVYFCR = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-JWMNZM = "".join(chr(c) for c in [79, 110, 122, 101, 110])
-JYKLGQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-JYMOUN = "".join(chr(c) for c in [70, 65, 78])
-JZTATD = 450
-KEAKST = 458
-KFWRKI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KINEJN = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-KJPUNR = 347
-KLGQPL = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-KMLOIJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-KQXPIC = 300
-KSOKPH = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-KVKZIL = "".join(
-    chr(c) for c in [75, 105, 110, 80, 117, 114, 103, 101, 65, 99, 116, 105, 118, 101]
-)
-KWIVDN = 327
-KZILXW = 277
-LAIIDN = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-LASSAK = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-LGQPLS = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-LHBQNR = 337
-LIUXFE = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-LJUIKF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-LKXSJW = "".join(chr(c) for c in [85, 80])
-LNMHXE = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-LOIJUG = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-LRAHEO = 292
-LSPFTS = "".join(chr(c) for c in [73, 68, 76, 69])
-LSXUJU = "".join(chr(c) for c in [85, 100, 86, 97, 108, 118, 101])
-LXWAJV = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-MAOAWB = 311
-MCBFEG = "".join(chr(c) for c in [85, 100, 66, 76])
-MCGETI = 462
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 56])
-MHXEKV = 271
-MJIGYO = 301
-MJMAOA = 310
-MJVHFT = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-MKQTDK = 479
-MLOIJU = 333
-MNHTBJ = "".join(chr(c) for c in [105, 110, 88, 77])
-MNZMJI = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121])
-MOUNBL = 354
-NBLKXS = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-NEJNIB = "".join(chr(c) for c in [78, 79])
-NHTBJE = "".join(chr(c) for c in [75, 54, 48, 48])
-NIBXTI = "".join(chr(c) for c in [114, 72, 73, 100])
-NIBXYB = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-NKMLOI = 332
-NMHXEK = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-NPYYLI = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-NQGVUN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NQJYMO = 3
-NQLNMH = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-NQTMFZ = 454
-NRJZTA = 449
-NRSJMC = "".join(chr(c) for c in [85, 100, 80, 52])
-NRXCHW = 339
-NXNKML = 331
-NZMJIG = 274
-OACMCV = 472
-OAWBSI = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 82, 101, 97, 100])
-OIHBXI = 467
-OIJUGS = 357
-OJRJHI = "".join(chr(c) for c in [76, 79])
-OKPHUO = "".join(chr(c) for c in [79, 70, 70])
-ONPYYL = 304
-OOQNRS = "".join(chr(c) for c in [85, 100, 80, 51])
-OPHUGT = "".join(chr(c) for c in [51, 50, 75])
-OUSPBW = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-OUYNQJ = "".join(chr(c) for c in [66, 76])
-PBWJYK = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-PFTSIF = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-PHUGTY = "".join(chr(c) for c in [52, 56, 75])
-PHUOJR = "".join(chr(c) for c in [65, 76, 76])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 49, 66, 82, 101, 97, 100])
-PIPIVL = "".join(chr(c) for c in [76, 101, 97, 114, 110, 70, 97, 105, 108])
-PIVLAS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 108, 101, 99, 116]
-)
-PLSPFT = 307
-PQIPOU = 6
-PUNRJZ = 448
-PYYLIU = 358
-QBMJVH = "".join(chr(c) for c in [82, 104, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-QEXLSX = "".join(chr(c) for c in [77, 69, 68])
-QFFTTI = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-QFYLJU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-QGLRAH = 290
-QGVUNX = 323
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 66, 82, 101, 97, 100])
-QIPOUY = "".join(chr(c) for c in [80, 53])
-QJYMOU = "".join(chr(c) for c in [76, 49, 50, 48])
-QLAIID = "".join(
-    chr(c) for c in [76, 101, 97, 114, 110, 80, 104, 97, 115, 101, 69, 114, 114]
-)
-QLNMHX = 364
-QNRSJM = 11
-QNRXCH = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 49, 75, 87]
-)
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-QSNQLN = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-QTDKHT = "".join(chr(c) for c in [76, 73])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 55])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 49, 65, 82, 101, 97, 100])
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 54, 65, 82, 101, 97, 100])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-RJJJVY = 319
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 50])
-RKINEJ = 267
-RSJMCB = 10
-RTFMNH = "".join(chr(c) for c in [77, 73, 65])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-RXCHWD = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 70, 117, 108, 108]
-)
-RYXBQF = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        82,
-        104,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-SELHBQ = 335
-SEMCGE = 461
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SJMCBF = "".join(chr(c) for c in [85, 100, 80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 97, 110, 105])
-SKSOKP = "".join(chr(c) for c in [81, 85, 73, 69, 84])
-SKWIVD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-SNQLNM = 349
-SOKPHU = "".join(chr(c) for c in [83, 79, 65, 75])
-SOOQNR = 12
-SPBWJY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-SPFTSI = "".join(chr(c) for c in [83, 84, 79, 80])
-SRURAZ = 476
-SSAKQX = "".join(chr(c) for c in [80, 111, 119, 101, 114, 117, 112])
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-SSUHBV = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-STSEMC = 460
-SUHBVW = "".join(chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-SXUJUT = 7
-TATDZX = 451
-TBJEUT = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-TDZXNQ = 452
-TFMNHT = "".join(chr(c) for c in [68, 74, 83, 52])
-THBSKS = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-THECVY = "".join(chr(c) for c in [83, 49])
-TIACQF = 258
-TIDUBS = 365
-TIXQVX = 464
-TMFZDG = 455
-TOPHUG = "".join(chr(c) for c in [49, 54, 75])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-TSIFJB = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-TTIDUB = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-TYEKCW = "".join(chr(c) for c in [70, 73, 88])
-TYIYWS = "".join(chr(c) for c in [85, 76])
-TZBBEK = 479
-UBSSUH = "".join(chr(c) for c in [82, 104, 76, 111, 119, 70, 108, 111])
-UBYGDS = "".join(chr(c) for c in [82, 104, 72, 114, 75, 105, 110])
-UHBVWV = "".join(chr(c) for c in [82, 104, 72, 114, 72, 76])
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-UJUTYE = 5
-UNBLKX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 79, 110])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 49])
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-UOJRJH = 275
-UQEXLS = 306
-URAZMK = 477
-USOOQN = "".join(chr(c) for c in [85, 100, 80, 50])
-USPBWJ = 363
-UTOPHU = 322
-UTYEKC = "".join(chr(c) for c in [85, 100, 70, 98])
-UXFEFJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UYNQJY = "".join(chr(c) for c in [67, 80])
-VDNQGV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-VHFTHE = "".join(chr(c) for c in [77, 101, 110, 117])
-VKZILX = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-VLASSA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-VUBYGD = "".join(chr(c) for c in [82, 104, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-VUNXNK = 329
-VWVUBY = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-VXOIHB = 466
-VYFCRT = 321
-VYYPIP = "".join(chr(c) for c in [72, 51])
-WAJVDQ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-WAONPY = 303
-WBSIRY = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-WDAFIK = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 118])
-WIVDNQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-WMNZMJ = "".join(chr(c) for c in [86, 97, 108, 118, 101])
-WRKINE = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-WSKWIV = 325
-WVUBYG = "".join(chr(c) for c in [82, 104, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-XCHWDA = 341
-XEKVKZ = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-XFEFJT = 361
-XIBHZV = 469
-XLSXUJ = 0
-XNKMLO = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 54])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-XPICXQ = 280
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 52, 65, 82, 101, 97, 100])
-XQIEFX = 284
-XQVXOI = 465
-XSJWMN = "".join(chr(c) for c in [83, 112, 107, 114, 76, 105, 102, 116])
-XTIACQ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-XUJUTY = "".join(chr(c) for c in [85, 100, 84, 118, 76, 105, 102, 116])
-XWAJVD = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-XYBQSN = 265
-YBQSNQ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YEKCWA = "".join(chr(c) for c in [78, 65])
-YFCRTF = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YGDSBD = "".join(chr(c) for c in [82, 104, 72, 87, 75, 105, 110])
-YIYWSK = "".join(chr(c) for c in [67, 69])
-YKLGQP = 348
-YLIUXF = 359
-YLJUIK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YMOUNB = "".join(chr(c) for c in [70, 98])
-YNQJYM = "".join(chr(c) for c in [79, 51])
-YOUSPB = 302
-YPIPIV = "".join(chr(c) for c in [70, 114])
-YWSKWI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-YXBQFY = 351
-YYLIUX = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-YYPIPI = "".join(chr(c) for c in [72, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 57])
-ZILXWA = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-ZMJIGY = "".join(chr(c) for c in [86, 115, 112, 49, 70, 114, 111, 110, 116])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 51])
-ZUQEXL = "".join(chr(c) for c in [85, 100, 76, 105])
-ZVOACM = 471
-ZXNQTM = 453
-BFEGZU = [OKPHUO, CBFEGZ]
-DKHTZB = [
-    HUOJRJ,
-    USOOQN,
-    OOQNRS,
-    NRSJMC,
-    SJMCBF,
-    MCBFEG,
-    EGZUQE,
-    ZUQEXL,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    UTYEKC,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YYLIUX,
-    LIUXFE,
-    UXFEFJ,
-]
-EXLSXU = [OKPHUO, OJRJHI, QEXLSX, JRJHIU]
-GQPLSP = [KLGQPL, LGQPLS]
-IYWSKW = [TYIYWS, YIYWSK]
-JEUTOP = [
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-]
-JNIBXY = [NEJNIB, OJRJHI, QEXLSX, JRJHIU, EJNIBX]
-KCWAON = [OKPHUO, TYEKCW, YEKCWA, EKCWAO]
-KHTZBB = [
-    IIDNIB,
-    AIIDNI,
-    DQLAII,
-    QSNQLN,
-    VDQLAI,
-    LXWAJV,
-    IDNIBX,
-    DNIBXT,
-    AJVDQL,
-    IDUBSS,
-    BSSUHB,
-    QLAIID,
-    LAIIDN,
-    XWAJVD,
-    VKZILX,
-    IACQFF,
-    ZILXWA,
-    JVDQLA,
-    NIBXTI,
-    WAJVDQ,
-]
-KPHUOJ = [BSKSOK, SKSOKP, KSOKPH, SOKPHU, OKPHUO]
-KQTDKH = []
-KXSJWM = [BLKXSJ, LKXSJW]
-OQNRSJ = [OKPHUO, JRJHIU]
-OUNBLK = [OKPHUO, OKPHUO, TYEKCW, EKCWAO]
-POUYNQ = [OKPHUO, FJTACC]
-RJHIUS = [OKPHUO, OJRJHI, JRJHIU]
-SAKQXP = [
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-]
-SIFJBI = [LSPFTS, SPFTSI, PFTSIF, FTSIFJ, TSIFJB]
-TACCPQ = [OKPHUO, FJTACC, JTACCP]
-TDKHTZ = [
-    FEFJTA,
-    ACCPQI,
-    CCPQIP,
-    CPQIPO,
-    QIPOUY,
-    OUYNQJ,
-    UYNQJY,
-    YNQJYM,
-    QJYMOU,
-    JYMOUN,
-    YMOUNB,
-    UNBLKX,
-    NBLKXS,
-    XSJWMN,
-    SJWMNZ,
-    JWMNZM,
-    WMNZMJ,
-    MNZMJI,
-    ZMJIGY,
-    JIGYOU,
-    GYOUSP,
-    OUSPBW,
-    QTDKHT,
-]
-UGSELH = [IJUGSE, JUGSEL]
-UGTYIY = [TOPHUG, OPHUGT, PHUGTY, HUGTYI]
-WJYKLG = [SPBWJY, PBWJYK, BWJYKL]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -801,269 +19,589 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return SXUJUT
+        return 7
 
     @property
     def begin(self):
-        return HTZBBE
+        return 256
 
     @property
     def end(self):
-        return TZBBEK
+        return 479
 
     @property
     def all_device_keys(self):
-        return TDKHTZ
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "FAN",
+            "Fb",
+            "AlwayOn",
+            "TvLift",
+            "SpkrLift",
+            "Sani",
+            "Onzen",
+            "Valve",
+            "RhDuty",
+            "Vsp1Front",
+            "Vsp1Min",
+            "VSP3Front",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return DKHTZB
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdValve",
+            "UdTvLift",
+            "UdSpkrLift",
+            "UdFb",
+            "UdVSP1",
+            "UdVSP3",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return KHTZBB
+        return [
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "RhDutyErr",
+            "ThermistanceErr",
+            "LearnPhaseErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "TempNotValid",
+            "RhCommErr",
+            "FreqDetecErr",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoTempStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoByteStructAccessor(self.struct, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoEnumStructAccessor(
-                self.struct, VHFTHE, HFTHEC, None, SAKQXP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 261, None
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoWordStructAccessor(self.struct, QXPICX, XPICXQ, None),
-            PICXQI: GeckoWordStructAccessor(self.struct, PICXQI, ICXQIE, None),
-            CXQIEF: GeckoWordStructAccessor(self.struct, CXQIEF, XQIEFX, None),
-            QIEFXQ: GeckoWordStructAccessor(self.struct, QIEFXQ, IEFXQG, None),
-            EFXQGL: GeckoWordStructAccessor(self.struct, EFXQGL, FXQGLR, None),
-            XQGLRA: GeckoWordStructAccessor(self.struct, XQGLRA, QGLRAH, None),
-            GLRAHE: GeckoWordStructAccessor(self.struct, GLRAHE, LRAHEO, None),
-            RAHEOC: GeckoWordStructAccessor(self.struct, RAHEOC, AHEOCT, None),
-            HEOCTH: GeckoWordStructAccessor(self.struct, HEOCTH, EOCTHB, None),
-            OCTHBS: GeckoWordStructAccessor(self.struct, OCTHBS, CTHBSK, None),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, KPHUOJ, None, None, PHUOJR
+            "RhTriacTemp": GeckoTempStructAccessor(
+                self.struct, "RhTriacTemp", 263, None
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, JHIUSO, RJHIUS, HIUSOO, IUSOOQ, PHUOJR
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                353,
+                None,
+                [
+                    "NORMAL",
+                    "S1",
+                    "S2",
+                    "H1",
+                    "H2",
+                    "H3",
+                    "H4",
+                    "Fr",
+                    "LearnFail",
+                    "Learning",
+                    "BreakerSelect",
+                    "PhaseSelect",
+                    "ConfigSelect",
+                    "StickBank",
+                    "K600Upload",
+                    "Powerup",
+                ],
+                None,
+                None,
+                None,
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, UOJRJH, SOOQNR, RJHIUS, HIUSOO, IUSOOQ, PHUOJR
+            "HeaterPhaseSign": GeckoByteStructAccessor(
+                self.struct, "HeaterPhaseSign", 300, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, UOJRJH, QNRSJM, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "Out1ARead": GeckoWordStructAccessor(self.struct, "Out1ARead", 280, None),
+            "Out1BRead": GeckoWordStructAccessor(self.struct, "Out1BRead", 282, None),
+            "Out2ARead": GeckoWordStructAccessor(self.struct, "Out2ARead", 284, None),
+            "Out2BRead": GeckoWordStructAccessor(self.struct, "Out2BRead", 286, None),
+            "Out3ARead": GeckoWordStructAccessor(self.struct, "Out3ARead", 288, None),
+            "Out4ARead": GeckoWordStructAccessor(self.struct, "Out4ARead", 290, None),
+            "Out5ARead": GeckoWordStructAccessor(self.struct, "Out5ARead", 292, None),
+            "Out6ARead": GeckoWordStructAccessor(self.struct, "Out6ARead", 294, None),
+            "Out7ARead": GeckoWordStructAccessor(self.struct, "Out7ARead", 296, None),
+            "OutHtrRead": GeckoWordStructAccessor(self.struct, "OutHtrRead", 298, None),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                362,
+                None,
+                ["NOT_SET", "QUIET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, UOJRJH, RSJMCB, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 275, 14, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, UOJRJH, JMCBFE, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 275, 12, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, UOJRJH, FEGZUQ, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 275, 11, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, UOJRJH, GZUQEX, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 275, 10, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, UQEXLS, XLSXUJ, EXLSXU, None, IUSOOQ, PHUOJR
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 275, 9, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, UOJRJH, SXUJUT, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UOJRJH, UJUTYE, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UOJRJH, IUSOOQ, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 306, 0, ["OFF", "LO", "MED", "HI"], None, 4, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, UOJRJH, HIUSOO, KCWAON, HIUSOO, IUSOOQ, PHUOJR
+            "UdValve": GeckoEnumStructAccessor(
+                self.struct, "UdValve", 275, 7, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, PHUOJR),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, PHUOJR),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, PHUOJR),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, PHUOJR),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, PHUOJR),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, PHUOJR),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, XLSXUJ, TACCPQ, None, IUSOOQ, None
+            "UdTvLift": GeckoEnumStructAccessor(
+                self.struct, "UdTvLift", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, EFJTAC, HIUSOO, TACCPQ, None, IUSOOQ, None
+            "UdSpkrLift": GeckoEnumStructAccessor(
+                self.struct, "UdSpkrLift", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, EFJTAC, IUSOOQ, TACCPQ, None, IUSOOQ, None
+            "UdFb": GeckoEnumStructAccessor(
+                self.struct, "UdFb", 275, 2, ["OFF", "FIX", "NA", "SCAN"], 2, 4, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, EFJTAC, PQIPOU, TACCPQ, None, IUSOOQ, None
+            "UdVSP1": GeckoByteStructAccessor(self.struct, "UdVSP1", 303, "ALL"),
+            "UdVSP3": GeckoByteStructAccessor(self.struct, "UdVSP3", 304, "ALL"),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 358, "ALL"
             ),
-            QIPOUY: GeckoEnumStructAccessor(
-                self.struct, QIPOUY, IPOUYN, XLSXUJ, POUYNQ, None, HIUSOO, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 359, "ALL"
             ),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, IPOUYN, GZUQEX, BFEGZU, None, HIUSOO, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 360, "ALL"
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, IPOUYN, HIUSOO, BFEGZU, None, HIUSOO, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 361, "ALL"
             ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, IPOUYN, NQJYMO, BFEGZU, None, HIUSOO, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 356, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, IPOUYN, IUSOOQ, BFEGZU, None, HIUSOO, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 356, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, IPOUYN, SXUJUT, BFEGZU, None, HIUSOO, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 356, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, XLSXUJ, OUNBLK, None, IUSOOQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 356, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, MOUNBL, HIUSOO, BFEGZU, None, HIUSOO, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 355, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, MOUNBL, NQJYMO, KXSJWM, None, HIUSOO, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 355, 1, ["OFF", "ON"], None, 2, None
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, MOUNBL, IUSOOQ, KXSJWM, None, HIUSOO, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 355, 2, ["OFF", "ON"], None, 2, None
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, MOUNBL, UJUTYE, BFEGZU, None, HIUSOO, None
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 355, 3, ["OFF", "ON"], None, 2, None
             ),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, MOUNBL, PQIPOU, BFEGZU, None, HIUSOO, None
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 355, 4, ["OFF", "ON"], None, 2, None
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MOUNBL, SXUJUT, BFEGZU, None, HIUSOO, None
+            "FAN": GeckoEnumStructAccessor(
+                self.struct, "FAN", 355, 7, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, None),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, None),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, None),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, WJYKLG, None, None, PHUOJR
+            "Fb": GeckoEnumStructAccessor(
+                self.struct, "Fb", 354, 0, ["OFF", "OFF", "FIX", "SCAN"], None, 4, None
             ),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, XLSXUJ, GQPLSP, None, HIUSOO, PHUOJR
+            "AlwayOn": GeckoEnumStructAccessor(
+                self.struct, "AlwayOn", 354, 2, ["OFF", "ON"], None, 2, None
             ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, SIFJBI, None, None, PHUOJR
+            "TvLift": GeckoEnumStructAccessor(
+                self.struct, "TvLift", 354, 3, ["DOWN", "UP"], None, 2, None
             ),
-            IFJBIA: GeckoTimeStructAccessor(self.struct, IFJBIA, FJBIAM, PHUOJR),
-            JBIAMJ: GeckoByteStructAccessor(self.struct, JBIAMJ, BIAMJM, PHUOJR),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, YKLGQP, GZUQEX, GQPLSP, None, HIUSOO, PHUOJR
+            "SpkrLift": GeckoEnumStructAccessor(
+                self.struct, "SpkrLift", 354, 4, ["DOWN", "UP"], None, 2, None
             ),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, SIFJBI, None, None, PHUOJR
+            "Sani": GeckoEnumStructAccessor(
+                self.struct, "Sani", 354, 5, ["OFF", "ON"], None, 2, None
             ),
-            JMAOAW: GeckoTimeStructAccessor(self.struct, JMAOAW, MAOAWB, PHUOJR),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, YKLGQP, HIUSOO, GQPLSP, None, HIUSOO, PHUOJR
+            "Onzen": GeckoEnumStructAccessor(
+                self.struct, "Onzen", 354, 6, ["OFF", "ON"], None, 2, None
             ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SIFJBI, None, None, PHUOJR
+            "Valve": GeckoEnumStructAccessor(
+                self.struct, "Valve", 354, 7, ["OFF", "ON"], None, 2, None
             ),
-            WBSIRY: GeckoTimeStructAccessor(self.struct, WBSIRY, BSIRYX, PHUOJR),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, PHUOJR),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, PHUOJR),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, PHUOJR),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, UJUTYE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, SXUJUT, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, JUIKFW, NQJYMO, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JUIKFW, XLSXUJ, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JUIKFW, GZUQEX, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FYLJUI, HIUSOO, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, FYLJUI, NQJYMO, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, None, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, None
+            "RhDuty": GeckoByteStructAccessor(self.struct, "RhDuty", 274, None),
+            "Vsp1Front": GeckoByteStructAccessor(self.struct, "Vsp1Front", 301, None),
+            "Vsp1Min": GeckoByteStructAccessor(self.struct, "Vsp1Min", 305, None),
+            "VSP3Front": GeckoByteStructAccessor(self.struct, "VSP3Front", 302, None),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                363,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            NIBXYB: GeckoTempStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoTempStructAccessor(self.struct, BXYBQS, XYBQSN, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, SXUJUT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, SNQLNM, GZUQEX, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QLNMHX, XLSXUJ, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, FYLJUI, XLSXUJ, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, MHXEKV, HIUSOO, None),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, MHXEKV, XLSXUJ, PHUOJR
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                348,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, FYLJUI, GZUQEX, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, BQSNQL, PQIPOU, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, BQSNQL, UJUTYE, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KZILXW, UJUTYE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, ILXWAJ, NQJYMO, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, ILXWAJ, HIUSOO, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, JUIKFW, IUSOOQ, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, ILXWAJ, IUSOOQ, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, ILXWAJ, GZUQEX, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, KZILXW, PQIPOU, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, KZILXW, IUSOOQ, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, KZILXW, NQJYMO, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, KZILXW, HIUSOO, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, KZILXW, GZUQEX, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, KZILXW, XLSXUJ, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, ILXWAJ, SXUJUT, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, ILXWAJ, PQIPOU, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, ILXWAJ, UJUTYE, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, ILXWAJ, XLSXUJ, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, NQJYMO, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, TIACQF, HIUSOO, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, TIACQF, GZUQEX, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, CQFFTT, HIUSOO, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, FFTTID, HIUSOO, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, TIACQF, IUSOOQ, None),
-            TTIDUB: GeckoWordStructAccessor(self.struct, TTIDUB, TIDUBS, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, CQFFTT, SXUJUT, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, CQFFTT, NQJYMO, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, CQFFTT, XLSXUJ, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, TIACQF, SXUJUT, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, TIACQF, PQIPOU, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, TIACQF, UJUTYE, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, TIACQF, NQJYMO, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, TIACQF, XLSXUJ, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, FFTTID, SXUJUT, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, FFTTID, PQIPOU, None),
-            WVUBYG: GeckoBoolStructAccessor(self.struct, WVUBYG, FFTTID, UJUTYE, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, FFTTID, IUSOOQ, None),
-            UBYGDS: GeckoBoolStructAccessor(self.struct, UBYGDS, FFTTID, NQJYMO, None),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, FFTTID, GZUQEX, None),
-            YGDSBD: GeckoBoolStructAccessor(self.struct, YGDSBD, FFTTID, XLSXUJ, None),
-            GDSBDJ: GeckoBoolStructAccessor(self.struct, GDSBDJ, BXTIAC, IUSOOQ, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, BXTIAC, HIUSOO, None),
-            SBDJQR: GeckoBoolStructAccessor(self.struct, SBDJQR, BXTIAC, GZUQEX, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, BXTIAC, XLSXUJ, None),
-            DJQRJJ: GeckoWordStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, None),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, None),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, JEUTOP, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                307,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, XLSXUJ, UGTYIY, None, IUSOOQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 308, "ALL"
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, UTOPHU, HIUSOO, IYWSKW, None, HIUSOO, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 316, "ALL"
             ),
-            YWSKWI: GeckoWordStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoByteStructAccessor(self.struct, SKWIVD, KWIVDN, None),
-            WIVDNQ: GeckoByteStructAccessor(self.struct, WIVDNQ, IVDNQG, None),
-            VDNQGV: GeckoByteStructAccessor(self.struct, VDNQGV, DNQGVU, None),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, None),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoWordStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, UGSELH, None, HIUSOO, PHUOJR
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                348,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            GSELHB: GeckoWordStructAccessor(self.struct, GSELHB, SELHBQ, None),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, None),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, None),
-            QNRXCH: GeckoWordStructAccessor(self.struct, QNRXCH, NRXCHW, None),
-            RXCHWD: GeckoWordStructAccessor(self.struct, RXCHWD, XCHWDA, None),
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                310,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 311, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                348,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                313,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 314, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 350, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 351, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 352, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 269, 5, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 269, 7, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 279, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 279, 0, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 269, 2, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 269, 3, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 267, None, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                268,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 272, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 265, None
+            ),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 349, 1, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 364, 0, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 269, 0, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 271, 2, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 271, 0, "ALL"
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KinPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KinPurgeActive", 270, 5, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 278, 4, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "FreqDetecErr": GeckoBoolStructAccessor(
+                self.struct, "FreqDetecErr", 277, 6, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnPhaseErr": GeckoBoolStructAccessor(
+                self.struct, "LearnPhaseErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 260, 3, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 258, 2, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 258, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 257, 2, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 259, 2, None
+            ),
+            "RhNoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloXTries", 258, 4, None
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 365, None
+            ),
+            "RhCommErr": GeckoBoolStructAccessor(
+                self.struct, "RhCommErr", 257, 7, None
+            ),
+            "RhNotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RhNotEnoughHeat", 257, 3, None
+            ),
+            "RhLowFlo": GeckoBoolStructAccessor(self.struct, "RhLowFlo", 257, 0, None),
+            "RhDutyErr": GeckoBoolStructAccessor(
+                self.struct, "RhDutyErr", 258, 7, None
+            ),
+            "RhNoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloRetry", 258, 6, None
+            ),
+            "RhNoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloTemp", 258, 5, None
+            ),
+            "RhHrHL": GeckoBoolStructAccessor(self.struct, "RhHrHL", 258, 3, None),
+            "RhRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RhRegOverHeat", 258, 0, None
+            ),
+            "RhHrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacPr", 259, 7, None
+            ),
+            "RhHrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacOH", 259, 6, None
+            ),
+            "RhSWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhSWTriacOH", 259, 5, None
+            ),
+            "RhHwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHwTriacOH", 259, 4, None
+            ),
+            "RhHrKin": GeckoBoolStructAccessor(self.struct, "RhHrKin", 259, 3, None),
+            "RhSwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RhSwKinTemp", 259, 1, None
+            ),
+            "RhHWKin": GeckoBoolStructAccessor(self.struct, "RhHWKin", 259, 0, None),
+            "RhHeaterDisabled": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterDisabled", 260, 4, None
+            ),
+            "RhFloCheck": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheck", 260, 2, None
+            ),
+            "RhHeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterSuspended", 260, 1, None
+            ),
+            "RhFloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheckReady", 260, 0, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 317, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 319, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 320, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                321,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                322,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 322, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 325, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 327, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 328, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 324, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 323, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 329, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 331, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 332, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 333, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                357,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "inThermID": GeckoWordStructAccessor(self.struct, "inThermID", 335, None),
+            "inThermRev": GeckoByteStructAccessor(self.struct, "inThermRev", 337, None),
+            "inThermRel": GeckoByteStructAccessor(self.struct, "inThermRel", 338, None),
+            "inThermCur1KW": GeckoWordStructAccessor(
+                self.struct, "inThermCur1KW", 339, None
+            ),
+            "inThermCurFull": GeckoWordStructAccessor(
+                self.struct, "inThermCurFull", 341, None
+            ),
         }

--- a/src/geckolib/driver/packs/inxm-log-8.py
+++ b/src/geckolib/driver/packs/inxm-log-8.py
@@ -12,809 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 355
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ACQFFT = "".join(chr(c) for c in [82, 104, 67, 111, 109, 109, 69, 114, 114])
-AFIKJP = "".join(chr(c) for c in [75, 52, 48, 48])
-AHEOCT = 294
-AIIDNI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-AJVDQL = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-AKQXPI = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101, 83, 105, 103, 110]
-)
-AKSTSE = 455
-AMJMAO = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-AONPYY = 359
-ASSAKQ = "".join(chr(c) for c in [75, 54, 48, 48, 85, 112, 108, 111, 97, 100])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 48])
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-AZMKQT = 474
-BDJQRJ = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BEKBDF = "".join(chr(c) for c in [76, 73])
-BHZVOA = 466
-BIAMJM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-BJEUTO = "".join(chr(c) for c in [54, 52, 75])
-BLKXSJ = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121])
-BMJVHF = 263
-BQFYLJ = "".join(chr(c) for c in [67, 80, 79, 84])
-BQNRXC = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 118])
-BQSNQL = 271
-BSIRYX = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BSKSOK = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-BSSUHB = "".join(chr(c) for c in [82, 104, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-BVWVUB = "".join(
-    chr(c)
-    for c in [82, 104, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101, 100]
-)
-BWJYKL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-BXTIAC = 259
-BXYBQS = 364
-BYGDSB = 317
-CBFEGZ = "".join(chr(c) for c in [79, 78])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-CHWDAF = 347
-CMCVDS = 469
-CPQIPO = "".join(chr(c) for c in [66, 76])
-CQBMJV = 261
-CQFFTT = "".join(
-    chr(c)
-    for c in [82, 104, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-CRTFMN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-CTHBSK = 298
-CVDSSR = 470
-CVYYPI = "".join(chr(c) for c in [72, 50])
-CWAONP = 358
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 50, 65, 82, 101, 97, 100])
-DAFIKJ = "".join(chr(c) for c in [75, 50, 48, 48])
-DFSROG = 256
-DGKEAK = 453
-DJQRJJ = 321
-DKHTZB = 477
-DNIBXT = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-DNQGVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DQLAII = "".join(chr(c) for c in [114, 72, 73, 100])
-DSBDJQ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-DSSRUR = 471
-DUBSSU = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 55])
-ECVYYP = "".join(chr(c) for c in [72, 49])
-EFJTAC = "".join(chr(c) for c in [80, 51])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 51, 65, 82, 101, 97, 100])
-EGZUQE = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-EJNIBX = 270
-EKCWAO = 304
-EKVKZI = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-ELHBQN = 341
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-EOCTHB = 296
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EUTOPH = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-FCRTFM = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-FEFJTA = "".join(chr(c) for c in [80, 50])
-FEGZUQ = 8
-FFTTID = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121, 69, 114, 114])
-FIKJPU = "".join(chr(c) for c in [75, 56, 53])
-FJBIAM = 311
-FJTACC = "".join(chr(c) for c in [80, 52])
-FMNHTB = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-FSROGM = 479
-FTHECV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTSIFJ = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-FTTIDU = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-FXQGLR = 288
-FYLJUI = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-FZDGKE = 452
-GDSBDJ = 319
-GETIXQ = 459
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 54])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 53, 65, 82, 101, 97, 100])
-GQPLSP = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-GSELHB = 339
-GTYIYW = 327
-GVUNXN = 333
-GZUQEX = 1
-HBQNRX = 343
-HBSKSO = 362
-HBVWVU = "".join(chr(c) for c in [82, 104, 72, 87, 75, 105, 110])
-HBXIBH = 464
-HECVYY = "".join(chr(c) for c in [83, 50])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 55, 65, 82, 101, 97, 100])
-HFTHEC = 353
-HIUSOO = 2
-HTBJEU = "".join(chr(c) for c in [51, 50, 75])
-HTZBBE = 478
-HUGTYI = 325
-HUOJRJ = "".join(chr(c) for c in [85, 100, 80, 49])
-HWDAFI = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-HXEKVK = 278
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-IACQFF = 365
-IAMJMA = 313
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-IBXTIA = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-IBXYBQ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ICXQIE = 282
-IDNIBX = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IDUBSS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-IEFXQG = 286
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-IGYOUS = "".join(chr(c) for c in [70, 85, 76, 76])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-IIDNIB = 258
-IJUGSE = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 108])
-IKFWRK = "".join(chr(c) for c in [78, 79])
-IKJPUN = "".join(chr(c) for c in [75, 56])
-ILXWAJ = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-INEJNI = 265
-IPIVLA = "".join(chr(c) for c in [76, 101, 97, 114, 110, 105, 110, 103])
-IPOUYN = 3
-IRYXBQ = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-IUSOOQ = 4
-IUXFEF = "".join(chr(c) for c in [72, 73, 71, 72])
-IVDNQG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-IVLASS = "".join(chr(c) for c in [80, 104, 97, 115, 101, 83, 101, 108, 101, 99, 116])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-IYWSKW = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-JBIAMJ = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-JHIUSO = 14
-JIGYOU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-JJJVYF = "".join(chr(c) for c in [77, 73, 65])
-JJVYFC = "".join(chr(c) for c in [68, 74, 83, 52])
-JMAOAW = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-JMCBFE = 9
-JNIBXY = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-JPUNRJ = "".join(chr(c) for c in [75, 53])
-JQRJJJ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-JRJHIU = "".join(chr(c) for c in [72, 73])
-JTACCP = 6
-JUGSEL = 338
-JUIKFW = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JUTYEK = "".join(chr(c) for c in [85, 100, 83, 112, 107, 114, 76, 105, 102, 116])
-JVDQLA = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-JVHFTH = 256
-JVYFCR = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-JWMNZM = 305
-JYKLGQ = "".join(chr(c) for c in [73, 68, 76, 69])
-JYMOUN = "".join(chr(c) for c in [85, 80])
-JZTATD = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-KCWAON = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KEAKST = 454
-KFWRKI = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-KINEJN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-KJPUNR = "".join(chr(c) for c in [75, 52])
-KLGQPL = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-KMLOIJ = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 73, 68])
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-KQXPIC = 300
-KSOKPH = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 56])
-KVKZIL = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-KWIVDN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-KXSJWM = "".join(chr(c) for c in [86, 115, 112, 49, 70, 114, 111, 110, 116])
-KZILXW = "".join(
-    chr(c) for c in [70, 114, 101, 113, 68, 101, 116, 101, 99, 69, 114, 114]
-)
-LAIIDN = 260
-LASSAK = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-LGQPLS = "".join(chr(c) for c in [78, 69, 87])
-LHBQNR = "".join(chr(c) for c in [75, 54, 48, 48, 73, 68])
-LIUXFE = 356
-LJUIKF = 267
-LKXSJW = 274
-LNMHXE = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LOIJUG = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 118])
-LRAHEO = 292
-LSPFTS = 308
-LSXUJU = "".join(chr(c) for c in [85, 100, 86, 97, 108, 118, 101])
-LXWAJV = "".join(
-    chr(c) for c in [76, 101, 97, 114, 110, 80, 104, 97, 115, 101, 69, 114, 114]
-)
-MAOAWB = 350
-MCBFEG = "".join(chr(c) for c in [85, 100, 66, 76])
-MCGETI = 458
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 52])
-MHXEKV = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-MJIGYO = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-MJMAOA = 314
-MJVHFT = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-MKQTDK = 475
-MLOIJU = 335
-MNHTBJ = 322
-MNZMJI = 302
-MOUNBL = "".join(chr(c) for c in [83, 112, 107, 114, 76, 105, 102, 116])
-NBLKXS = "".join(chr(c) for c in [86, 97, 108, 118, 101])
-NEJNIB = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-NHTBJE = "".join(chr(c) for c in [49, 54, 75])
-NIBXTI = 257
-NIBXYB = 349
-NMHXEK = 277
-NPYYLI = 360
-NQGVUN = 332
-NQJYMO = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-NQLNMH = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-NQTMFZ = 450
-NRJZTA = "".join(chr(c) for c in [75, 56, 48, 48])
-NRSJMC = "".join(chr(c) for c in [85, 100, 80, 52])
-NRXCHW = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 108])
-NXNKML = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-NZMJIG = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-OACMCV = 468
-OAWBSI = 351
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 82, 101, 97, 100])
-OIHBXI = 463
-OIJUGS = 337
-OJRJHI = "".join(chr(c) for c in [76, 79])
-OKPHUO = "".join(chr(c) for c in [79, 70, 70])
-ONPYYL = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OOQNRS = "".join(chr(c) for c in [85, 100, 80, 51])
-OUNBLK = "".join(chr(c) for c in [83, 97, 110, 105])
-OUSPBW = 348
-OUYNQJ = "".join(chr(c) for c in [70, 65, 78])
-PFTSIF = 316
-PHUGTY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-PHUOJR = "".join(chr(c) for c in [65, 76, 76])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 49, 66, 82, 101, 97, 100])
-PIPIVL = "".join(chr(c) for c in [76, 101, 97, 114, 110, 70, 97, 105, 108])
-PIVLAS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 108, 101, 99, 116]
-)
-PLSPFT = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-POUYNQ = "".join(chr(c) for c in [76, 49, 50, 48])
-PQIPOU = "".join(chr(c) for c in [67, 80])
-PUNRJZ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-PYYLIU = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QBMJVH = "".join(chr(c) for c in [82, 104, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-QEXLSX = "".join(chr(c) for c in [77, 69, 68])
-QFFTTI = "".join(chr(c) for c in [82, 104, 76, 111, 119, 70, 108, 111])
-QFYLJU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-QGLRAH = 290
-QGVUNX = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 66, 82, 101, 97, 100])
-QIPOUY = "".join(chr(c) for c in [79, 51])
-QJYMOU = "".join(chr(c) for c in [68, 79, 87, 78])
-QLAIID = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QLNMHX = "".join(
-    chr(c) for c in [75, 105, 110, 80, 117, 114, 103, 101, 65, 99, 116, 105, 118, 101]
-)
-QNRSJM = 11
-QNRXCH = 345
-QRJJJV = "".join(chr(c) for c in [105, 110, 88, 69])
-QSNQLN = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-QTDKHT = 476
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 51])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 49, 65, 82, 101, 97, 100])
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 54, 65, 82, 101, 97, 100])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-RJJJVY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-RJZTAT = "".join(chr(c) for c in [])
-RKINEJ = 272
-RSJMCB = 10
-RTFMNH = "".join(chr(c) for c in [105, 110, 89, 84])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-RXCHWD = 346
-RYXBQF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-SBDJQR = 320
-SELHBQ = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 70, 117, 108, 108]
-)
-SEMCGE = 457
-SIFJBI = 310
-SIRYXB = 269
-SJMCBF = "".join(chr(c) for c in [85, 100, 80, 53])
-SJWMNZ = "".join(chr(c) for c in [86, 115, 112, 49, 77, 105, 110])
-SKSOKP = "".join(chr(c) for c in [81, 85, 73, 69, 84])
-SKWIVD = 323
-SNQLNM = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-SOKPHU = "".join(chr(c) for c in [83, 79, 65, 75])
-SOOQNR = 12
-SPBWJY = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-SPFTSI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-SRURAZ = 472
-SSAKQX = "".join(chr(c) for c in [80, 111, 119, 101, 114, 117, 112])
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-SSUHBV = "".join(chr(c) for c in [82, 104, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-STSEMC = 456
-SUHBVW = "".join(chr(c) for c in [82, 104, 72, 114, 75, 105, 110])
-SXUJUT = 7
-TACCPQ = "".join(chr(c) for c in [80, 53])
-TBJEUT = "".join(chr(c) for c in [52, 56, 75])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-TDZXNQ = 448
-THBSKS = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-THECVY = "".join(chr(c) for c in [83, 49])
-TIACQF = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-TIDUBS = "".join(chr(c) for c in [82, 104, 72, 114, 72, 76])
-TIXQVX = 460
-TMFZDG = 451
-TOPHUG = "".join(chr(c) for c in [67, 69])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 57])
-TSIFJB = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-TTIDUB = "".join(chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-TYEKCW = 303
-TYIYWS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-UBSSUH = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UGSELH = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 49, 75, 87]
-)
-UGTYIY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-UHBVWV = "".join(chr(c) for c in [82, 104, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-UIKFWR = 268
-UJUTYE = 5
-UNBLKX = "".join(chr(c) for c in [79, 110, 122, 101, 110])
-UNRJZT = "".join(chr(c) for c in [75, 49, 48, 48])
-UNXNKM = 357
-UOJRJH = 275
-UQEXLS = 306
-URAZMK = 473
-USOOQN = "".join(chr(c) for c in [85, 100, 80, 50])
-USPBWJ = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-UTOPHU = "".join(chr(c) for c in [85, 76])
-UTYEKC = "".join(chr(c) for c in [85, 100, 86, 83, 80, 49])
-UXFEFJ = "".join(chr(c) for c in [76, 79, 87])
-UYNQJY = "".join(chr(c) for c in [65, 108, 119, 97, 121, 79, 110])
-VDNQGV = 331
-VDQLAI = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-VHFTHE = "".join(chr(c) for c in [77, 101, 110, 117])
-VKZILX = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-VLASSA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-VUBYGD = "".join(
-    chr(c)
-    for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-VUNXNK = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VWVUBY = "".join(chr(c) for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107])
-VXOIHB = 462
-VYFCRT = "".join(chr(c) for c in [105, 110, 88, 77])
-VYYPIP = "".join(chr(c) for c in [72, 51])
-WAJVDQ = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-WAONPY = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-WBSIRY = 352
-WDAFIK = 367
-WIVDNQ = 329
-WJYKLG = 307
-WMNZMJ = "".join(chr(c) for c in [86, 83, 80, 51, 70, 114, 111, 110, 116])
-WRKINE = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-WSKWIV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        82,
-        104,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-XCHWDA = "".join(chr(c) for c in [75, 54, 48, 48, 80, 114, 111, 116, 111, 99, 111, 108])
-XEKVKZ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-XIBHZV = 465
-XLSXUJ = 0
-XNKMLO = "".join(chr(c) for c in [70, 117, 108, 108])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 50])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-XPICXQ = 280
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 52, 65, 82, 101, 97, 100])
-XQIEFX = 284
-XQVXOI = 461
-XSJWMN = 301
-XTIACQ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-XUJUTY = "".join(chr(c) for c in [85, 100, 84, 118, 76, 105, 102, 116])
-XWAJVD = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-XYBQSN = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-YBQSNQ = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YEKCWA = "".join(chr(c) for c in [85, 100, 86, 83, 80, 51])
-YFCRTF = "".join(chr(c) for c in [75, 54, 48, 48])
-YGDSBD = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-YIYWSK = 328
-YKLGQP = "".join(chr(c) for c in [83, 84, 79, 80])
-YLIUXF = "".join(chr(c) for c in [80, 49])
-YLJUIK = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YNQJYM = 354
-YOUSPB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-YPIPIV = "".join(chr(c) for c in [70, 114])
-YWSKWI = 324
-YXBQFY = 279
-YYLIUX = 361
-YYPIPI = "".join(chr(c) for c in [72, 52])
-ZBBEKB = 479
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 53])
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-ZMJIGY = 363
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-ZTATDZ = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-ZUQEXL = "".join(chr(c) for c in [85, 100, 76, 105])
-ZVOACM = 467
-ZXNQTM = 449
-BBEKBD = []
-BDFSRO = [
-    AJVDQL,
-    WAJVDQ,
-    ILXWAJ,
-    JNIBXY,
-    ZILXWA,
-    XEKVKZ,
-    JVDQLA,
-    VDQLAI,
-    VKZILX,
-    ACQFFT,
-    FFTTID,
-    LXWAJV,
-    XWAJVD,
-    EKVKZI,
-    LNMHXE,
-    IDNIBX,
-    MHXEKV,
-    KZILXW,
-    DQLAII,
-    KVKZIL,
-]
-BFEGZU = [OKPHUO, CBFEGZ]
-CCPQIP = [OKPHUO, IUXFEF]
-EKBDFS = [
-    YLIUXF,
-    FEFJTA,
-    EFJTAC,
-    FJTACC,
-    TACCPQ,
-    CPQIPO,
-    PQIPOU,
-    QIPOUY,
-    POUYNQ,
-    OUYNQJ,
-    UYNQJY,
-    NQJYMO,
-    MOUNBL,
-    OUNBLK,
-    UNBLKX,
-    NBLKXS,
-    BLKXSJ,
-    KXSJWM,
-    SJWMNZ,
-    WMNZMJ,
-    NZMJIG,
-    BEKBDF,
-]
-EXLSXU = [OKPHUO, OJRJHI, QEXLSX, JRJHIU]
-FWRKIN = [IKFWRK, OJRJHI, QEXLSX, JRJHIU, KFWRKI]
-GYOUSP = [MJIGYO, JIGYOU, IGYOUS]
-JEUTOP = [NHTBJE, HTBJEU, TBJEUT, BJEUTO]
-KBDFSR = [
-    HUOJRJ,
-    USOOQN,
-    OOQNRS,
-    NRSJMC,
-    SJMCBF,
-    MCBFEG,
-    EGZUQE,
-    ZUQEXL,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    UTYEKC,
-    YEKCWA,
-    KCWAON,
-    WAONPY,
-    ONPYYL,
-    PYYLIU,
-]
-KPHUOJ = [BSKSOK, SKSOKP, KSOKPH, SOKPHU, OKPHUO]
-NKMLOI = [NXNKML, XNKMLO]
-OPHUGT = [UTOPHU, TOPHUG]
-OQNRSJ = [OKPHUO, JRJHIU]
-PBWJYK = [USPBWJ, SPBWJY]
-QPLSPF = [JYKLGQ, YKLGQP, KLGQPL, LGQPLS, GQPLSP]
-RJHIUS = [OKPHUO, OJRJHI, JRJHIU]
-SAKQXP = [
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-]
-TATDZX = [
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    NRJZTA,
-    RJZTAT,
-    RJZTAT,
-    RJZTAT,
-    JZTATD,
-    ZTATDZ,
-]
-TFMNHT = [
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-]
-XFEFJT = [OKPHUO, IUXFEF, UXFEFJ]
-YMOUNB = [QJYMOU, JYMOUN]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -822,266 +19,606 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return FEGZUQ
+        return 8
 
     @property
     def begin(self):
-        return DFSROG
+        return 256
 
     @property
     def end(self):
-        return FSROGM
+        return 479
 
     @property
     def all_device_keys(self):
-        return EKBDFS
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "FAN",
+            "AlwayOn",
+            "TvLift",
+            "SpkrLift",
+            "Sani",
+            "Onzen",
+            "Valve",
+            "RhDuty",
+            "Vsp1Front",
+            "Vsp1Min",
+            "VSP3Front",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return KBDFSR
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdValve",
+            "UdTvLift",
+            "UdSpkrLift",
+            "UdVSP1",
+            "UdVSP3",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return BDFSRO
+        return [
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "RhDutyErr",
+            "ThermistanceErr",
+            "LearnPhaseErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "TempNotValid",
+            "RhCommErr",
+            "FreqDetecErr",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoTempStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoByteStructAccessor(self.struct, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoEnumStructAccessor(
-                self.struct, VHFTHE, HFTHEC, None, SAKQXP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 261, None
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoWordStructAccessor(self.struct, QXPICX, XPICXQ, None),
-            PICXQI: GeckoWordStructAccessor(self.struct, PICXQI, ICXQIE, None),
-            CXQIEF: GeckoWordStructAccessor(self.struct, CXQIEF, XQIEFX, None),
-            QIEFXQ: GeckoWordStructAccessor(self.struct, QIEFXQ, IEFXQG, None),
-            EFXQGL: GeckoWordStructAccessor(self.struct, EFXQGL, FXQGLR, None),
-            XQGLRA: GeckoWordStructAccessor(self.struct, XQGLRA, QGLRAH, None),
-            GLRAHE: GeckoWordStructAccessor(self.struct, GLRAHE, LRAHEO, None),
-            RAHEOC: GeckoWordStructAccessor(self.struct, RAHEOC, AHEOCT, None),
-            HEOCTH: GeckoWordStructAccessor(self.struct, HEOCTH, EOCTHB, None),
-            OCTHBS: GeckoWordStructAccessor(self.struct, OCTHBS, CTHBSK, None),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, KPHUOJ, None, None, PHUOJR
+            "RhTriacTemp": GeckoTempStructAccessor(
+                self.struct, "RhTriacTemp", 263, None
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, JHIUSO, RJHIUS, HIUSOO, IUSOOQ, PHUOJR
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                353,
+                None,
+                [
+                    "NORMAL",
+                    "S1",
+                    "S2",
+                    "H1",
+                    "H2",
+                    "H3",
+                    "H4",
+                    "Fr",
+                    "LearnFail",
+                    "Learning",
+                    "BreakerSelect",
+                    "PhaseSelect",
+                    "ConfigSelect",
+                    "StickBank",
+                    "K600Upload",
+                    "Powerup",
+                ],
+                None,
+                None,
+                None,
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, UOJRJH, SOOQNR, RJHIUS, HIUSOO, IUSOOQ, PHUOJR
+            "HeaterPhaseSign": GeckoByteStructAccessor(
+                self.struct, "HeaterPhaseSign", 300, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, UOJRJH, QNRSJM, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "Out1ARead": GeckoWordStructAccessor(self.struct, "Out1ARead", 280, None),
+            "Out1BRead": GeckoWordStructAccessor(self.struct, "Out1BRead", 282, None),
+            "Out2ARead": GeckoWordStructAccessor(self.struct, "Out2ARead", 284, None),
+            "Out2BRead": GeckoWordStructAccessor(self.struct, "Out2BRead", 286, None),
+            "Out3ARead": GeckoWordStructAccessor(self.struct, "Out3ARead", 288, None),
+            "Out4ARead": GeckoWordStructAccessor(self.struct, "Out4ARead", 290, None),
+            "Out5ARead": GeckoWordStructAccessor(self.struct, "Out5ARead", 292, None),
+            "Out6ARead": GeckoWordStructAccessor(self.struct, "Out6ARead", 294, None),
+            "Out7ARead": GeckoWordStructAccessor(self.struct, "Out7ARead", 296, None),
+            "OutHtrRead": GeckoWordStructAccessor(self.struct, "OutHtrRead", 298, None),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                362,
+                None,
+                ["NOT_SET", "QUIET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, UOJRJH, RSJMCB, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 275, 14, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, UOJRJH, JMCBFE, OQNRSJ, HIUSOO, HIUSOO, PHUOJR
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 275, 12, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, UOJRJH, FEGZUQ, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 275, 11, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, UOJRJH, GZUQEX, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 275, 10, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, UQEXLS, XLSXUJ, EXLSXU, None, IUSOOQ, PHUOJR
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 275, 9, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, UOJRJH, SXUJUT, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UOJRJH, UJUTYE, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UOJRJH, IUSOOQ, BFEGZU, HIUSOO, HIUSOO, PHUOJR
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 306, 0, ["OFF", "LO", "MED", "HI"], None, 4, "ALL"
             ),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, PHUOJR),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, PHUOJR),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, PHUOJR),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, PHUOJR),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, PHUOJR),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, PHUOJR),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, XLSXUJ, XFEFJT, None, IUSOOQ, None
+            "UdValve": GeckoEnumStructAccessor(
+                self.struct, "UdValve", 275, 7, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, LIUXFE, HIUSOO, XFEFJT, None, IUSOOQ, None
+            "UdTvLift": GeckoEnumStructAccessor(
+                self.struct, "UdTvLift", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, LIUXFE, IUSOOQ, XFEFJT, None, IUSOOQ, None
+            "UdSpkrLift": GeckoEnumStructAccessor(
+                self.struct, "UdSpkrLift", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, LIUXFE, JTACCP, XFEFJT, None, IUSOOQ, None
+            "UdVSP1": GeckoByteStructAccessor(self.struct, "UdVSP1", 303, "ALL"),
+            "UdVSP3": GeckoByteStructAccessor(self.struct, "UdVSP3", 304, "ALL"),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 358, "ALL"
             ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, XLSXUJ, CCPQIP, None, HIUSOO, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 359, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ACCPQI, GZUQEX, BFEGZU, None, HIUSOO, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 360, "ALL"
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, ACCPQI, HIUSOO, BFEGZU, None, HIUSOO, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 361, "ALL"
             ),
-            QIPOUY: GeckoEnumStructAccessor(
-                self.struct, QIPOUY, ACCPQI, IPOUYN, BFEGZU, None, HIUSOO, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 356, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, ACCPQI, IUSOOQ, BFEGZU, None, HIUSOO, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 356, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, ACCPQI, SXUJUT, BFEGZU, None, HIUSOO, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 356, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, HIUSOO, BFEGZU, None, HIUSOO, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 356, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, YNQJYM, IPOUYN, YMOUNB, None, HIUSOO, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 355, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, YNQJYM, IUSOOQ, YMOUNB, None, HIUSOO, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 355, 1, ["OFF", "ON"], None, 2, None
             ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, YNQJYM, UJUTYE, BFEGZU, None, HIUSOO, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 355, 2, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, YNQJYM, JTACCP, BFEGZU, None, HIUSOO, None
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 355, 3, ["OFF", "ON"], None, 2, None
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, YNQJYM, SXUJUT, BFEGZU, None, HIUSOO, None
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 355, 4, ["OFF", "ON"], None, 2, None
             ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, None),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, None),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, None),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, None, GYOUSP, None, None, PHUOJR
+            "FAN": GeckoEnumStructAccessor(
+                self.struct, "FAN", 355, 7, ["OFF", "ON"], None, 2, None
             ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, XLSXUJ, PBWJYK, None, HIUSOO, PHUOJR
+            "AlwayOn": GeckoEnumStructAccessor(
+                self.struct, "AlwayOn", 354, 2, ["OFF", "ON"], None, 2, None
             ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, QPLSPF, None, None, PHUOJR
+            "TvLift": GeckoEnumStructAccessor(
+                self.struct, "TvLift", 354, 3, ["DOWN", "UP"], None, 2, None
             ),
-            PLSPFT: GeckoTimeStructAccessor(self.struct, PLSPFT, LSPFTS, PHUOJR),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, PHUOJR),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, OUSPBW, GZUQEX, PBWJYK, None, HIUSOO, PHUOJR
+            "SpkrLift": GeckoEnumStructAccessor(
+                self.struct, "SpkrLift", 354, 4, ["DOWN", "UP"], None, 2, None
             ),
-            TSIFJB: GeckoEnumStructAccessor(
-                self.struct, TSIFJB, SIFJBI, None, QPLSPF, None, None, PHUOJR
+            "Sani": GeckoEnumStructAccessor(
+                self.struct, "Sani", 354, 5, ["OFF", "ON"], None, 2, None
             ),
-            IFJBIA: GeckoTimeStructAccessor(self.struct, IFJBIA, FJBIAM, PHUOJR),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, OUSPBW, HIUSOO, PBWJYK, None, HIUSOO, PHUOJR
+            "Onzen": GeckoEnumStructAccessor(
+                self.struct, "Onzen", 354, 6, ["OFF", "ON"], None, 2, None
             ),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, IAMJMA, None, QPLSPF, None, None, PHUOJR
+            "Valve": GeckoEnumStructAccessor(
+                self.struct, "Valve", 354, 7, ["OFF", "ON"], None, 2, None
             ),
-            AMJMAO: GeckoTimeStructAccessor(self.struct, AMJMAO, MJMAOA, PHUOJR),
-            JMAOAW: GeckoByteStructAccessor(self.struct, JMAOAW, MAOAWB, PHUOJR),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, PHUOJR),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, PHUOJR),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, UJUTYE, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, SIRYXB, SXUJUT, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, IPOUYN, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, XLSXUJ, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, YXBQFY, GZUQEX, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, SIRYXB, HIUSOO, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, SIRYXB, IPOUYN, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, None, None),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, FWRKIN, None, None, None
+            "RhDuty": GeckoByteStructAccessor(self.struct, "RhDuty", 274, None),
+            "Vsp1Front": GeckoByteStructAccessor(self.struct, "Vsp1Front", 301, None),
+            "Vsp1Min": GeckoByteStructAccessor(self.struct, "Vsp1Min", 305, None),
+            "VSP3Front": GeckoByteStructAccessor(self.struct, "VSP3Front", 302, None),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                363,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoTempStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoTempStructAccessor(self.struct, KINEJN, INEJNI, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, EJNIBX, SXUJUT, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, GZUQEX, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, XLSXUJ, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, SIRYXB, XLSXUJ, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, HIUSOO, None),
-            QSNQLN: GeckoBoolStructAccessor(
-                self.struct, QSNQLN, BQSNQL, XLSXUJ, PHUOJR
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                348,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, SIRYXB, GZUQEX, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, EJNIBX, JTACCP, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, EJNIBX, UJUTYE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NMHXEK, UJUTYE, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, HXEKVK, IPOUYN, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, HXEKVK, HIUSOO, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, YXBQFY, IUSOOQ, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, HXEKVK, IUSOOQ, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, HXEKVK, GZUQEX, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, NMHXEK, JTACCP, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, NMHXEK, IUSOOQ, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, NMHXEK, IPOUYN, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, NMHXEK, HIUSOO, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, NMHXEK, GZUQEX, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, NMHXEK, XLSXUJ, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, HXEKVK, SXUJUT, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, HXEKVK, JTACCP, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, HXEKVK, UJUTYE, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, HXEKVK, XLSXUJ, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LAIIDN, IPOUYN, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, IIDNIB, HIUSOO, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, IIDNIB, GZUQEX, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, NIBXTI, HIUSOO, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, HIUSOO, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, IIDNIB, IUSOOQ, None),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, NIBXTI, SXUJUT, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, NIBXTI, IPOUYN, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, NIBXTI, XLSXUJ, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, IIDNIB, SXUJUT, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, IIDNIB, JTACCP, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, IIDNIB, UJUTYE, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, IIDNIB, IPOUYN, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, IIDNIB, XLSXUJ, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, BXTIAC, SXUJUT, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, BXTIAC, JTACCP, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, BXTIAC, UJUTYE, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, BXTIAC, IUSOOQ, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, BXTIAC, IPOUYN, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, BXTIAC, GZUQEX, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, BXTIAC, XLSXUJ, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, LAIIDN, IUSOOQ, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, LAIIDN, HIUSOO, None),
-            WVUBYG: GeckoBoolStructAccessor(self.struct, WVUBYG, LAIIDN, GZUQEX, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, LAIIDN, XLSXUJ, None),
-            UBYGDS: GeckoWordStructAccessor(self.struct, UBYGDS, BYGDSB, None),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, None),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DJQRJJ, None, TFMNHT, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                307,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, XLSXUJ, JEUTOP, None, IUSOOQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 308, "ALL"
             ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, MNHTBJ, HIUSOO, OPHUGT, None, HIUSOO, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 316, "ALL"
             ),
-            PHUGTY: GeckoWordStructAccessor(self.struct, PHUGTY, HUGTYI, None),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, None),
-            KWIVDN: GeckoWordStructAccessor(self.struct, KWIVDN, WIVDNQ, None),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, None),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, None),
-            QGVUNX: GeckoWordStructAccessor(self.struct, QGVUNX, GVUNXN, None),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, NKMLOI, None, HIUSOO, PHUOJR
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                348,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KMLOIJ: GeckoWordStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, None),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, None),
-            UGSELH: GeckoWordStructAccessor(self.struct, UGSELH, GSELHB, None),
-            SELHBQ: GeckoWordStructAccessor(self.struct, SELHBQ, ELHBQN, None),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, WDAFIK, None, TATDZX, None, None, None
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                310,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 311, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                348,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                313,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 314, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 350, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 351, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 352, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 269, 5, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 269, 7, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 279, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 279, 0, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 269, 2, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 269, 3, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 267, None, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                268,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 272, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 265, None
+            ),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 349, 1, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 364, 0, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 269, 0, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 271, 2, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 271, 0, "ALL"
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KinPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KinPurgeActive", 270, 5, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 278, 4, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "FreqDetecErr": GeckoBoolStructAccessor(
+                self.struct, "FreqDetecErr", 277, 6, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnPhaseErr": GeckoBoolStructAccessor(
+                self.struct, "LearnPhaseErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 260, 3, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 258, 2, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 258, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 257, 2, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 259, 2, None
+            ),
+            "RhNoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloXTries", 258, 4, None
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 365, None
+            ),
+            "RhCommErr": GeckoBoolStructAccessor(
+                self.struct, "RhCommErr", 257, 7, None
+            ),
+            "RhNotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RhNotEnoughHeat", 257, 3, None
+            ),
+            "RhLowFlo": GeckoBoolStructAccessor(self.struct, "RhLowFlo", 257, 0, None),
+            "RhDutyErr": GeckoBoolStructAccessor(
+                self.struct, "RhDutyErr", 258, 7, None
+            ),
+            "RhNoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloRetry", 258, 6, None
+            ),
+            "RhNoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloTemp", 258, 5, None
+            ),
+            "RhHrHL": GeckoBoolStructAccessor(self.struct, "RhHrHL", 258, 3, None),
+            "RhRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RhRegOverHeat", 258, 0, None
+            ),
+            "RhHrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacPr", 259, 7, None
+            ),
+            "RhHrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacOH", 259, 6, None
+            ),
+            "RhSWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhSWTriacOH", 259, 5, None
+            ),
+            "RhHwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHwTriacOH", 259, 4, None
+            ),
+            "RhHrKin": GeckoBoolStructAccessor(self.struct, "RhHrKin", 259, 3, None),
+            "RhSwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RhSwKinTemp", 259, 1, None
+            ),
+            "RhHWKin": GeckoBoolStructAccessor(self.struct, "RhHWKin", 259, 0, None),
+            "RhHeaterDisabled": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterDisabled", 260, 4, None
+            ),
+            "RhFloCheck": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheck", 260, 2, None
+            ),
+            "RhHeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterSuspended", 260, 1, None
+            ),
+            "RhFloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheckReady", 260, 0, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 317, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 319, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 320, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                321,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                322,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 322, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 325, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 327, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 328, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 324, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 323, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 329, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 331, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 332, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 333, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                357,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "inThermID": GeckoWordStructAccessor(self.struct, "inThermID", 335, None),
+            "inThermRev": GeckoByteStructAccessor(self.struct, "inThermRev", 337, None),
+            "inThermRel": GeckoByteStructAccessor(self.struct, "inThermRel", 338, None),
+            "inThermCur1KW": GeckoWordStructAccessor(
+                self.struct, "inThermCur1KW", 339, None
+            ),
+            "inThermCurFull": GeckoWordStructAccessor(
+                self.struct, "inThermCurFull", 341, None
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                367,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/inxm-log-9.py
+++ b/src/geckolib/driver/packs/inxm-log-9.py
@@ -12,807 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 274
-ACMCVD = 475
-ACQFFT = "".join(chr(c) for c in [82, 104, 83, 119, 75, 105, 110, 84, 101, 109, 112])
-AFIKJP = 448
-AHEOCT = "".join(chr(c) for c in [72, 73])
-AIIDNI = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121, 69, 114, 114])
-AJVDQL = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-AKQXPI = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 80, 104, 97, 115, 101, 83, 105, 103, 110]
-)
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-AOAWBS = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-AONPYY = "".join(chr(c) for c in [67, 80])
-ASSAKQ = "".join(chr(c) for c in [75, 54, 48, 48, 85, 112, 108, 111, 97, 100])
-ATDZXN = 454
-AWBSIR = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BFEGZU = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BIAMJM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-BJEUTO = 324
-BLKXSJ = 371
-BMJVHF = 263
-BQFYLJ = 265
-BQNRXC = "".join(chr(c) for c in [75, 53])
-BQSNQL = "".join(
-    chr(c) for c in [70, 114, 101, 113, 68, 101, 116, 101, 99, 69, 114, 114]
-)
-BSIRYX = "".join(chr(c) for c in [78, 79])
-BSKSOK = "".join(chr(c) for c in [85, 100, 80, 51])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-BVWVUB = "".join(chr(c) for c in [105, 110, 88, 69])
-BWJYKL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-BXIBHZ = 471
-BXTIAC = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 79, 72])
-BXYBQS = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BYGDSB = "".join(chr(c) for c in [105, 110, 88, 77])
-CBFEGZ = 304
-CCPQIP = "".join(chr(c) for c in [86, 115, 112, 49, 70, 114, 111, 110, 116])
-CGETIX = 465
-CHWDAF = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-CPQIPO = 301
-CQBMJV = 261
-CQFFTT = "".join(chr(c) for c in [82, 104, 72, 87, 75, 105, 110])
-CTHBSK = 4
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-CVYYPI = "".join(chr(c) for c in [72, 50])
-CXQIEF = 362
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 48])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-DNIBXT = "".join(chr(c) for c in [82, 104, 72, 114, 72, 76])
-DNQGVU = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 108])
-DQLAII = "".join(chr(c) for c in [82, 104, 67, 111, 109, 109, 69, 114, 114])
-DSBDJQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-DZXNQT = 455
-EAKSTS = 461
-ECVYYP = "".join(chr(c) for c in [72, 49])
-EFJTAC = "".join(chr(c) for c in [83, 97, 110, 105])
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-EJNIBX = 277
-EKCWAO = "".join(chr(c) for c in [80, 53])
-EKVKZI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ELHBQN = "".join(chr(c) for c in [75, 56, 53])
-EMCGET = 464
-EOCTHB = 14
-ETIXQV = 466
-EUTOPH = 323
-EXLSXU = 361
-FCRTFM = "".join(chr(c) for c in [67, 69])
-FEFJTA = "".join(chr(c) for c in [83, 112, 107, 114, 76, 105, 102, 116])
-FEGZUQ = 358
-FFTTID = "".join(chr(c) for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107])
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 49])
-FJBIAM = 269
-FJTACC = "".join(chr(c) for c in [79, 110, 122, 101, 110])
-FMNHTB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-FTHECV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTSIFJ = 351
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        82,
-        104,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-FWRKIN = 271
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 270
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-GDSBDJ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-GKEAKS = 460
-GLRAHE = "".join(chr(c) for c in [85, 100, 80, 49])
-GQPLSP = 313
-GSELHB = "".join(chr(c) for c in [75, 50, 48, 48])
-GTYIYW = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-GVUNXN = 339
-GZUQEX = 359
-HBQNRX = "".join(chr(c) for c in [75, 52])
-HBSKSO = 12
-HBVWVU = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-HECVYY = "".join(chr(c) for c in [83, 50])
-HFTHEC = 353
-HIUSOO = "".join(chr(c) for c in [85, 100, 76, 105])
-HTBJEU = 328
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 66, 76])
-HWDAFI = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-HXEKVK = "".join(chr(c) for c in [83, 99, 97, 110, 69, 114, 114])
-HZVOAC = 473
-IACQFF = "".join(chr(c) for c in [82, 104, 72, 114, 75, 105, 110])
-IAMJMA = 279
-IBHZVO = 472
-IBXTIA = "".join(chr(c) for c in [82, 104, 72, 114, 84, 114, 105, 97, 99, 80, 114])
-IBXYBQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 49]
-)
-ICXQIE = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IDNIBX = "".join(chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 84, 101, 109, 112])
-IDUBSS = 317
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-IGYOUS = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-IHBXIB = 470
-IIDNIB = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 82, 101, 116, 114, 121]
-)
-IJUGSE = 347
-IKFWRK = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-IKJPUN = 449
-ILXWAJ = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-INEJNI = "".join(
-    chr(c) for c in [75, 105, 110, 80, 117, 114, 103, 101, 65, 99, 116, 105, 118, 101]
-)
-IPIVLA = "".join(chr(c) for c in [76, 101, 97, 114, 110, 105, 110, 103])
-IPOUYN = "".join(chr(c) for c in [86, 83, 80, 51, 70, 114, 111, 110, 116])
-IUSOOQ = 306
-IUXFEF = "".join(chr(c) for c in [68, 79, 87, 78])
-IVDNQG = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 82, 101, 118])
-IVLASS = "".join(chr(c) for c in [80, 104, 97, 115, 101, 83, 101, 108, 101, 99, 116])
-IXQVXO = 467
-IYWSKW = 357
-JBIAMJ = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-JEUTOP = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-JHIUSO = 1
-JIGYOU = "".join(chr(c) for c in [78, 69, 87])
-JJJVYF = "".join(chr(c) for c in [52, 56, 75])
-JJVYFC = "".join(chr(c) for c in [54, 52, 75])
-JMAOAW = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-JMCBFE = 303
-JNIBXY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JPUNRJ = 450
-JQRJJJ = 322
-JRJHIU = 8
-JTACCP = "".join(chr(c) for c in [86, 97, 108, 118, 101])
-JUGSEL = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-JUIKFW = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [80, 50])
-JVDQLA = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-JVHFTH = 256
-JYKLGQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 53])
-KCWAON = 355
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-KFWRKI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-KINEJN = "".join(chr(c) for c in [67, 111, 111, 108, 105, 110, 103, 68, 111, 119, 110])
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 50])
-KLGQPL = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-KMLOIJ = 345
-KPHUOJ = "".join(chr(c) for c in [85, 100, 80, 53])
-KQTDKH = 256
-KQXPIC = 300
-KSOKPH = 11
-KSTSEM = 462
-KVKZIL = 260
-KWIVDN = "".join(chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 73, 68])
-KXSJWM = 348
-KZILXW = 258
-LAIIDN = "".join(chr(c) for c in [82, 104, 76, 111, 119, 70, 108, 111])
-LASSAK = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-LGQPLS = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-LHBQNR = "".join(chr(c) for c in [75, 56])
-LIUXFE = "".join(chr(c) for c in [84, 118, 76, 105, 102, 116])
-LJUIKF = 349
-LKXSJW = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-LNMHXE = "".join(chr(c) for c in [70, 117, 115, 101, 50, 69, 114, 114])
-LOIJUG = 346
-LRAHEO = 275
-LSPFTS = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LSXUJU = 356
-LXWAJV = 257
-MAOAWB = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-MCBFEG = "".join(chr(c) for c in [85, 100, 86, 83, 80, 51])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-MCVDSS = 476
-MFZDGK = 458
-MHXEKV = "".join(chr(c) for c in [83, 117, 112, 112, 108, 121, 69, 114, 114])
-MJIGYO = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-MJMAOA = "".join(chr(c) for c in [67, 80, 79, 84])
-MJVHFT = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-MLOIJU = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 108])
-MNHTBJ = 327
-MNZMJI = 307
-MOUNBL = 368
-NBLKXS = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-NEJNIB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-NIBXTI = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-NIBXYB = 278
-NKMLOI = "".join(chr(c) for c in [75, 54, 48, 48, 82, 101, 118])
-NMHXEK = "".join(chr(c) for c in [70, 117, 115, 101, 49, 69, 114, 114])
-NPYYLI = 3
-NQGVUN = 338
-NQJYMO = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQLNMH = "".join(
-    chr(c) for c in [76, 101, 97, 114, 110, 80, 104, 97, 115, 101, 69, 114, 114]
-)
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 57])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 52])
-NRSJMC = 5
-NRXCHW = "".join(chr(c) for c in [75, 49, 48, 48])
-NXNKML = "".join(chr(c) for c in [75, 54, 48, 48, 73, 68])
-NZMJIG = "".join(chr(c) for c in [73, 68, 76, 69])
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-OAWBSI = 267
-OCTHBS = 2
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-OIJUGS = "".join(chr(c) for c in [75, 54, 48, 48, 80, 114, 111, 116, 111, 99, 111, 108])
-OKPHUO = 10
-ONPYYL = "".join(chr(c) for c in [79, 51])
-OOQNRS = "".join(chr(c) for c in [85, 100, 86, 97, 108, 118, 101])
-OPHUGT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-OQNRSJ = 7
-OUNBLK = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-OUSPBW = 308
-OUYNQJ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-PBWJYK = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-PFTSIF = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-PHUGTY = 331
-PHUOJR = 9
-PICXQI = 0
-PIPIVL = "".join(chr(c) for c in [76, 101, 97, 114, 110, 70, 97, 105, 108])
-PIVLAS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 83, 101, 108, 101, 99, 116]
-)
-PLSPFT = 314
-POUYNQ = 302
-PQIPOU = "".join(chr(c) for c in [86, 115, 112, 49, 77, 105, 110])
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 51])
-PYYLIU = "".join(chr(c) for c in [76, 49, 50, 48])
-QBMJVH = "".join(chr(c) for c in [82, 104, 84, 114, 105, 97, 99, 84, 101, 109, 112])
-QEXLSX = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QFFTTI = "".join(
-    chr(c)
-    for c in [82, 104, 72, 101, 97, 116, 101, 114, 68, 105, 115, 97, 98, 108, 101, 100]
-)
-QFYLJU = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-QGLRAH = "".join(chr(c) for c in [65, 76, 76])
-QGVUNX = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 49, 75, 87]
-)
-QIEFXQ = "".join(chr(c) for c in [81, 85, 73, 69, 84])
-QIPOUY = 305
-QJYMOU = "".join(chr(c) for c in [70, 85, 76, 76])
-QLAIID = "".join(
-    chr(c)
-    for c in [82, 104, 78, 111, 116, 69, 110, 111, 117, 103, 104, 72, 101, 97, 116]
-)
-QLNMHX = "".join(chr(c) for c in [70, 117, 115, 101, 51, 69, 114, 114])
-QNRSJM = "".join(chr(c) for c in [85, 100, 84, 118, 76, 105, 102, 116])
-QNRXCH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-QPLSPF = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-QRJJJV = "".join(chr(c) for c in [49, 54, 75])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        110,
-        116,
-        97,
-        99,
-        116,
-        111,
-        114,
-        67,
-        111,
-        105,
-        108,
-        70,
-        97,
-        105,
-        108,
-        69,
-        114,
-        114,
-    ]
-)
-QTDKHT = 480
-QTMFZD = 457
-QVXOIH = 468
-QXPICX = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-RAHEOC = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [76, 73])
-RJHIUS = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJJJVY = "".join(chr(c) for c in [51, 50, 75])
-RJZTAT = 452
-RKINEJ = "".join(chr(c) for c in [80, 117, 109, 112, 82, 117, 110])
-RSJMCB = "".join(chr(c) for c in [85, 100, 83, 112, 107, 114, 76, 105, 102, 116])
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-RURAZM = 479
-RXCHWD = "".join(chr(c) for c in [75, 56, 48, 48])
-RYXBQF = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-SBDJQR = "".join(chr(c) for c in [105, 110, 89, 84])
-SELHBQ = "".join(chr(c) for c in [75, 52, 48, 48])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-SIFJBI = 352
-SIRYXB = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-SJMCBF = "".join(chr(c) for c in [85, 100, 86, 83, 80, 49])
-SJWMNZ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        78,
-        111,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-        69,
-        114,
-        114,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [85, 100, 80, 52])
-SPBWJY = 316
-SPFTSI = 350
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-SSAKQX = "".join(chr(c) for c in [80, 111, 119, 101, 114, 117, 112])
-SSRURA = 478
-SSUHBV = 320
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-SXUJUT = "".join(chr(c) for c in [72, 73, 71, 72])
-TACCPQ = "".join(chr(c) for c in [82, 104, 68, 117, 116, 121])
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 54])
-TBJEUT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 55])
-TFMNHT = 325
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 50])
-THECVY = "".join(chr(c) for c in [83, 49])
-TIACQF = "".join(chr(c) for c in [82, 104, 72, 119, 84, 114, 105, 97, 99, 79, 72])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-TOPHUG = 329
-TSEMCG = 463
-TSIFJB = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-TTIDUB = "".join(
-    chr(c)
-    for c in [82, 104, 70, 108, 111, 67, 104, 101, 99, 107, 82, 101, 97, 100, 121]
-)
-TYEKCW = "".join(chr(c) for c in [80, 52])
-TYIYWS = 333
-UBSSUH = 319
-UBYGDS = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-UGSELH = 367
-UGTYIY = 332
-UHBVWV = 321
-UIKFWR = 364
-UNBLKX = 369
-UNRJZT = 451
-UNXNKM = 341
-UOJRJH = "".join(chr(c) for c in [79, 78])
-UQEXLS = 360
-USOOQN = "".join(chr(c) for c in [77, 69, 68])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-UTYEKC = "".join(chr(c) for c in [80, 51])
-UXFEFJ = "".join(chr(c) for c in [85, 80])
-UYNQJY = 363
-VDNQGV = 337
-VDQLAI = 365
-VDSSRU = 477
-VHFTHE = "".join(chr(c) for c in [77, 101, 110, 117])
-VKZILX = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-VLASSA = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-VOACMC = 474
-VUBYGD = "".join(chr(c) for c in [68, 74, 83, 52])
-VUNXNK = "".join(
-    chr(c) for c in [105, 110, 84, 104, 101, 114, 109, 67, 117, 114, 70, 117, 108, 108]
-)
-VWVUBY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-VYYPIP = "".join(chr(c) for c in [72, 51])
-WAJVDQ = 259
-WAONPY = "".join(chr(c) for c in [66, 76])
-WBSIRY = 268
-WIVDNQ = 335
-WJYKLG = 310
-WMNZMJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-WRKINE = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-WSKWIV = "".join(chr(c) for c in [70, 117, 108, 108])
-WVUBYG = "".join(chr(c) for c in [77, 73, 65])
-XBQFYL = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XCHWDA = "".join(chr(c) for c in [])
-XEKVKZ = "".join(chr(c) for c in [114, 72, 73, 100])
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XLSXUJ = "".join(chr(c) for c in [80, 49])
-XNKMLO = 343
-XNQTMF = 456
-XOIHBX = 469
-XPICXQ = 373
-XQIEFX = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-XSJWMN = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-XTIACQ = "".join(chr(c) for c in [82, 104, 83, 87, 84, 114, 105, 97, 99, 79, 72])
-XUJUTY = "".join(chr(c) for c in [76, 79, 87])
-XWAJVD = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-XYBQSN = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YBQSNQ = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-YEKCWA = 6
-YFCRTF = "".join(chr(c) for c in [85, 76])
-YGDSBD = "".join(chr(c) for c in [75, 54, 48, 48])
-YIYWSK = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-YKLGQP = 311
-YLIUXF = 354
-YLJUIK = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-YMOUNB = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YNQJYM = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-YOUSPB = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YPIPIV = "".join(chr(c) for c in [70, 114])
-YWSKWI = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-YXBQFY = 272
-YYLIUX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 79, 110])
-YYPIPI = "".join(chr(c) for c in [72, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 459
-ZILXWA = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 84, 79, 80])
-ZTATDZ = 453
-ZUQEXL = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 56])
-AZMKQT = [
-    XLSXUJ,
-    JUTYEK,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    WAONPY,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    YYLIUX,
-    LIUXFE,
-    FEFJTA,
-    EFJTAC,
-    FJTACC,
-    JTACCP,
-    TACCPQ,
-    CCPQIP,
-    PQIPOU,
-    IPOUYN,
-    OUYNQJ,
-    YMOUNB,
-    OUNBLK,
-    NBLKXS,
-    RAZMKQ,
-]
-BDJQRJ = [
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-]
-CRTFMN = [YFCRTF, FCRTFM]
-CWAONP = [FXQGLR, SXUJUT]
-GYOUSP = [NZMJIG, ZMJIGY, MJIGYO, JIGYOU, IGYOUS]
-HEOCTH = [FXQGLR, RAHEOC, AHEOCT]
-IRYXBQ = [BSIRYX, RAHEOC, USOOQN, AHEOCT, SIRYXB]
-JVYFCR = [QRJJJV, RJJJVY, JJJVYF, JJVYFC]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYMOUN = [YNQJYM, NQJYMO, QJYMOU]
-MKQTDK = [
-    NMHXEK,
-    LNMHXE,
-    SNQLNM,
-    YLJUIK,
-    QSNQLN,
-    IBXYBQ,
-    MHXEKV,
-    HXEKVK,
-    YBQSNQ,
-    DQLAII,
-    AIIDNI,
-    NQLNMH,
-    QLNMHX,
-    BXYBQS,
-    NEJNIB,
-    ZILXWA,
-    JNIBXY,
-    BQSNQL,
-    XEKVKZ,
-    XYBQSN,
-]
-OJRJHI = [FXQGLR, UOJRJH]
-SAKQXP = [
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    ASSAKQ,
-    SSAKQX,
-]
-SKSOKP = [FXQGLR, AHEOCT]
-SKWIVD = [YWSKWI, WSKWIV]
-SOOQNR = [FXQGLR, RAHEOC, USOOQN, AHEOCT]
-UJUTYE = [FXQGLR, SXUJUT, XUJUTY]
-URAZMK = []
-WDAFIK = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    XCHWDA,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-]
-XFEFJT = [IUXFEF, UXFEFJ]
-XQGLRA = [XQIEFX, QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-ZMKQTD = [
-    GLRAHE,
-    THBSKS,
-    BSKSOK,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    RJHIUS,
-    HIUSOO,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    BFEGZU,
-    EGZUQE,
-    ZUQEXL,
-    QEXLSX,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -820,259 +19,614 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return PHUOJR
+        return 9
 
     @property
     def begin(self):
-        return KQTDKH
+        return 256
 
     @property
     def end(self):
-        return QTDKHT
+        return 480
 
     @property
     def all_device_keys(self):
-        return AZMKQT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "AlwayOn",
+            "TvLift",
+            "SpkrLift",
+            "Sani",
+            "Onzen",
+            "Valve",
+            "RhDuty",
+            "Vsp1Front",
+            "Vsp1Min",
+            "VSP3Front",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ZMKQTD
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdValve",
+            "UdTvLift",
+            "UdSpkrLift",
+            "UdVSP1",
+            "UdVSP3",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return MKQTDK
+        return [
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "RhDutyErr",
+            "ThermistanceErr",
+            "LearnPhaseErr",
+            "rHId",
+            "Fuse3Err",
+            "SupplyErr",
+            "Fuse2Err",
+            "TempNotValid",
+            "RhCommErr",
+            "FreqDetecErr",
+            "KinPumpOff",
+            "ScanErr",
+            "ContactorCoilFailErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "NoHeaterCurrentErr",
+            "AmbiantOHLevel1",
+            "Fuse1Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoTempStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoByteStructAccessor(self.struct, MJVHFT, JVHFTH, None),
-            VHFTHE: GeckoEnumStructAccessor(
-                self.struct, VHFTHE, HFTHEC, None, SAKQXP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 261, None
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoBoolStructAccessor(self.struct, QXPICX, XPICXQ, PICXQI, None),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, XQGLRA, None, None, QGLRAH
+            "RhTriacTemp": GeckoTempStructAccessor(
+                self.struct, "RhTriacTemp", 263, None
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, EOCTHB, HEOCTH, OCTHBS, CTHBSK, QGLRAH
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                353,
+                None,
+                [
+                    "NORMAL",
+                    "S1",
+                    "S2",
+                    "H1",
+                    "H2",
+                    "H3",
+                    "H4",
+                    "Fr",
+                    "LearnFail",
+                    "Learning",
+                    "BreakerSelect",
+                    "PhaseSelect",
+                    "ConfigSelect",
+                    "StickBank",
+                    "K600Upload",
+                    "Powerup",
+                ],
+                None,
+                None,
+                None,
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, LRAHEO, HBSKSO, HEOCTH, OCTHBS, CTHBSK, QGLRAH
+            "HeaterPhaseSign": GeckoByteStructAccessor(
+                self.struct, "HeaterPhaseSign", 300, None
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, LRAHEO, KSOKPH, SKSOKP, OCTHBS, OCTHBS, QGLRAH
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 373, 0, None
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, LRAHEO, OKPHUO, SKSOKP, OCTHBS, OCTHBS, QGLRAH
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                362,
+                None,
+                ["NOT_SET", "QUIET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, LRAHEO, PHUOJR, SKSOKP, OCTHBS, OCTHBS, QGLRAH
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 275, 14, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, LRAHEO, JRJHIU, OJRJHI, OCTHBS, OCTHBS, QGLRAH
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 275, 12, ["OFF", "LO", "HI"], 2, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, LRAHEO, JHIUSO, OJRJHI, OCTHBS, OCTHBS, QGLRAH
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 275, 11, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, IUSOOQ, PICXQI, SOOQNR, None, CTHBSK, QGLRAH
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 275, 10, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, LRAHEO, OQNRSJ, OJRJHI, OCTHBS, OCTHBS, QGLRAH
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 275, 9, ["OFF", "HI"], 2, 2, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, LRAHEO, NRSJMC, OJRJHI, OCTHBS, OCTHBS, QGLRAH
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 275, 8, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, LRAHEO, CTHBSK, OJRJHI, OCTHBS, OCTHBS, QGLRAH
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 275, 1, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QGLRAH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QGLRAH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QGLRAH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QGLRAH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QGLRAH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QGLRAH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, PICXQI, UJUTYE, None, CTHBSK, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 306, 0, ["OFF", "LO", "MED", "HI"], None, 4, "ALL"
             ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, LSXUJU, OCTHBS, UJUTYE, None, CTHBSK, None
+            "UdValve": GeckoEnumStructAccessor(
+                self.struct, "UdValve", 275, 7, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, LSXUJU, CTHBSK, UJUTYE, None, CTHBSK, None
+            "UdTvLift": GeckoEnumStructAccessor(
+                self.struct, "UdTvLift", 275, 5, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, LSXUJU, YEKCWA, UJUTYE, None, CTHBSK, None
+            "UdSpkrLift": GeckoEnumStructAccessor(
+                self.struct, "UdSpkrLift", 275, 4, ["OFF", "ON"], 2, 2, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, PICXQI, CWAONP, None, OCTHBS, None
+            "UdVSP1": GeckoByteStructAccessor(self.struct, "UdVSP1", 303, "ALL"),
+            "UdVSP3": GeckoByteStructAccessor(self.struct, "UdVSP3", 304, "ALL"),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 358, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, KCWAON, JHIUSO, OJRJHI, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 359, "ALL"
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, KCWAON, OCTHBS, OJRJHI, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 360, "ALL"
             ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, KCWAON, NPYYLI, OJRJHI, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 361, "ALL"
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, KCWAON, CTHBSK, OJRJHI, None, OCTHBS, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 356, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, OCTHBS, OJRJHI, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 356, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, YLIUXF, NPYYLI, XFEFJT, None, OCTHBS, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 356, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, YLIUXF, CTHBSK, XFEFJT, None, OCTHBS, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 356, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YLIUXF, NRSJMC, OJRJHI, None, OCTHBS, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 355, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, YLIUXF, YEKCWA, OJRJHI, None, OCTHBS, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 355, 1, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, YLIUXF, OQNRSJ, OJRJHI, None, OCTHBS, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 355, 2, ["OFF", "ON"], None, 2, None
             ),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, None),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, None),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, None),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, QGLRAH
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 355, 3, ["OFF", "ON"], None, 2, None
             ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JYMOUN, None, None, None
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 355, 4, ["OFF", "ON"], None, 2, None
             ),
-            OUNBLK: GeckoWordStructAccessor(self.struct, OUNBLK, UNBLKX, None),
-            NBLKXS: GeckoWordStructAccessor(self.struct, NBLKXS, BLKXSJ, QGLRAH),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, PICXQI, JWMNZM, None, OCTHBS, QGLRAH
+            "AlwayOn": GeckoEnumStructAccessor(
+                self.struct, "AlwayOn", 354, 2, ["OFF", "ON"], None, 2, None
             ),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, GYOUSP, None, None, QGLRAH
+            "TvLift": GeckoEnumStructAccessor(
+                self.struct, "TvLift", 354, 3, ["DOWN", "UP"], None, 2, None
             ),
-            YOUSPB: GeckoTimeStructAccessor(self.struct, YOUSPB, OUSPBW, QGLRAH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QGLRAH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, KXSJWM, JHIUSO, JWMNZM, None, OCTHBS, QGLRAH
+            "SpkrLift": GeckoEnumStructAccessor(
+                self.struct, "SpkrLift", 354, 4, ["DOWN", "UP"], None, 2, None
             ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, GYOUSP, None, None, QGLRAH
+            "Sani": GeckoEnumStructAccessor(
+                self.struct, "Sani", 354, 5, ["OFF", "ON"], None, 2, None
             ),
-            JYKLGQ: GeckoTimeStructAccessor(self.struct, JYKLGQ, YKLGQP, QGLRAH),
-            KLGQPL: GeckoEnumStructAccessor(
-                self.struct, KLGQPL, KXSJWM, OCTHBS, JWMNZM, None, OCTHBS, QGLRAH
+            "Onzen": GeckoEnumStructAccessor(
+                self.struct, "Onzen", 354, 6, ["OFF", "ON"], None, 2, None
             ),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, GYOUSP, None, None, QGLRAH
+            "Valve": GeckoEnumStructAccessor(
+                self.struct, "Valve", 354, 7, ["OFF", "ON"], None, 2, None
             ),
-            QPLSPF: GeckoTimeStructAccessor(self.struct, QPLSPF, PLSPFT, QGLRAH),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QGLRAH),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QGLRAH),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QGLRAH),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, NRSJMC, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, FJBIAM, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, NPYYLI, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, PICXQI, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, IAMJMA, JHIUSO, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, FJBIAM, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, FJBIAM, NPYYLI, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, None, None),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, IRYXBQ, None, None, None
+            "RhDuty": GeckoByteStructAccessor(self.struct, "RhDuty", 274, None),
+            "Vsp1Front": GeckoByteStructAccessor(self.struct, "Vsp1Front", 301, None),
+            "Vsp1Min": GeckoByteStructAccessor(self.struct, "Vsp1Min", 305, None),
+            "VSP3Front": GeckoByteStructAccessor(self.struct, "VSP3Front", 302, None),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                363,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            RYXBQF: GeckoTempStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoTempStructAccessor(self.struct, XBQFYL, BQFYLJ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, OQNRSJ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, JHIUSO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, PICXQI, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, FJBIAM, PICXQI, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, OCTHBS, None),
-            WRKINE: GeckoBoolStructAccessor(
-                self.struct, WRKINE, FWRKIN, PICXQI, QGLRAH
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                368,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, FJBIAM, JHIUSO, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, FYLJUI, YEKCWA, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, FYLJUI, NRSJMC, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, EJNIBX, NRSJMC, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, NPYYLI, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, NIBXYB, OCTHBS, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, IAMJMA, CTHBSK, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, NIBXYB, CTHBSK, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, NIBXYB, JHIUSO, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, EJNIBX, YEKCWA, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, EJNIBX, CTHBSK, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, EJNIBX, NPYYLI, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, EJNIBX, OCTHBS, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, EJNIBX, JHIUSO, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, EJNIBX, PICXQI, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NIBXYB, OQNRSJ, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NIBXYB, YEKCWA, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, NIBXYB, NRSJMC, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, NIBXYB, PICXQI, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, KVKZIL, NPYYLI, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KZILXW, OCTHBS, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, KZILXW, JHIUSO, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, LXWAJV, OCTHBS, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, WAJVDQ, OCTHBS, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, KZILXW, CTHBSK, None),
-            JVDQLA: GeckoWordStructAccessor(self.struct, JVDQLA, VDQLAI, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, LXWAJV, OQNRSJ, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LXWAJV, NPYYLI, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, LXWAJV, PICXQI, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, KZILXW, OQNRSJ, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, KZILXW, YEKCWA, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, KZILXW, NRSJMC, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, KZILXW, NPYYLI, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, KZILXW, PICXQI, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, WAJVDQ, OQNRSJ, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, WAJVDQ, YEKCWA, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, WAJVDQ, NRSJMC, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, WAJVDQ, CTHBSK, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, WAJVDQ, NPYYLI, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, WAJVDQ, JHIUSO, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, WAJVDQ, PICXQI, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, KVKZIL, CTHBSK, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, KVKZIL, OCTHBS, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, KVKZIL, JHIUSO, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, KVKZIL, PICXQI, None),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, BDJQRJ, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 369, None
             ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, PICXQI, JVYFCR, None, CTHBSK, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 371, "ALL"
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, JQRJJJ, OCTHBS, CRTFMN, None, OCTHBS, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                348,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            RTFMNH: GeckoWordStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoWordStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, None),
-            GTYIYW: GeckoWordStructAccessor(self.struct, GTYIYW, TYIYWS, None),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, SKWIVD, None, OCTHBS, QGLRAH
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                307,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KWIVDN: GeckoWordStructAccessor(self.struct, KWIVDN, WIVDNQ, None),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, None),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, None),
-            QGVUNX: GeckoWordStructAccessor(self.struct, QGVUNX, GVUNXN, None),
-            VUNXNK: GeckoWordStructAccessor(self.struct, VUNXNK, UNXNKM, None),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, WDAFIK, None, None, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 308, "ALL"
+            ),
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 316, "ALL"
+            ),
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                348,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                310,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 311, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                348,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                313,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 314, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 350, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 351, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 352, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 269, 5, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 269, 7, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 279, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 279, 0, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 279, 1, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 269, 2, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 269, 3, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 267, None, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                268,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 272, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 265, None
+            ),
+            "Heating": GeckoBoolStructAccessor(self.struct, "Heating", 270, 7, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 349, 1, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 364, 0, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 269, 0, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 271, 2, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 271, 0, "ALL"
+            ),
+            "PumpRun": GeckoBoolStructAccessor(self.struct, "PumpRun", 269, 1, None),
+            "CoolingDown": GeckoBoolStructAccessor(
+                self.struct, "CoolingDown", 270, 6, None
+            ),
+            "KinPurgeActive": GeckoBoolStructAccessor(
+                self.struct, "KinPurgeActive", 270, 5, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 277, 5, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 278, 3, None
+            ),
+            "AmbiantOHLevel1": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel1", 278, 2, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 279, 4, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 278, 4, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 278, 1, None
+            ),
+            "FreqDetecErr": GeckoBoolStructAccessor(
+                self.struct, "FreqDetecErr", 277, 6, None
+            ),
+            "ContactorCoilFailErr": GeckoBoolStructAccessor(
+                self.struct, "ContactorCoilFailErr", 277, 4, None
+            ),
+            "NoHeaterCurrentErr": GeckoBoolStructAccessor(
+                self.struct, "NoHeaterCurrentErr", 277, 3, None
+            ),
+            "LearnPhaseErr": GeckoBoolStructAccessor(
+                self.struct, "LearnPhaseErr", 277, 2, None
+            ),
+            "Fuse3Err": GeckoBoolStructAccessor(self.struct, "Fuse3Err", 277, 1, None),
+            "Fuse2Err": GeckoBoolStructAccessor(self.struct, "Fuse2Err", 277, 0, None),
+            "Fuse1Err": GeckoBoolStructAccessor(self.struct, "Fuse1Err", 278, 7, None),
+            "SupplyErr": GeckoBoolStructAccessor(
+                self.struct, "SupplyErr", 278, 6, None
+            ),
+            "ScanErr": GeckoBoolStructAccessor(self.struct, "ScanErr", 278, 5, None),
+            "rHId": GeckoBoolStructAccessor(self.struct, "rHId", 278, 0, None),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 260, 3, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 258, 2, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 258, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 257, 2, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 259, 2, None
+            ),
+            "RhNoFloXTries": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloXTries", 258, 4, None
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 365, None
+            ),
+            "RhCommErr": GeckoBoolStructAccessor(
+                self.struct, "RhCommErr", 257, 7, None
+            ),
+            "RhNotEnoughHeat": GeckoBoolStructAccessor(
+                self.struct, "RhNotEnoughHeat", 257, 3, None
+            ),
+            "RhLowFlo": GeckoBoolStructAccessor(self.struct, "RhLowFlo", 257, 0, None),
+            "RhDutyErr": GeckoBoolStructAccessor(
+                self.struct, "RhDutyErr", 258, 7, None
+            ),
+            "RhNoFloRetry": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloRetry", 258, 6, None
+            ),
+            "RhNoFloTemp": GeckoBoolStructAccessor(
+                self.struct, "RhNoFloTemp", 258, 5, None
+            ),
+            "RhHrHL": GeckoBoolStructAccessor(self.struct, "RhHrHL", 258, 3, None),
+            "RhRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RhRegOverHeat", 258, 0, None
+            ),
+            "RhHrTriacPr": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacPr", 259, 7, None
+            ),
+            "RhHrTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHrTriacOH", 259, 6, None
+            ),
+            "RhSWTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhSWTriacOH", 259, 5, None
+            ),
+            "RhHwTriacOH": GeckoBoolStructAccessor(
+                self.struct, "RhHwTriacOH", 259, 4, None
+            ),
+            "RhHrKin": GeckoBoolStructAccessor(self.struct, "RhHrKin", 259, 3, None),
+            "RhSwKinTemp": GeckoBoolStructAccessor(
+                self.struct, "RhSwKinTemp", 259, 1, None
+            ),
+            "RhHWKin": GeckoBoolStructAccessor(self.struct, "RhHWKin", 259, 0, None),
+            "RhHeaterDisabled": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterDisabled", 260, 4, None
+            ),
+            "RhFloCheck": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheck", 260, 2, None
+            ),
+            "RhHeaterSuspended": GeckoBoolStructAccessor(
+                self.struct, "RhHeaterSuspended", 260, 1, None
+            ),
+            "RhFloCheckReady": GeckoBoolStructAccessor(
+                self.struct, "RhFloCheckReady", 260, 0, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 317, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 319, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 320, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                321,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                322,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 322, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 325, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 327, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 328, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 324, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 323, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 329, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 331, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 332, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 333, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                357,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "inThermID": GeckoWordStructAccessor(self.struct, "inThermID", 335, None),
+            "inThermRev": GeckoByteStructAccessor(self.struct, "inThermRev", 337, None),
+            "inThermRel": GeckoByteStructAccessor(self.struct, "inThermRel", 338, None),
+            "inThermCur1KW": GeckoWordStructAccessor(
+                self.struct, "inThermCur1KW", 339, None
+            ),
+            "inThermCurFull": GeckoWordStructAccessor(
+                self.struct, "inThermCurFull", 341, None
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                367,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/inxm.py
+++ b/src/geckolib/driver/packs/inxm.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inye-v3-cfg-80.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-80.py
@@ -12,1920 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACQFFT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-ADXLUB = 136
-AFIKJP = 109
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-AIVEMV = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-AJVDQL = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AMJMAO = "".join(chr(c) for c in [72, 105])
-AOAWBS = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-AOESVZ = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = 10
-AWBSIR = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-AXADXL = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-AXNCUG = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-BDFSRO = 7
-BDJQRJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BEKBDF = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BEXLTP = 80
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BGJFJN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-BHZVOA = 157
-BIAMJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [67, 89, 65, 78])
-BMIKGN = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-BQNRXC = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-BQSNQL = 33
-BSIRYX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BSKSOK = 40
-BVHDVR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-BVNAXA = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-BVWVUB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BWJYKL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-BXIBHZ = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-BXTIAC = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-BXYBQS = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BYGDSB = 167
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-CHWDAF = 107
-CMCVDS = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-CRHYUA = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-CRTFMN = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CUGUCY = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = 121
-CYWONF = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-CZOLSI = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-DAFIKJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-DDPMXF = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DFSROG = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DJQRJJ = 170
-DKEYGG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-DMPSCT = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-DNIBXT = 77
-DNQGVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-DQLAII = 68
-DRXAIV = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-DSBDJQ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DSSRUR = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-DUBSSU = "".join(chr(c) for c in [85, 76])
-DVRIDK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-DXLUBG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-DZXNQT = 71
-EAKSTS = 5
-EAOESV = 134
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-EKBDFS = 6
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-ELHBQN = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-ELWUEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-EMCGET = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-EMVCYW = "".join(chr(c) for c in [76, 65])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-EUHNNX = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-EUTOPH = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-EVBVHD = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EYGGVY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-EZFETD = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FCPOUB = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-FCRTFM = 122
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-FIKJPU = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-FJBIAM = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FJNTTU = 143
-FJTACC = 43
-FLSIJU = 151
-FOUURI = 127
-FSROGM = 110
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-FUBJLO = "".join(chr(c) for c in [66, 76, 85, 69])
-FWRKIN = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-FXQGLR = 16
-FYLJUI = "".join(chr(c) for c in [80, 49])
-FZCZOL = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-FZDGKE = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GCRHYU = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-GDSBDJ = 168
-GETIXQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GGVYKL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-GJFJNT = 141
-GKEAKS = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GNVFOU = 126
-GSELHB = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-GTYIYW = 89
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GVUNXN = 96
-GVYKLT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = 52
-HBXIBH = 130
-HDVRID = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-HSVSIB = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-HTBJEU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HUGTYI = 88
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-HXEKVK = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-HZVOAC = "".join(chr(c) for c in [79, 70, 70])
-IACQFF = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IAMJMA = "".join(chr(c) for c in [76, 111])
-IBHZVO = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IBXTIA = 115
-IBXYBQ = 63
-ICXQIE = 13
-IDKEYG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-IDNIBX = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IDUBSS = 51
-IEFXQG = 15
-IFJBIA = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IGYOUS = "".join(chr(c) for c in [79, 119, 110])
-IHBXIB = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-IJUGSE = 101
-IJUZMR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-IKFWRK = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-IKGNVF = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-IKJPUN = 3
-INEJNI = 30
-INELWU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-IPOUYN = 47
-IRYXBQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-IVEMVC = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 75
-IYWSKW = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JEUTOP = 85
-JFJNTT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JJJVYF = "".join(chr(c) for c in [105, 110, 89, 74])
-JLOINE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-JMAOAW = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JNTTUV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-JPUNRJ = 4
-JQRJJJ = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-JUIKFW = 28
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = 155
-JVDQLA = 66
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-JWMNZM = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JYMOUN = 2
-JZTATD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-KBDFSR = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-KCWAON = 21
-KEAKST = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KEYGGV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-KGNVFO = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-KHTZBB = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-KINEJN = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-KJPUNR = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KLGQPL = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-KLTQLV = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-KMLOIJ = 99
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = 76
-KVFCPO = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-KWIVDN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-KXSJWM = 80
-KZILXW = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-LAIIDN = 70
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-LHBQNR = 104
-LIUXFE = 25
-LJUIKF = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 31
-LOIJUG = 100
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-LSIPMD = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-LSPFTS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTQLVH = 172
-LUBGJF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-LVHSVS = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-LXWAJV = 3
-MAOAWB = 1
-MCBFEG = 163
-MCGETI = 73
-MCVDSS = 158
-MDMPSC = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MEAOES = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-MFZDGK = 72
-MHXEKV = 164
-MIKGNV = 125
-MJIGYO = 81
-MJVHFT = 12
-MKQTDK = 64
-MLOIJU = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-MNHTBJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-MNZMJI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-MRKVFC = "".join(chr(c) for c in [82, 71, 66])
-MVCYWO = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MXFUBJ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NEJNIB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-NELWUE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NFZCZO = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NHTBJE = 83
-NIBXTI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-NIBXYB = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NKMLOI = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-NMHXEK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-NNXWEE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = 95
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQTMFZ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NRJZTA = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-NTTUVR = 145
-NVFOUU = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-NXNKML = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-NXWEEZ = "".join(chr(c) for c in [65, 108, 112, 115])
-NZMJIG = 56
-OACMCV = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-OAWBSI = 58
-OCTHBS = 38
-OGMDDP = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-OIHBXI = 128
-OIJUGS = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-OINELW = 8
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-ONFZCZ = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = 87
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = 124
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-OUURIE = "".join(chr(c) for c in [49])
-OUYNQJ = 48
-PBWJYK = 120
-PHUGTY = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 27
-PMDMPS = "".join(chr(c) for c in [73, 100, 111, 108])
-PMXFUB = "".join(chr(c) for c in [82, 69, 68])
-POUBMI = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-PUMEAO = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-PUNRJZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-QFYLJU = 78
-QGLRAH = 26
-QGVUNX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-QLNMHX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QLVHSV = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 105
-QPLSPF = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-QRJJJV = 171
-QSNQLN = "".join(chr(c) for c in [70])
-QTDKHT = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-QTMFZD = 82
-QVXOIH = 160
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 133
-RAZMKQ = "".join(chr(c) for c in [50, 52, 104])
-RFLSIJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-RHYUAX = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-RIDKEY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-RIEVBV = "".join(chr(c) for c in [52])
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = "".join(chr(c) for c in [105, 110, 89, 84])
-RJZTAT = 116
-ROGMDD = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = 74
-RURAZM = 34
-RXAIVE = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-RXCHWD = 106
-RYXBQF = 61
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = 169
-SBVNAX = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-SCTTGC = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-SELHBQ = 103
-SIFJBI = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-SIJUZM = 153
-SIPMDM = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-SIRYXB = 60
-SJWMNZ = 54
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = 92
-SNQLNM = "".join(chr(c) for c in [67])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-SPFTSI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-SROGMD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SRURAZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-SSUHBV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-STSEMC = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-SUHBVW = 114
-SVZSSB = 135
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-TBJEUT = 84
-TDKHTZ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TDRXAI = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-TDZXNQ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TGCRHY = 112
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-TIDUBS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-TIXQVX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TMFZDG = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-TOPHUG = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TQLVHS = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-TSEMCG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-TSIFJB = 57
-TTGCRH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-TTIDUB = 162
-TTUVRF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-TUVRFL = 147
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-TZBBEK = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-UAXNCU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-UBGJFJ = 139
-UBJLOI = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-UBMIKG = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-UBSSUH = "".join(chr(c) for c in [67, 69])
-UBYGDS = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-UCYRAP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-UEUHNN = 111
-UGSELH = 102
-UGTYIY = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-UGUCYR = 113
-UHBVWV = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-UHNNXW = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UIKFWR = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UJUTYE = 18
-UNBLKX = 79
-UNRJZT = 6
-UNXNKM = 97
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [65, 109, 80, 109])
-URIEVB = "".join(chr(c) for c in [51])
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = 118
-UTOPHU = 86
-UTYEKC = 19
-UURIEV = "".join(chr(c) for c in [50])
-UVRFLS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-VBVHDV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-VCYWON = "".join(chr(c) for c in [77, 65, 65, 88])
-VDNQGV = 94
-VDQLAI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VDSSRU = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-VEMVCY = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-VFCPOU = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VFOUUR = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-VHDVRI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VHSVSI = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-VKZILX = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-VOACMC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-VRFLSI = 149
-VRIDKE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-VUBYGD = 166
-VUNXNK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VWVUBY = 165
-VYFCRT = 53
-VYKLTQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-WAJVDQ = 35
-WAONPY = 22
-WBSIRY = 59
-WDAFIK = 108
-WEEZFE = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-WIVDNQ = 93
-WJYKLG = 32
-WMNZMJ = 55
-WONFZC = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WRKINE = 29
-WSKWIV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-WUEUHN = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XADXLU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-XAIVEM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-XBQFYL = 62
-XCHWDA = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-XEKVKZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XFUBJL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-XIBHZV = 132
-XLUBGJ = 137
-XNCUGU = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-XNKMLO = 98
-XOIHBX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-XSJWMN = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-XTIACQ = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-XWEEZF = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-XYBQSN = 1
-YBQSNQ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YEKCWA = 20
-YFCRTF = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGDSBD = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGGVYK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-YIYWSK = 90
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-YKLTQL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOUSPB = 0
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-YUAXNC = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-YWONFZ = "".join(chr(c) for c in [80, 68, 67])
-YWSKWI = 91
-YXBQFY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZDGKEA = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ZFETDR = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-ZILXWA = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-ZMJIGY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-ZMKQTD = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ZMRKVF = 123
-ZOLSIP = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-ZSSBVN = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-ZTATDZ = 8
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-ZXNQTM = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-ACMCVD = [JVHFTH, HZVOAC, ZVOACM, VOACMC, OACMCV]
-AZMKQT = [JVHFTH, URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BSSUHB = [DUBSSU, UBSSUH]
-CPOUBM = [VFCPOU, FCPOUB]
-CTTGCR = [
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-]
-DKHTZB = [QTDKHT, TDKHTZ]
-ETIXQV = [VLASSA, CGETIX, GETIXQ]
-FFTTID = [BXTIAC, XTIACQ, TIACQF, IACQFF, ACQFFT, CQFFTT, QFFTTI]
-FMNHTB = [NEJNIB, TFMNHT]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-GQPLSP = [JYKLGQ, YKLGQP, KLGQPL, LGQPLS]
-GYOUSP = [JIGYOU, IGYOUS]
-HBQNRX = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-HYUAXN = [CRHYUA, RHYUAX, VLASSA, VLASSA]
-IBEXLT = []
-IEVBVH = [VLASSA, OUURIE, UURIEV, URIEVB, RIEVBV]
-IIDNIB = [NEJNIB, AIIDNI]
-ILXWAJ = [KZILXW, ZILXWA]
-JBIAMJ = [SIFJBI, IFJBIA, FJBIAM]
-JJVYFC = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    RJJJVY,
-    VLASSA,
-    JJJVYF,
-]
-JNIBXY = [NEJNIB, EJNIBX]
-KFWRKI = [UIKFWR, IKFWRK]
-KVKZIL = [HXEKVK, XEKVKZ, EKVKZI]
-LOINEL = [HZVOAC, PMXFUB, MXFUBJ, XFUBJL, FUBJLO, UBJLOI, BJLOIN, JLOINE]
-LWUEUH = [NELWUE, ELWUEU]
-MDDPMX = [OGMDDP, GMDDPM]
-MJMAOA = [IAMJMA, AMJMAO]
-NAXADX = [VZSSBV, ZSSBVN, SSBVNA, SBVNAX, BVNAXA, VNAXAD, VLASSA, VLASSA]
-NCUGUC = [JVHFTH, AXNCUG, XNCUGU, VLASSA]
-NQLNMH = [QSNQLN, SNQLNM]
-OESVZS = [AOESVZ]
-PFTSIF = [LSPFTS, SPFTSI]
-RKINEJ = [PIPIVL, FYLJUI]
-RKVFCP = [MRKVFC, JLOINE]
-SEMCGE = [STSEMC, TSEMCG]
-SIBEXL = [NBLKXS]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-SSRURA = [VDSSRU, DSSRUR]
-SVSIBE = [TQLVHS, QLVHSV, LVHSVS, VHSVSI, HSVSIB]
-UMEAOE = [APUMEA, PUMEAO]
-VSIBEX = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-]
-VXOIHB = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XNQTMF = [JVHFTH, LSPFTS, ZXNQTM]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-YLJUIK = [JVHFTH, FYLJUI, PIPIVL]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1933,417 +19,1500 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return BEXLTP
+        return 80
 
     @property
     def output_keys(self):
-        return VSIBEX
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, YOUSPB, GYOUSP, None, JYMOUN, QBMJVH
-            ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, JBIAMJ, None, None, QBMJVH
-            ),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, MJIGYO, JYMOUN, MJMAOA, None, JYMOUN, QBMJVH
-            ),
-            JMAOAW: GeckoBoolStructAccessor(
-                self.struct, JMAOAW, QJYMOU, MAOAWB, QBMJVH
-            ),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, QBMJVH),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, QBMJVH),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTempStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, RKINEJ, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, KVKZIL, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, MJIGYO, LXWAJV, ILXWAJ, None, JYMOUN, QBMJVH
-            ),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, QBMJVH),
-            AJVDQL: GeckoTempStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoTempStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, LAIIDN, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, FFTTID, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, BSSUHB, None, None, QBMJVH
-            ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, QBMJVH),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, QBMJVH),
-            BDJQRJ: GeckoByteStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, JJVYFC, None, None, None
-            ),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, FMNHTB, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, XLSXUJ, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, OPHUGT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, QBMJVH),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, QBMJVH),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, QBMJVH),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, QBMJVH),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, QBMJVH),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, HBQNRX, None, None, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, HBQNRX, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, HBQNRX, None, None, QBMJVH
-            ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, CHWDAF, None, HBQNRX, None, None, QBMJVH
-            ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, WDAFIK, None, HBQNRX, None, None, QBMJVH
-            ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, HBQNRX, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoTimeStructAccessor(self.struct, KJPUNR, JPUNRJ, QBMJVH),
-            PUNRJZ: GeckoTimeStructAccessor(self.struct, PUNRJZ, UNRJZT, QBMJVH),
-            NRJZTA: GeckoTimeStructAccessor(self.struct, NRJZTA, RJZTAT, QBMJVH),
-            JZTATD: GeckoTimeStructAccessor(self.struct, JZTATD, ZTATDZ, QBMJVH),
-            TATDZX: GeckoTimeStructAccessor(self.struct, TATDZX, ATDZXN, QBMJVH),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, None, XNQTMF, None, None, QBMJVH
-            ),
-            NQTMFZ: GeckoBoolStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, YOUSPB, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, MFZDGK, JYMOUN, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, MFZDGK, YOUSPB, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, MFZDGK, MAOAWB, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, MFZDGK, LXWAJV, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, MFZDGK, MOUNBL, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, MFZDGK, EAKSTS, QBMJVH
-            ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, SEMCGE, None, None, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, QBMJVH),
-            XQVXOI: GeckoEnumStructAccessor(
-                self.struct, XQVXOI, QVXOIH, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoTimeStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoTimeStructAccessor(self.struct, IHBXIB, HBXIBH, QBMJVH),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, QBMJVH),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, BHZVOA, None, ACMCVD, None, None, QBMJVH
-            ),
-            CMCVDS: GeckoTimeStructAccessor(self.struct, CMCVDS, MCVDSS, QBMJVH),
-            CVDSSR: GeckoEnumStructAccessor(
-                self.struct, CVDSSR, QJYMOU, LXWAJV, SSRURA, None, JYMOUN, QBMJVH
-            ),
-            SRURAZ: GeckoEnumStructAccessor(
-                self.struct, SRURAZ, RURAZM, None, AZMKQT, None, None, QBMJVH
-            ),
-            ZMKQTD: GeckoWordStructAccessor(self.struct, ZMKQTD, MKQTDK, QBMJVH),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, MJIGYO, MAOAWB, DKHTZB, None, JYMOUN, QBMJVH
-            ),
-            KHTZBB: GeckoBoolStructAccessor(
-                self.struct, KHTZBB, MJIGYO, MOUNBL, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MJIGYO, EAKSTS, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, MJIGYO, EKBDFS, QBMJVH
-            ),
-            KBDFSR: GeckoBoolStructAccessor(
-                self.struct, KBDFSR, MJIGYO, BDFSRO, QBMJVH
-            ),
-            DFSROG: GeckoBoolStructAccessor(
-                self.struct, DFSROG, FSROGM, YOUSPB, QBMJVH
-            ),
-            SROGMD: GeckoBoolStructAccessor(
-                self.struct, SROGMD, FSROGM, MAOAWB, QBMJVH
-            ),
-            ROGMDD: GeckoEnumStructAccessor(
-                self.struct, ROGMDD, FSROGM, JYMOUN, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DDPMXF: GeckoEnumStructAccessor(
-                self.struct, DDPMXF, FSROGM, LXWAJV, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, FSROGM, MOUNBL, LOINEL, None, OINELW, QBMJVH
-            ),
-            INELWU: GeckoEnumStructAccessor(
-                self.struct, INELWU, FSROGM, BDFSRO, LWUEUH, None, JYMOUN, QBMJVH
-            ),
-            TTGCRH: GeckoBoolStructAccessor(
-                self.struct, TTGCRH, TGCRHY, MAOAWB, QBMJVH
-            ),
-            GCRHYU: GeckoEnumStructAccessor(
-                self.struct, GCRHYU, TGCRHY, JYMOUN, HYUAXN, None, MOUNBL, QBMJVH
-            ),
-            YUAXNC: GeckoBoolStructAccessor(
-                self.struct, YUAXNC, TGCRHY, MOUNBL, QBMJVH
-            ),
-            UAXNCU: GeckoEnumStructAccessor(
-                self.struct, UAXNCU, TGCRHY, EKBDFS, NCUGUC, None, MOUNBL, QBMJVH
-            ),
-            CUGUCY: GeckoByteStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoBoolStructAccessor(
-                self.struct, GUCYRA, QJYMOU, YOUSPB, QBMJVH
-            ),
-            UCYRAP: GeckoByteStructAccessor(self.struct, UCYRAP, CYRAPU, QBMJVH),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, RAPUME, None, UMEAOE, None, None, QBMJVH
-            ),
-            MEAOES: GeckoEnumStructAccessor(
-                self.struct, MEAOES, EAOESV, None, OESVZS, None, None, QBMJVH
-            ),
-            ESVZSS: GeckoEnumStructAccessor(
-                self.struct, ESVZSS, SVZSSB, YOUSPB, NAXADX, None, OINELW, QBMJVH
-            ),
-            AXADXL: GeckoBoolStructAccessor(
-                self.struct, AXADXL, SVZSSB, BDFSRO, QBMJVH
-            ),
-            XADXLU: GeckoByteStructAccessor(self.struct, XADXLU, ADXLUB, QBMJVH),
-            DXLUBG: GeckoWordStructAccessor(self.struct, DXLUBG, XLUBGJ, QBMJVH),
-            LUBGJF: GeckoWordStructAccessor(self.struct, LUBGJF, UBGJFJ, QBMJVH),
-            BGJFJN: GeckoWordStructAccessor(self.struct, BGJFJN, GJFJNT, QBMJVH),
-            JFJNTT: GeckoWordStructAccessor(self.struct, JFJNTT, FJNTTU, QBMJVH),
-            JNTTUV: GeckoWordStructAccessor(self.struct, JNTTUV, NTTUVR, QBMJVH),
-            TTUVRF: GeckoWordStructAccessor(self.struct, TTUVRF, TUVRFL, QBMJVH),
-            UVRFLS: GeckoWordStructAccessor(self.struct, UVRFLS, VRFLSI, QBMJVH),
-            RFLSIJ: GeckoWordStructAccessor(self.struct, RFLSIJ, FLSIJU, QBMJVH),
-            LSIJUZ: GeckoWordStructAccessor(self.struct, LSIJUZ, SIJUZM, QBMJVH),
-            IJUZMR: GeckoWordStructAccessor(self.struct, IJUZMR, JUZMRK, QBMJVH),
-            UZMRKV: GeckoEnumStructAccessor(
-                self.struct, UZMRKV, ZMRKVF, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            KVFCPO: GeckoEnumStructAccessor(
-                self.struct, KVFCPO, ZMRKVF, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            POUBMI: GeckoEnumStructAccessor(
-                self.struct, POUBMI, OUBMIK, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            UBMIKG: GeckoEnumStructAccessor(
-                self.struct, UBMIKG, OUBMIK, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            BMIKGN: GeckoEnumStructAccessor(
-                self.struct, BMIKGN, MIKGNV, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            IKGNVF: GeckoEnumStructAccessor(
-                self.struct, IKGNVF, MIKGNV, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            KGNVFO: GeckoEnumStructAccessor(
-                self.struct, KGNVFO, GNVFOU, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            NVFOUU: GeckoEnumStructAccessor(
-                self.struct, NVFOUU, GNVFOU, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            VFOUUR: GeckoEnumStructAccessor(
-                self.struct, VFOUUR, FOUURI, YOUSPB, IEVBVH, None, OINELW, None
-            ),
-            EVBVHD: GeckoBoolStructAccessor(self.struct, EVBVHD, FOUURI, BDFSRO, None),
-            VBVHDV: GeckoBoolStructAccessor(self.struct, VBVHDV, ZMRKVF, MOUNBL, None),
-            BVHDVR: GeckoBoolStructAccessor(self.struct, BVHDVR, ZMRKVF, EAKSTS, None),
-            VHDVRI: GeckoBoolStructAccessor(self.struct, VHDVRI, ZMRKVF, EKBDFS, None),
-            HDVRID: GeckoBoolStructAccessor(self.struct, HDVRID, ZMRKVF, BDFSRO, None),
-            DVRIDK: GeckoBoolStructAccessor(self.struct, DVRIDK, OUBMIK, MOUNBL, None),
-            VRIDKE: GeckoBoolStructAccessor(self.struct, VRIDKE, OUBMIK, EAKSTS, None),
-            RIDKEY: GeckoBoolStructAccessor(self.struct, RIDKEY, OUBMIK, EKBDFS, None),
-            IDKEYG: GeckoBoolStructAccessor(self.struct, IDKEYG, OUBMIK, BDFSRO, None),
-            DKEYGG: GeckoBoolStructAccessor(self.struct, DKEYGG, MIKGNV, MOUNBL, None),
-            KEYGGV: GeckoBoolStructAccessor(self.struct, KEYGGV, MIKGNV, EAKSTS, None),
-            EYGGVY: GeckoBoolStructAccessor(self.struct, EYGGVY, MIKGNV, EKBDFS, None),
-            YGGVYK: GeckoBoolStructAccessor(self.struct, YGGVYK, MIKGNV, BDFSRO, None),
-            GGVYKL: GeckoBoolStructAccessor(self.struct, GGVYKL, GNVFOU, MOUNBL, None),
-            GVYKLT: GeckoBoolStructAccessor(self.struct, GVYKLT, GNVFOU, EAKSTS, None),
-            VYKLTQ: GeckoBoolStructAccessor(self.struct, VYKLTQ, GNVFOU, EKBDFS, None),
-            YKLTQL: GeckoBoolStructAccessor(self.struct, YKLTQL, GNVFOU, BDFSRO, None),
-            KLTQLV: GeckoEnumStructAccessor(
-                self.struct, KLTQLV, LTQLVH, None, SVSIBE, None, None, None
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/inye-v3-cfg-81.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-81.py
@@ -12,2072 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACQFFT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-ADXLUB = 134
-AFIKJP = 109
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-AIVEMV = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-AJVDQL = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AMJMAO = "".join(chr(c) for c in [72, 105])
-AOAWBS = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-AOESVZ = 174
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [80, 50])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = 10
-AWBSIR = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-AXNCUG = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-BDFSRO = 7
-BDJQRJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BEKBDF = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BEXLTP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BGJFJN = 135
-BHZVOA = 157
-BIAMJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [67, 89, 65, 78])
-BMIKGN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        56,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-BQNRXC = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-BQSNQL = 33
-BSIRYX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BSKSOK = 40
-BVHDVR = 124
-BVNAXA = 133
-BVWVUB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BWJYKL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-BXIBHZ = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-BXTIAC = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-BXYBQS = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BYGDSB = 167
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-CHWDAF = 107
-CMCVDS = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-CPOUBM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        54,
-    ]
-)
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-CRHYUA = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-CRTFMN = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CUGUCY = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = 121
-CYWONF = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-CZOLSI = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-DAFIKJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-DDPMXF = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DFSROG = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DJQRJJ = 170
-DKEYGG = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-DMPSCT = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-DNIBXT = 77
-DNQGVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-DQLAII = 68
-DRXAIV = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-DSBDJQ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DSSRUR = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-DUBSSU = "".join(chr(c) for c in [85, 76])
-DVRIDK = 125
-DXLUBG = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-DZXNQT = 71
-EAKSTS = 5
-EAOESV = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 50])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-EKBDFS = 6
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-ELHBQN = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-ELWUEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-EMCGET = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-EMVCYW = "".join(chr(c) for c in [76, 65])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = 175
-ETDRXA = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-EUHNNX = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-EUTOPH = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EXLTPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-EYGGVY = 127
-EZFETD = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FCPOUB = 145
-FCRTFM = 122
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-FIKJPU = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-FJBIAM = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FJNTTU = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-FJTACC = 43
-FLSIJU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-FOUURI = 123
-FSROGM = 110
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-FUBJLO = "".join(chr(c) for c in [66, 76, 85, 69])
-FWRKIN = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-FXQGLR = 16
-FYLJUI = "".join(chr(c) for c in [80, 49])
-FZCZOL = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-FZDGKE = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GCRHYU = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-GDSBDJ = 168
-GETIXQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GGVYKL = "".join(chr(c) for c in [50])
-GJFJNT = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-GKEAKS = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GNVFOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-        48,
-    ]
-)
-GSELHB = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-GTYIYW = 89
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GVUNXN = 96
-GVYKLT = "".join(chr(c) for c in [51])
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = 52
-HBXIBH = 130
-HDVRID = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-HSVSIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-HTBJEU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HUGTYI = 88
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-HWOGXX = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-HXEKVK = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-HZVOAC = "".join(chr(c) for c in [79, 70, 70])
-IACQFF = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IAMJMA = "".join(chr(c) for c in [76, 111])
-IBEXLT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-IBHZVO = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IBXTIA = 115
-IBXYBQ = 63
-ICXQIE = 13
-IDKEYG = 126
-IDNIBX = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IDUBSS = 51
-IEFXQG = 15
-IEVBVH = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-IFJBIA = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IGYOUS = "".join(chr(c) for c in [79, 119, 110])
-IHBXIB = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-IJUGSE = 101
-IJUZMR = 137
-IKFWRK = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-IKGNVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        57,
-    ]
-)
-IKJPUN = 3
-INEJNI = 30
-INELWU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-IPOUYN = 47
-IRYXBQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUVMKZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-IVEMVC = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 75
-IYWSKW = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JEUTOP = 85
-JFJNTT = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JJJVYF = "".join(chr(c) for c in [105, 110, 89, 74])
-JLOINE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-JMAOAW = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JNTTUV = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-JPUNRJ = 4
-JQRJJJ = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JQSGME = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-JUIKFW = 28
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        50,
-    ]
-)
-JVDQLA = 66
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-JWMNZM = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JYMOUN = 2
-JZTATD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-KBDFSR = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-KCWAON = 21
-KEAKST = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KEYGGV = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-KGNVFO = 153
-KHTZBB = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-KINEJN = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-KJPUNR = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KLGQPL = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-KLTQLV = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-KMLOIJ = 99
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = 76
-KVFCPO = 143
-KWIVDN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-KXSJWM = 80
-KZHWOG = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-KZILXW = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-LAIIDN = 70
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-LHBQNR = 104
-LIUXFE = 25
-LJUIKF = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 31
-LOIJUG = 100
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = 136
-LSIPMD = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-LSPFTS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTPOXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-LTQLVH = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-LVHSVS = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-LXWAJV = 3
-MAOAWB = 1
-MCBFEG = 163
-MCGETI = 73
-MCVDSS = 158
-MDMPSC = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MECYXM = 81
-MFZDGK = 72
-MHXEKV = 164
-MIKGNV = 151
-MJIGYO = 81
-MJVHFT = 12
-MKQTDK = 64
-MKZHWO = 172
-MLOIJU = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-MNHTBJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-MNZMJI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-MRKVFC = 141
-MVCYWO = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MXFUBJ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-NAXADX = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NEJNIB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-NELWUE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NFZCZO = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NHTBJE = 83
-NIBXTI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-NIBXYB = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NKMLOI = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-NMHXEK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-NNXWEE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = 95
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQTMFZ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NRJZTA = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-NTTUVR = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-NVFOUU = 155
-NXNKML = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-NXWEEZ = "".join(chr(c) for c in [65, 108, 112, 115])
-NZMJIG = 56
-OACMCV = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-OAWBSI = 58
-OCTHBS = 38
-OESVZS = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 51])
-OGMDDP = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-OGXXYO = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-OIHBXI = 128
-OIJUGS = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-OINELW = 8
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-ONFZCZ = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = 87
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        55,
-    ]
-)
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-OUURIE = "".join(chr(c) for c in [82, 71, 66])
-OUYNQJ = 48
-OXIUVM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-PBWJYK = 120
-PHUGTY = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 27
-PMDMPS = "".join(chr(c) for c in [73, 100, 111, 108])
-PMXFUB = "".join(chr(c) for c in [82, 69, 68])
-POUBMI = 147
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-POXIUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-PUMEAO = "".join(chr(c) for c in [80, 51])
-PUNRJZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-QFYLJU = 78
-QGLRAH = 26
-QGVUNX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-QLNMHX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 105
-QPLSPF = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-QRJJJV = 171
-QSNQLN = "".join(chr(c) for c in [70])
-QTDKHT = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-QTMFZD = 82
-QVXOIH = 160
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 173
-RAZMKQ = "".join(chr(c) for c in [50, 52, 104])
-RFLSIJ = 178
-RHYUAX = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-RIDKEY = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-RIEVBV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = "".join(chr(c) for c in [105, 110, 89, 84])
-RJZTAT = 116
-RKVFCP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        52,
-    ]
-)
-ROGMDD = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = 74
-RURAZM = 34
-RXAIVE = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-RXCHWD = 106
-RYXBQF = 61
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = 169
-SBVNAX = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-SCTTGC = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-SELHBQ = 103
-SIBEXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-SIFJBI = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-SIJUZM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-    ]
-)
-SIPMDM = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-SIRYXB = 60
-SJWMNZ = 54
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = 92
-SNQLNM = "".join(chr(c) for c in [67])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-SPFTSI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-SROGMD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SRURAZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = 177
-SSUHBV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-STSEMC = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-SUHBVW = 114
-SVSIBE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-SVZSSB = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 52])
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-TBJEUT = 84
-TDKHTZ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TDRXAI = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-TDZXNQ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TGCRHY = 112
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-TIDUBS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-TIXQVX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TMFZDG = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-TOPHUG = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TPOXIU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-TQLVHS = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-TSEMCG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-TSIFJB = 57
-TTGCRH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-TTIDUB = 162
-TTUVRF = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-TZBBEK = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-UAXNCU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-UBGJFJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-UBJLOI = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-UBMIKG = 149
-UBSSUH = "".join(chr(c) for c in [67, 69])
-UBYGDS = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-UCYRAP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-UEUHNN = 111
-UGSELH = 102
-UGTYIY = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-UGUCYR = 113
-UHBVWV = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-UHNNXW = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UIKFWR = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UJUTYE = 18
-UMEAOE = "".join(chr(c) for c in [80, 52])
-UNBLKX = 79
-UNRJZT = 6
-UNXNKM = 97
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [65, 109, 80, 109])
-URIEVB = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = 118
-UTOPHU = 86
-UTYEKC = 19
-UVMKZH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-UVRFLS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = 139
-VBVHDV = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-VCYWON = "".join(chr(c) for c in [77, 65, 65, 88])
-VDNQGV = 94
-VDQLAI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VDSSRU = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-VEMVCY = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-VFCPOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        53,
-    ]
-)
-VFOUUR = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-VHDVRI = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VHSVSI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-VKZILX = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VMKZHW = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-VNAXAD = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-VRFLSI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        66,
-        117,
-        111,
-        121,
-        97,
-        110,
-        99,
-        121,
-        80,
-        117,
-        109,
-        112,
-    ]
-)
-VRIDKE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-VSIBEX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-VUBYGD = 166
-VUNXNK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VWVUBY = 165
-VYFCRT = 53
-VYKLTQ = "".join(chr(c) for c in [52])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = 176
-WAJVDQ = 35
-WAONPY = 22
-WBSIRY = 59
-WDAFIK = 108
-WEEZFE = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-WIVDNQ = 93
-WJYKLG = 32
-WMNZMJ = 55
-WOGXXY = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-WONFZC = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WRKINE = 29
-WSKWIV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-WUEUHN = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XADXLU = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-XAIVEM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-XBQFYL = 62
-XCHWDA = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-XEKVKZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XFUBJL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-XIBHZV = 132
-XIUVMK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-XLTPOX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XLUBGJ = "".join(
-    chr(c)
-    for c in [
-        85,
-        83,
-        69,
-        95,
-        86,
-        65,
-        82,
-        73,
-        65,
-        66,
-        76,
-        69,
-        95,
-        83,
-        80,
-        69,
-        69,
-        68,
-        95,
-        80,
-        85,
-        77,
-        80,
-        83,
-    ]
-)
-XNCUGU = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-XNKMLO = 98
-XOIHBX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-XSJWMN = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-XTIACQ = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-XWEEZF = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-XXYOJQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-XYBQSN = 1
-XYOJQS = 179
-YBQSNQ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YEKCWA = 20
-YFCRTF = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGDSBD = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGGVYK = "".join(chr(c) for c in [49])
-YIYWSK = 90
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOJQSG = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-YOUSPB = 0
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 49])
-YUAXNC = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-YWONFZ = "".join(chr(c) for c in [80, 68, 67])
-YWSKWI = 91
-YXBQFY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZDGKEA = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ZFETDR = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-ZHWOGX = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-ZILXWA = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-ZMJIGY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-ZMKQTD = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ZMRKVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        51,
-    ]
-)
-ZOLSIP = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-ZSSBVN = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 53])
-ZTATDZ = 8
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-ZXNQTM = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-ACMCVD = [JVHFTH, HZVOAC, ZVOACM, VOACMC, OACMCV]
-AXADXL = [VNAXAD, NAXADX]
-AZMKQT = [JVHFTH, URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BSSUHB = [DUBSSU, UBSSUH]
-CTTGCR = [
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-]
-DKHTZB = [QTDKHT, TDKHTZ]
-ETIXQV = [VLASSA, CGETIX, GETIXQ]
-EVBVHD = [RIEVBV, IEVBVH]
-FFTTID = [BXTIAC, XTIACQ, TIACQF, IACQFF, ACQFFT, CQFFTT, QFFTTI]
-FMNHTB = [NEJNIB, TFMNHT]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-GMECYX = []
-GQPLSP = [JYKLGQ, YKLGQP, KLGQPL, LGQPLS]
-GXXYOJ = [KZHWOG, ZHWOGX, HWOGXX, WOGXXY, OGXXYO]
-GYOUSP = [JIGYOU, IGYOUS]
-HBQNRX = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-HYUAXN = [CRHYUA, RHYUAX, VLASSA, VLASSA]
-IIDNIB = [NEJNIB, AIIDNI]
-ILXWAJ = [KZILXW, ZILXWA]
-JBIAMJ = [SIFJBI, IFJBIA, FJBIAM]
-JJVYFC = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    RJJJVY,
-    VLASSA,
-    JJJVYF,
-]
-JNIBXY = [NEJNIB, EJNIBX]
-KFWRKI = [UIKFWR, IKFWRK]
-KVKZIL = [HXEKVK, XEKVKZ, EKVKZI]
-LOINEL = [HZVOAC, PMXFUB, MXFUBJ, XFUBJL, FUBJLO, UBJLOI, BJLOIN, JLOINE]
-LUBGJF = [DXLUBG, XLUBGJ]
-LWUEUH = [NELWUE, ELWUEU]
-MDDPMX = [OGMDDP, GMDDPM]
-MEAOES = [JVHFTH, FYLJUI, APUMEA, PUMEAO, UMEAOE, YYPIPI]
-MJMAOA = [IAMJMA, AMJMAO]
-NCUGUC = [JVHFTH, AXNCUG, XNCUGU, VLASSA]
-NQLNMH = [QSNQLN, SNQLNM]
-OJQSGM = [YOJQSG, JLOINE, MXFUBJ, LTQLVH, XFUBJL, BJLOIN, TQLVHS, HZVOAC]
-PFTSIF = [LSPFTS, SPFTSI]
-QLVHSV = [FUBJLO, JLOINE, MXFUBJ, LTQLVH, XFUBJL, BJLOIN, TQLVHS, HZVOAC]
-QSGMEC = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-]
-RKINEJ = [PIPIVL, FYLJUI]
-SEMCGE = [STSEMC, TSEMCG]
-SGMECY = [NBLKXS]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-SSRURA = [VDSSRU, DSSRUR]
-TUVRFL = [GJFJNT, JFJNTT, FJNTTU, JNTTUV, NTTUVR, TTUVRF, VLASSA, VLASSA]
-UURIEV = [OUURIE, JLOINE]
-VXOIHB = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XNQTMF = [JVHFTH, LSPFTS, ZXNQTM]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-YKLTQL = [VLASSA, YGGVYK, GGVYKL, GVYKLT, VYKLTQ]
-YLJUIK = [JVHFTH, FYLJUI, PIPIVL]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -2085,442 +19,1592 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return MECYXM
+        return 81
 
     @property
     def output_keys(self):
-        return QSGMEC
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, YOUSPB, GYOUSP, None, JYMOUN, QBMJVH
-            ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, JBIAMJ, None, None, QBMJVH
-            ),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, MJIGYO, JYMOUN, MJMAOA, None, JYMOUN, QBMJVH
-            ),
-            JMAOAW: GeckoBoolStructAccessor(
-                self.struct, JMAOAW, QJYMOU, MAOAWB, QBMJVH
-            ),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, QBMJVH),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, QBMJVH),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTempStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, RKINEJ, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, KVKZIL, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, MJIGYO, LXWAJV, ILXWAJ, None, JYMOUN, QBMJVH
-            ),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, QBMJVH),
-            AJVDQL: GeckoTempStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoTempStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, LAIIDN, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, FFTTID, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, BSSUHB, None, None, QBMJVH
-            ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, QBMJVH),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, QBMJVH),
-            BDJQRJ: GeckoByteStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, JJVYFC, None, None, None
-            ),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, FMNHTB, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, XLSXUJ, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, OPHUGT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, QBMJVH),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, QBMJVH),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, QBMJVH),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, QBMJVH),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, QBMJVH),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, HBQNRX, None, None, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, HBQNRX, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, HBQNRX, None, None, QBMJVH
-            ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, CHWDAF, None, HBQNRX, None, None, QBMJVH
-            ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, WDAFIK, None, HBQNRX, None, None, QBMJVH
-            ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, HBQNRX, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoTimeStructAccessor(self.struct, KJPUNR, JPUNRJ, QBMJVH),
-            PUNRJZ: GeckoTimeStructAccessor(self.struct, PUNRJZ, UNRJZT, QBMJVH),
-            NRJZTA: GeckoTimeStructAccessor(self.struct, NRJZTA, RJZTAT, QBMJVH),
-            JZTATD: GeckoTimeStructAccessor(self.struct, JZTATD, ZTATDZ, QBMJVH),
-            TATDZX: GeckoTimeStructAccessor(self.struct, TATDZX, ATDZXN, QBMJVH),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, None, XNQTMF, None, None, QBMJVH
-            ),
-            NQTMFZ: GeckoBoolStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, YOUSPB, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, MFZDGK, JYMOUN, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, MFZDGK, YOUSPB, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, MFZDGK, MAOAWB, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, MFZDGK, LXWAJV, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, MFZDGK, MOUNBL, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, MFZDGK, EAKSTS, QBMJVH
-            ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, SEMCGE, None, None, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, QBMJVH),
-            XQVXOI: GeckoEnumStructAccessor(
-                self.struct, XQVXOI, QVXOIH, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoTimeStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoTimeStructAccessor(self.struct, IHBXIB, HBXIBH, QBMJVH),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, QBMJVH),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, BHZVOA, None, ACMCVD, None, None, QBMJVH
-            ),
-            CMCVDS: GeckoTimeStructAccessor(self.struct, CMCVDS, MCVDSS, QBMJVH),
-            CVDSSR: GeckoEnumStructAccessor(
-                self.struct, CVDSSR, QJYMOU, LXWAJV, SSRURA, None, JYMOUN, QBMJVH
-            ),
-            SRURAZ: GeckoEnumStructAccessor(
-                self.struct, SRURAZ, RURAZM, None, AZMKQT, None, None, QBMJVH
-            ),
-            ZMKQTD: GeckoWordStructAccessor(self.struct, ZMKQTD, MKQTDK, QBMJVH),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, MJIGYO, MAOAWB, DKHTZB, None, JYMOUN, QBMJVH
-            ),
-            KHTZBB: GeckoBoolStructAccessor(
-                self.struct, KHTZBB, MJIGYO, MOUNBL, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MJIGYO, EAKSTS, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, MJIGYO, EKBDFS, QBMJVH
-            ),
-            KBDFSR: GeckoBoolStructAccessor(
-                self.struct, KBDFSR, MJIGYO, BDFSRO, QBMJVH
-            ),
-            DFSROG: GeckoBoolStructAccessor(
-                self.struct, DFSROG, FSROGM, YOUSPB, QBMJVH
-            ),
-            SROGMD: GeckoBoolStructAccessor(
-                self.struct, SROGMD, FSROGM, MAOAWB, QBMJVH
-            ),
-            ROGMDD: GeckoEnumStructAccessor(
-                self.struct, ROGMDD, FSROGM, JYMOUN, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DDPMXF: GeckoEnumStructAccessor(
-                self.struct, DDPMXF, FSROGM, LXWAJV, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, FSROGM, MOUNBL, LOINEL, None, OINELW, QBMJVH
-            ),
-            INELWU: GeckoEnumStructAccessor(
-                self.struct, INELWU, FSROGM, BDFSRO, LWUEUH, None, JYMOUN, QBMJVH
-            ),
-            TTGCRH: GeckoBoolStructAccessor(
-                self.struct, TTGCRH, TGCRHY, MAOAWB, QBMJVH
-            ),
-            GCRHYU: GeckoEnumStructAccessor(
-                self.struct, GCRHYU, TGCRHY, JYMOUN, HYUAXN, None, MOUNBL, QBMJVH
-            ),
-            YUAXNC: GeckoBoolStructAccessor(
-                self.struct, YUAXNC, TGCRHY, MOUNBL, QBMJVH
-            ),
-            UAXNCU: GeckoEnumStructAccessor(
-                self.struct, UAXNCU, TGCRHY, EKBDFS, NCUGUC, None, MOUNBL, QBMJVH
-            ),
-            CUGUCY: GeckoByteStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoBoolStructAccessor(
-                self.struct, GUCYRA, QJYMOU, YOUSPB, QBMJVH
-            ),
-            UCYRAP: GeckoByteStructAccessor(self.struct, UCYRAP, CYRAPU, QBMJVH),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, RAPUME, None, MEAOES, None, None, QBMJVH
-            ),
-            EAOESV: GeckoEnumStructAccessor(
-                self.struct, EAOESV, AOESVZ, None, MEAOES, None, None, QBMJVH
-            ),
-            OESVZS: GeckoEnumStructAccessor(
-                self.struct, OESVZS, ESVZSS, None, MEAOES, None, None, QBMJVH
-            ),
-            SVZSSB: GeckoEnumStructAccessor(
-                self.struct, SVZSSB, VZSSBV, None, MEAOES, None, None, QBMJVH
-            ),
-            ZSSBVN: GeckoEnumStructAccessor(
-                self.struct, ZSSBVN, SSBVNA, None, MEAOES, None, None, QBMJVH
-            ),
-            SBVNAX: GeckoEnumStructAccessor(
-                self.struct, SBVNAX, BVNAXA, None, AXADXL, None, None, QBMJVH
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, ADXLUB, None, LUBGJF, None, None, QBMJVH
-            ),
-            UBGJFJ: GeckoEnumStructAccessor(
-                self.struct, UBGJFJ, BGJFJN, YOUSPB, TUVRFL, None, OINELW, QBMJVH
-            ),
-            UVRFLS: GeckoBoolStructAccessor(
-                self.struct, UVRFLS, BGJFJN, BDFSRO, QBMJVH
-            ),
-            VRFLSI: GeckoEnumStructAccessor(
-                self.struct, VRFLSI, RFLSIJ, None, MEAOES, None, None, QBMJVH
-            ),
-            FLSIJU: GeckoByteStructAccessor(self.struct, FLSIJU, LSIJUZ, QBMJVH),
-            SIJUZM: GeckoWordStructAccessor(self.struct, SIJUZM, IJUZMR, QBMJVH),
-            JUZMRK: GeckoWordStructAccessor(self.struct, JUZMRK, UZMRKV, QBMJVH),
-            ZMRKVF: GeckoWordStructAccessor(self.struct, ZMRKVF, MRKVFC, QBMJVH),
-            RKVFCP: GeckoWordStructAccessor(self.struct, RKVFCP, KVFCPO, QBMJVH),
-            VFCPOU: GeckoWordStructAccessor(self.struct, VFCPOU, FCPOUB, QBMJVH),
-            CPOUBM: GeckoWordStructAccessor(self.struct, CPOUBM, POUBMI, QBMJVH),
-            OUBMIK: GeckoWordStructAccessor(self.struct, OUBMIK, UBMIKG, QBMJVH),
-            BMIKGN: GeckoWordStructAccessor(self.struct, BMIKGN, MIKGNV, QBMJVH),
-            IKGNVF: GeckoWordStructAccessor(self.struct, IKGNVF, KGNVFO, QBMJVH),
-            GNVFOU: GeckoWordStructAccessor(self.struct, GNVFOU, NVFOUU, QBMJVH),
-            VFOUUR: GeckoEnumStructAccessor(
-                self.struct, VFOUUR, FOUURI, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            URIEVB: GeckoEnumStructAccessor(
-                self.struct, URIEVB, FOUURI, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            VBVHDV: GeckoEnumStructAccessor(
-                self.struct, VBVHDV, BVHDVR, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            VHDVRI: GeckoEnumStructAccessor(
-                self.struct, VHDVRI, BVHDVR, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            HDVRID: GeckoEnumStructAccessor(
-                self.struct, HDVRID, DVRIDK, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            VRIDKE: GeckoEnumStructAccessor(
-                self.struct, VRIDKE, DVRIDK, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            RIDKEY: GeckoEnumStructAccessor(
-                self.struct, RIDKEY, IDKEYG, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            DKEYGG: GeckoEnumStructAccessor(
-                self.struct, DKEYGG, IDKEYG, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            KEYGGV: GeckoEnumStructAccessor(
-                self.struct, KEYGGV, EYGGVY, YOUSPB, YKLTQL, None, OINELW, None
-            ),
-            KLTQLV: GeckoEnumStructAccessor(
-                self.struct, KLTQLV, EYGGVY, LXWAJV, QLVHSV, None, OINELW, QBMJVH
-            ),
-            LVHSVS: GeckoBoolStructAccessor(self.struct, LVHSVS, EYGGVY, BDFSRO, None),
-            VHSVSI: GeckoBoolStructAccessor(self.struct, VHSVSI, FOUURI, MOUNBL, None),
-            HSVSIB: GeckoBoolStructAccessor(self.struct, HSVSIB, FOUURI, EAKSTS, None),
-            SVSIBE: GeckoBoolStructAccessor(self.struct, SVSIBE, FOUURI, EKBDFS, None),
-            VSIBEX: GeckoBoolStructAccessor(self.struct, VSIBEX, FOUURI, BDFSRO, None),
-            SIBEXL: GeckoBoolStructAccessor(self.struct, SIBEXL, BVHDVR, MOUNBL, None),
-            IBEXLT: GeckoBoolStructAccessor(self.struct, IBEXLT, BVHDVR, EAKSTS, None),
-            BEXLTP: GeckoBoolStructAccessor(self.struct, BEXLTP, BVHDVR, EKBDFS, None),
-            EXLTPO: GeckoBoolStructAccessor(self.struct, EXLTPO, BVHDVR, BDFSRO, None),
-            XLTPOX: GeckoBoolStructAccessor(self.struct, XLTPOX, DVRIDK, MOUNBL, None),
-            LTPOXI: GeckoBoolStructAccessor(self.struct, LTPOXI, DVRIDK, EAKSTS, None),
-            TPOXIU: GeckoBoolStructAccessor(self.struct, TPOXIU, DVRIDK, EKBDFS, None),
-            POXIUV: GeckoBoolStructAccessor(self.struct, POXIUV, DVRIDK, BDFSRO, None),
-            OXIUVM: GeckoBoolStructAccessor(self.struct, OXIUVM, IDKEYG, MOUNBL, None),
-            XIUVMK: GeckoBoolStructAccessor(self.struct, XIUVMK, IDKEYG, EAKSTS, None),
-            IUVMKZ: GeckoBoolStructAccessor(self.struct, IUVMKZ, IDKEYG, EKBDFS, None),
-            UVMKZH: GeckoBoolStructAccessor(self.struct, UVMKZH, IDKEYG, BDFSRO, None),
-            VMKZHW: GeckoEnumStructAccessor(
-                self.struct, VMKZHW, MKZHWO, None, GXXYOJ, None, None, None
-            ),
-            XXYOJQ: GeckoEnumStructAccessor(
-                self.struct, XXYOJQ, XYOJQS, MOUNBL, OJQSGM, None, OINELW, QBMJVH
-            ),
-            JQSGME: GeckoBoolStructAccessor(self.struct, JQSGME, XYOJQS, BDFSRO, None),
         }

--- a/src/geckolib/driver/packs/inye-v3-cfg-82.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-82.py
@@ -12,2100 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACMCVD = 157
-ACQFFT = 115
-AFIKJP = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = 66
-AIVEMV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-AJVDQL = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AMJMAO = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-AOAWBS = "".join(chr(c) for c in [76, 111])
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 49])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-AXADXL = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BDFSRO = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BDJQRJ = 167
-BEKBDF = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BEXLTP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BHZVOA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-BIAMJM = 57
-BJLOIN = "".join(chr(c) for c in [82, 69, 68])
-BMIKGN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        55,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 60
-BQNRXC = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-BQSNQL = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-BSIRYX = 1
-BSKSOK = 40
-BSSUHB = 162
-BVNAXA = 177
-BWJYKL = 0
-BXYBQS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-CHWDAF = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-CMCVDS = "".join(chr(c) for c in [79, 70, 70])
-CPOUBM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        53,
-    ]
-)
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-CRHYUA = 112
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CTTGCR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-CUGUCY = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-CVDSSR = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CYWONF = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-CYXMPY = 82
-CZOLSI = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DAFIKJ = 106
-DDPMXF = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-DGKEAK = 82
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DKEYGG = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-DKHTZB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-DMPSCT = "".join(chr(c) for c in [73, 100, 111, 108])
-DNIBXT = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-DNQGVU = 92
-DPMXFU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-DRXAIV = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-DSBDJQ = 166
-DVRIDK = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-DXLUBG = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-DZXNQT = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-EAKSTS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-EAOESV = "".join(chr(c) for c in [80, 52])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = 29
-EKBDFS = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = 31
-ELHBQN = 101
-ELWUEU = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-EMCGET = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EMVCYW = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = 174
-ETDRXA = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-EUHNNX = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-EUTOPH = 83
-EVBVHD = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EXLTPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-EYGGVY = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-EZFETD = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-FCPOUB = 143
-FCRTFM = "".join(chr(c) for c in [105, 110, 89, 74])
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FFTTID = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-FIKJPU = 107
-FJNTTU = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-FJTACC = 43
-FLSIJU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        66,
-        117,
-        111,
-        121,
-        97,
-        110,
-        99,
-        121,
-        80,
-        117,
-        109,
-        112,
-    ]
-)
-FMNHTB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-FOUURI = 155
-FSROGM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTTIDU = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-FUBJLO = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-FWRKIN = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FXQGLR = 16
-FYLJUI = 61
-FZCZOL = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-GCRHYU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-GETIXQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-GGVYKL = 127
-GJFJNT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-GKEAKS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GNVFOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        57,
-    ]
-)
-GQPLSP = 32
-GSELHB = 100
-GTYIYW = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-GUCYRA = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-GVUNXN = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-GVYKLT = "".join(chr(c) for c in [49])
-GXXYOJ = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-GYOUSP = 56
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBQNRX = 102
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = "".join(chr(c) for c in [67, 69])
-HBXIBH = 160
-HDVRID = 124
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-HSVSIB = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-HTBJEU = 74
-HTZBBE = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HUGTYI = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = 105
-HWOGXX = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-HYUAXN = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HZVOAC = 130
-IACQFF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-IAMJMA = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-IBEXLT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-IBHZVO = 128
-IBXTIA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-IBXYBQ = 30
-ICXQIE = 13
-IDKEYG = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-IDNIBX = 68
-IDUBSS = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IEFXQG = 15
-IEVBVH = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-IFJBIA = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-IGYOUS = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IHBXIB = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-IIDNIB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IJUGSE = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-IJUZMR = 136
-IKFWRK = "".join(chr(c) for c in [80, 49])
-IKGNVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        56,
-    ]
-)
-IKJPUN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-ILXWAJ = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-INELWU = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-IPOUYN = 47
-IRYXBQ = 58
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUVMKZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = 91
-IVEMVC = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 73
-IYWSKW = 88
-JBIAMJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-JEUTOP = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JFJNTT = 135
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = 55
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-JJVYFC = 170
-JLOINE = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JNTTUV = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-JPUNRJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JQRJJJ = 168
-JQSGME = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = 99
-JUIKFW = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-    ]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JWMNZM = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JYKLGQ = 118
-JYMOUN = 2
-JZTATD = 4
-KBDFSR = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-KCWAON = 21
-KEAKST = 72
-KEYGGV = 126
-KGNVFO = 151
-KHTZBB = 64
-KINEJN = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-KJPUNR = 108
-KLGQPL = 120
-KLTQLV = "".join(chr(c) for c in [52])
-KMLOIJ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(chr(c) for c in [65, 109, 80, 109])
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KVFCPO = 141
-KVKZIL = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-KWIVDN = 90
-KXSJWM = 80
-KZHWOG = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-LAIIDN = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LHBQNR = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-LIUXFE = 25
-LJUIKF = 62
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 33
-LOIJUG = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-LOINEL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = 178
-LSIPMD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-LSPFTS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTPOXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-LUBGJF = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-LVHSVS = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-MAOAWB = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-MCBFEG = 163
-MCGETI = 76
-MCVDSS = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-MDDPMX = 110
-MDMPSC = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-MEAOES = "".join(chr(c) for c in [80, 51])
-MFZDGK = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-MHXEKV = "".join(chr(c) for c in [67])
-MIKGNV = 149
-MJIGYO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-MJMAOA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-MJVHFT = 12
-MKQTDK = 34
-MKZHWO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-MLOIJU = 97
-MNHTBJ = 122
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MRKVFC = 139
-MVCYWO = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-MXFUBJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-NAXADX = 133
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NCUGUC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-NEJNIB = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-NELWUE = "".join(chr(c) for c in [67, 89, 65, 78])
-NFZCZO = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-NHTBJE = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-NIBXTI = 70
-NIBXYB = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-NKMLOI = 96
-NMHXEK = "".join(chr(c) for c in [70])
-NNXWEE = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQLNMH = 1
-NQTMFZ = 10
-NRJZTA = 3
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-NTTUVR = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-NVFOUU = 153
-NXNKML = 95
-NXWEEZ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-NZMJIG = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OACMCV = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-OAWBSI = "".join(chr(c) for c in [72, 105])
-OCTHBS = 38
-OESVZS = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 50])
-OGMDDP = 7
-OGXXYO = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-OIHBXI = 75
-OIJUGS = 98
-OINELW = "".join(chr(c) for c in [66, 76, 85, 69])
-OJQSGM = 179
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-ONFZCZ = "".join(chr(c) for c in [80, 68, 67])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        54,
-    ]
-)
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = 81
-OUURIE = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-OUYNQJ = 48
-OXIUVM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-PHUGTY = 85
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-PMDMPS = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-PMXFUB = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-POUBMI = 145
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-POXIUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-PUMEAO = 173
-PUNRJZ = 109
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-QGLRAH = 26
-QGVUNX = 93
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = 35
-QLNMHX = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QLVHSV = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 103
-QPLSPF = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-QSNQLN = 63
-QTDKHT = "".join(chr(c) for c in [50, 52, 104])
-QTMFZD = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QVXOIH = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 121
-RAZMKQ = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-RFLSIJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-RHYUAX = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-RIDKEY = 125
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = 169
-RJZTAT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-RKVFCP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        51,
-    ]
-)
-ROGMDD = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-RURAZM = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-RXAIVE = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-RXCHWD = 104
-RYXBQF = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-SBVNAX = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 53])
-SCTTGC = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-SELHBQ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-SEMCGE = 5
-SGMECY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-SIBEXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-SIFJBI = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-SIJUZM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SIPMDM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-SIRYXB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SJWMNZ = 180
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-SNQLNM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [79, 119, 110])
-SPFTSI = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SROGMD = 6
-SRURAZ = 158
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = 176
-SSRURA = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SSUHBV = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-STSEMC = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-SUHBVW = 51
-SVSIBE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-SVZSSB = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 51])
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = 6
-TBJEUT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TDRXAI = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-TDZXNQ = 116
-TFMNHT = 53
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 77
-TIDUBS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-TIXQVX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-TMFZDG = 71
-TOPHUG = 84
-TPOXIU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-TQLVHS = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-TSEMCG = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-TSIFJB = 27
-TTGCRH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-TTIDUB = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-TTUVRF = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-TUVRFL = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = 87
-TZBBEK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBGJFJ = "".join(
-    chr(c)
-    for c in [
-        85,
-        83,
-        69,
-        95,
-        86,
-        65,
-        82,
-        73,
-        65,
-        66,
-        76,
-        69,
-        95,
-        83,
-        80,
-        69,
-        69,
-        68,
-        95,
-        80,
-        85,
-        77,
-        80,
-        83,
-    ]
-)
-UBJLOI = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-UBMIKG = 147
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-UBYGDS = 52
-UCYRAP = 113
-UEUHNN = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-UGSELH = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UGTYIY = 86
-UHBVWV = "".join(chr(c) for c in [85, 76])
-UHNNXW = 111
-UIKFWR = 78
-UJUTYE = 18
-UMEAOE = "".join(chr(c) for c in [80, 50])
-UNBLKX = 79
-UNRJZT = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-UNXNKM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-URIEVB = "".join(chr(c) for c in [82, 71, 66])
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UTOPHU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-UTYEKC = 19
-UURIEV = 123
-UVMKZH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-UVRFLS = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = 137
-VBVHDV = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-VCYWON = "".join(chr(c) for c in [76, 65])
-VDNQGV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-VDQLAI = 3
-VDSSRU = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-VEMVCY = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-VFCPOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        52,
-    ]
-)
-VFOUUR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-        48,
-    ]
-)
-VHDVRI = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 164
-VLASSA = "".join(chr(c) for c in [])
-VMKZHW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-VNAXAD = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-VOACMC = 132
-VRIDKE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-VSIBEX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-VUBYGD = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-VUNXNK = 94
-VWVUBY = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-VYFCRT = 171
-VYKLTQ = "".join(chr(c) for c in [50])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = 175
-WAJVDQ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-WAONPY = 22
-WBSIRY = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WDAFIK = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-WEEZFE = "".join(chr(c) for c in [65, 108, 112, 115])
-WIVDNQ = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-WJYKLG = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-WMNZMJ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-WOGXXY = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-WONFZC = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-WRKINE = 28
-WSKWIV = 89
-WUEUHN = 8
-WVUBYG = 114
-XADXLU = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-XAIVEM = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XIBHZV = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XIUVMK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-XLTPOX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-XLUBGJ = 134
-XNCUGU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-XNKMLO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-XNQTMF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-XOIHBX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        83,
-        97,
-        102,
-        101,
-        116,
-        121,
-    ]
-)
-XTIACQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XWEEZF = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-XXYOJQ = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-XYBQSN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-YEKCWA = 20
-YFCRTF = "".join(chr(c) for c in [105, 110, 89, 84])
-YGDSBD = 165
-YGGVYK = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-YIYWSK = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-YKLGQP = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-YKLTQL = "".join(chr(c) for c in [51])
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YLJUIK = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOJQSG = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-YOUSPB = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-YUAXNC = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-YWONFZ = "".join(chr(c) for c in [77, 65, 65, 88])
-YWSKWI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-YXBQFY = 59
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-ZDGKEA = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ZFETDR = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ZHWOGX = 172
-ZILXWA = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-ZMJIGY = 54
-ZMKQTD = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-ZMRKVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        50,
-    ]
-)
-ZOLSIP = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZSSBVN = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 52])
-ZTATDZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZXNQTM = 8
-ADXLUB = [AXADXL, XADXLU]
-AOESVZ = [JVHFTH, IKFWRK, UMEAOE, MEAOES, EAOESV, YYPIPI]
-AWBSIR = [AOAWBS, OAWBSI]
-AZMKQT = [URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BGJFJN = [LUBGJF, UBGJFJ]
-BJEUTO = [BXYBQS, TBJEUT]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BVHDVR = [EVBVHD, VBVHDV]
-BVWVUB = [UHBVWV, HBVWVU]
-BXIBHZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-BXTIAC = [BXYBQS, IBXTIA]
-CRTFMN = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    YFCRTF,
-    VLASSA,
-    FCRTFM,
-]
-DFSROG = [KBDFSR, BDFSRO]
-DSSRUR = [JVHFTH, CMCVDS, MCVDSS, CVDSSR, VDSSRU]
-DUBSSU = [CQFFTT, QFFTTI, FFTTID, FTTIDU, TTIDUB, TIDUBS, IDUBSS]
-ECYXMP = []
-ETIXQV = [CGETIX, GETIXQ]
-FJBIAM = [SIFJBI, IFJBIA]
-FZDGKE = [JVHFTH, SIFJBI, MFZDGK]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-GMECYX = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-    XSJWMN,
-]
-HXEKVK = [NMHXEK, MHXEKV]
-INEJNI = [RKINEJ, KINEJN]
-JMAOAW = [IAMJMA, AMJMAO, MJMAOA]
-JNIBXY = [PIPIVL, IKFWRK]
-JVDQLA = [WAJVDQ, AJVDQL]
-KFWRKI = [JVHFTH, IKFWRK, PIPIVL]
-LTQLVH = [VLASSA, GVYKLT, VYKLTQ, YKLTQL, KLTQLV]
-LWUEUH = [CMCVDS, BJLOIN, JLOINE, LOINEL, OINELW, INELWU, NELWUE, ELWUEU]
-LXWAJV = [KZILXW, ZILXWA, ILXWAJ]
-MECYXM = [NBLKXS]
-MNZMJI = [JWMNZM, WMNZMJ]
-PBWJYK = [USPBWJ, SPBWJY]
-PFTSIF = [QPLSPF, PLSPFT, LSPFTS, SPFTSI]
-QSGMEC = [JQSGME, ELWUEU, JLOINE, QLVHSV, LOINEL, NELWUE, LVHSVS, CMCVDS]
-RIEVBV = [URIEVB, ELWUEU]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-TDKHTZ = [JVHFTH, KQTDKH, QTDKHT]
-TGCRHY = [
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-    CTTGCR,
-    TTGCRH,
-]
-UAXNCU = [HYUAXN, YUAXNC, VLASSA, VLASSA]
-UGUCYR = [JVHFTH, NCUGUC, CUGUCY, VLASSA]
-VHSVSI = [OINELW, ELWUEU, JLOINE, QLVHSV, LOINEL, NELWUE, LVHSVS, CMCVDS]
-VRFLSI = [FJNTTU, JNTTUV, NTTUVR, TTUVRF, TUVRFL, UVRFLS, VLASSA, VLASSA]
-VXOIHB = [VLASSA, XQVXOI, QVXOIH]
-XCHWDA = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-XFUBJL = [PMXFUB, MXFUBJ]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-XYOJQS = [HWOGXX, WOGXXY, OGXXYO, GXXYOJ, XXYOJQ]
-YBQSNQ = [BXYBQS, XYBQSN]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -2113,445 +19,1603 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return CYXMPY
+        return 82
 
     @property
     def output_keys(self):
-        return GMECYX
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MNZMJI, None, None, None
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, BWJYKL, PBWJYK, None, JYMOUN, QBMJVH
-            ),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, JMAOAW, None, None, QBMJVH
-            ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, OUSPBW, JYMOUN, AWBSIR, None, JYMOUN, QBMJVH
-            ),
-            WBSIRY: GeckoBoolStructAccessor(
-                self.struct, WBSIRY, QJYMOU, BSIRYX, QBMJVH
-            ),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoByteStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
-            ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoEnumStructAccessor(
-                self.struct, NIBXYB, IBXYBQ, None, YBQSNQ, None, None, QBMJVH
-            ),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoTempStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, HXEKVK, None, None, QBMJVH
-            ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, JNIBXY, None, None, QBMJVH
-            ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, LXWAJV, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, OUSPBW, VDQLAI, JVDQLA, None, JYMOUN, QBMJVH
-            ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoTempStructAccessor(self.struct, LAIIDN, AIIDNI, QBMJVH),
-            IIDNIB: GeckoTempStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, DUBSSU, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, SUHBVW, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, CRTFMN, None, None, None
-            ),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, BJEUTO, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, XLSXUJ, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NKMLOI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, QBMJVH),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, QBMJVH),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, XCHWDA, None, None, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, XCHWDA, None, None, QBMJVH
-            ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, XCHWDA, None, None, QBMJVH
-            ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, None, XCHWDA, None, None, QBMJVH
-            ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, XCHWDA, None, None, QBMJVH
-            ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, XCHWDA, None, None, QBMJVH
-            ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, QBMJVH),
-            RJZTAT: GeckoTimeStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoTimeStructAccessor(self.struct, ZTATDZ, TATDZX, QBMJVH),
-            ATDZXN: GeckoTimeStructAccessor(self.struct, ATDZXN, TDZXNQ, QBMJVH),
-            DZXNQT: GeckoTimeStructAccessor(self.struct, DZXNQT, ZXNQTM, QBMJVH),
-            XNQTMF: GeckoTimeStructAccessor(self.struct, XNQTMF, NQTMFZ, QBMJVH),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, None, FZDGKE, None, None, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, BWJYKL, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, KEAKST, JYMOUN, QBMJVH
-            ),
-            EAKSTS: GeckoBoolStructAccessor(
-                self.struct, EAKSTS, KEAKST, BWJYKL, QBMJVH
-            ),
-            AKSTSE: GeckoBoolStructAccessor(
-                self.struct, AKSTSE, KEAKST, BSIRYX, QBMJVH
-            ),
-            KSTSEM: GeckoBoolStructAccessor(
-                self.struct, KSTSEM, KEAKST, VDQLAI, QBMJVH
-            ),
-            STSEMC: GeckoBoolStructAccessor(
-                self.struct, STSEMC, KEAKST, MOUNBL, QBMJVH
-            ),
-            TSEMCG: GeckoBoolStructAccessor(
-                self.struct, TSEMCG, KEAKST, SEMCGE, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, IXQVXO, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoByteStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, HBXIBH, None, BXIBHZ, None, None, QBMJVH
-            ),
-            XIBHZV: GeckoTimeStructAccessor(self.struct, XIBHZV, IBHZVO, QBMJVH),
-            BHZVOA: GeckoTimeStructAccessor(self.struct, BHZVOA, HZVOAC, QBMJVH),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, QBMJVH),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, ACMCVD, None, DSSRUR, None, None, QBMJVH
-            ),
-            SSRURA: GeckoTimeStructAccessor(self.struct, SSRURA, SRURAZ, QBMJVH),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, QJYMOU, VDQLAI, AZMKQT, None, JYMOUN, QBMJVH
-            ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, TDKHTZ, None, None, QBMJVH
-            ),
-            DKHTZB: GeckoWordStructAccessor(self.struct, DKHTZB, KHTZBB, QBMJVH),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, OUSPBW, BSIRYX, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, OUSPBW, MOUNBL, QBMJVH
-            ),
-            EKBDFS: GeckoEnumStructAccessor(
-                self.struct, EKBDFS, OUSPBW, SEMCGE, DFSROG, None, JYMOUN, QBMJVH
-            ),
-            FSROGM: GeckoBoolStructAccessor(
-                self.struct, FSROGM, OUSPBW, SROGMD, QBMJVH
-            ),
-            ROGMDD: GeckoBoolStructAccessor(
-                self.struct, ROGMDD, OUSPBW, OGMDDP, QBMJVH
-            ),
-            GMDDPM: GeckoBoolStructAccessor(
-                self.struct, GMDDPM, MDDPMX, BWJYKL, QBMJVH
-            ),
-            DDPMXF: GeckoBoolStructAccessor(
-                self.struct, DDPMXF, MDDPMX, BSIRYX, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, MDDPMX, JYMOUN, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            FUBJLO: GeckoEnumStructAccessor(
-                self.struct, FUBJLO, MDDPMX, VDQLAI, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            UBJLOI: GeckoEnumStructAccessor(
-                self.struct, UBJLOI, MDDPMX, MOUNBL, LWUEUH, None, WUEUHN, QBMJVH
-            ),
-            UEUHNN: GeckoEnumStructAccessor(
-                self.struct, UEUHNN, MDDPMX, OGMDDP, MNZMJI, None, JYMOUN, QBMJVH
-            ),
-            GCRHYU: GeckoBoolStructAccessor(
-                self.struct, GCRHYU, CRHYUA, BSIRYX, QBMJVH
-            ),
-            RHYUAX: GeckoEnumStructAccessor(
-                self.struct, RHYUAX, CRHYUA, JYMOUN, UAXNCU, None, MOUNBL, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, CRHYUA, MOUNBL, QBMJVH
-            ),
-            XNCUGU: GeckoEnumStructAccessor(
-                self.struct, XNCUGU, CRHYUA, SROGMD, UGUCYR, None, MOUNBL, QBMJVH
-            ),
-            GUCYRA: GeckoByteStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoBoolStructAccessor(
-                self.struct, CYRAPU, QJYMOU, BWJYKL, QBMJVH
-            ),
-            YRAPUM: GeckoByteStructAccessor(self.struct, YRAPUM, RAPUME, QBMJVH),
-            APUMEA: GeckoEnumStructAccessor(
-                self.struct, APUMEA, PUMEAO, None, AOESVZ, None, None, QBMJVH
-            ),
-            OESVZS: GeckoEnumStructAccessor(
-                self.struct, OESVZS, ESVZSS, None, AOESVZ, None, None, QBMJVH
-            ),
-            SVZSSB: GeckoEnumStructAccessor(
-                self.struct, SVZSSB, VZSSBV, None, AOESVZ, None, None, QBMJVH
-            ),
-            ZSSBVN: GeckoEnumStructAccessor(
-                self.struct, ZSSBVN, SSBVNA, None, AOESVZ, None, None, QBMJVH
-            ),
-            SBVNAX: GeckoEnumStructAccessor(
-                self.struct, SBVNAX, BVNAXA, None, AOESVZ, None, None, QBMJVH
-            ),
-            VNAXAD: GeckoEnumStructAccessor(
-                self.struct, VNAXAD, NAXADX, None, ADXLUB, None, None, QBMJVH
-            ),
-            DXLUBG: GeckoEnumStructAccessor(
-                self.struct, DXLUBG, XLUBGJ, None, BGJFJN, None, None, QBMJVH
-            ),
-            GJFJNT: GeckoEnumStructAccessor(
-                self.struct, GJFJNT, JFJNTT, BWJYKL, VRFLSI, None, WUEUHN, QBMJVH
-            ),
-            RFLSIJ: GeckoBoolStructAccessor(
-                self.struct, RFLSIJ, JFJNTT, OGMDDP, QBMJVH
-            ),
-            FLSIJU: GeckoEnumStructAccessor(
-                self.struct, FLSIJU, LSIJUZ, None, AOESVZ, None, None, QBMJVH
-            ),
-            SIJUZM: GeckoByteStructAccessor(self.struct, SIJUZM, IJUZMR, QBMJVH),
-            JUZMRK: GeckoWordStructAccessor(self.struct, JUZMRK, UZMRKV, QBMJVH),
-            ZMRKVF: GeckoWordStructAccessor(self.struct, ZMRKVF, MRKVFC, QBMJVH),
-            RKVFCP: GeckoWordStructAccessor(self.struct, RKVFCP, KVFCPO, QBMJVH),
-            VFCPOU: GeckoWordStructAccessor(self.struct, VFCPOU, FCPOUB, QBMJVH),
-            CPOUBM: GeckoWordStructAccessor(self.struct, CPOUBM, POUBMI, QBMJVH),
-            OUBMIK: GeckoWordStructAccessor(self.struct, OUBMIK, UBMIKG, QBMJVH),
-            BMIKGN: GeckoWordStructAccessor(self.struct, BMIKGN, MIKGNV, QBMJVH),
-            IKGNVF: GeckoWordStructAccessor(self.struct, IKGNVF, KGNVFO, QBMJVH),
-            GNVFOU: GeckoWordStructAccessor(self.struct, GNVFOU, NVFOUU, QBMJVH),
-            VFOUUR: GeckoWordStructAccessor(self.struct, VFOUUR, FOUURI, QBMJVH),
-            OUURIE: GeckoEnumStructAccessor(
-                self.struct, OUURIE, UURIEV, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            IEVBVH: GeckoEnumStructAccessor(
-                self.struct, IEVBVH, UURIEV, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            VHDVRI: GeckoEnumStructAccessor(
-                self.struct, VHDVRI, HDVRID, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            DVRIDK: GeckoEnumStructAccessor(
-                self.struct, DVRIDK, HDVRID, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            VRIDKE: GeckoEnumStructAccessor(
-                self.struct, VRIDKE, RIDKEY, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            IDKEYG: GeckoEnumStructAccessor(
-                self.struct, IDKEYG, RIDKEY, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            DKEYGG: GeckoEnumStructAccessor(
-                self.struct, DKEYGG, KEYGGV, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            EYGGVY: GeckoEnumStructAccessor(
-                self.struct, EYGGVY, KEYGGV, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            YGGVYK: GeckoEnumStructAccessor(
-                self.struct, YGGVYK, GGVYKL, BWJYKL, LTQLVH, None, WUEUHN, None
-            ),
-            TQLVHS: GeckoEnumStructAccessor(
-                self.struct, TQLVHS, GGVYKL, VDQLAI, VHSVSI, None, WUEUHN, QBMJVH
-            ),
-            HSVSIB: GeckoBoolStructAccessor(self.struct, HSVSIB, GGVYKL, OGMDDP, None),
-            SVSIBE: GeckoBoolStructAccessor(self.struct, SVSIBE, UURIEV, MOUNBL, None),
-            VSIBEX: GeckoBoolStructAccessor(self.struct, VSIBEX, UURIEV, SEMCGE, None),
-            SIBEXL: GeckoBoolStructAccessor(self.struct, SIBEXL, UURIEV, SROGMD, None),
-            IBEXLT: GeckoBoolStructAccessor(self.struct, IBEXLT, UURIEV, OGMDDP, None),
-            BEXLTP: GeckoBoolStructAccessor(self.struct, BEXLTP, HDVRID, MOUNBL, None),
-            EXLTPO: GeckoBoolStructAccessor(self.struct, EXLTPO, HDVRID, SEMCGE, None),
-            XLTPOX: GeckoBoolStructAccessor(self.struct, XLTPOX, HDVRID, SROGMD, None),
-            LTPOXI: GeckoBoolStructAccessor(self.struct, LTPOXI, HDVRID, OGMDDP, None),
-            TPOXIU: GeckoBoolStructAccessor(self.struct, TPOXIU, RIDKEY, MOUNBL, None),
-            POXIUV: GeckoBoolStructAccessor(self.struct, POXIUV, RIDKEY, SEMCGE, None),
-            OXIUVM: GeckoBoolStructAccessor(self.struct, OXIUVM, RIDKEY, SROGMD, None),
-            XIUVMK: GeckoBoolStructAccessor(self.struct, XIUVMK, RIDKEY, OGMDDP, None),
-            IUVMKZ: GeckoBoolStructAccessor(self.struct, IUVMKZ, KEYGGV, MOUNBL, None),
-            UVMKZH: GeckoBoolStructAccessor(self.struct, UVMKZH, KEYGGV, SEMCGE, None),
-            VMKZHW: GeckoBoolStructAccessor(self.struct, VMKZHW, KEYGGV, SROGMD, None),
-            MKZHWO: GeckoBoolStructAccessor(self.struct, MKZHWO, KEYGGV, OGMDDP, None),
-            KZHWOG: GeckoEnumStructAccessor(
-                self.struct, KZHWOG, ZHWOGX, None, XYOJQS, None, None, None
-            ),
-            YOJQSG: GeckoEnumStructAccessor(
-                self.struct, YOJQSG, OJQSGM, MOUNBL, QSGMEC, None, WUEUHN, QBMJVH
-            ),
-            SGMECY: GeckoBoolStructAccessor(self.struct, SGMECY, OJQSGM, OGMDDP, None),
         }

--- a/src/geckolib/driver/packs/inye-v3-cfg-83.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-83.py
@@ -12,2155 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACMCVD = 157
-ACQFFT = 115
-ADXLUB = 175
-AFIKJP = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = 66
-AIVEMV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-AJVDQL = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AMJMAO = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-AOAWBS = "".join(chr(c) for c in [76, 111])
-AOESVZ = "".join(
-    chr(c)
-    for c in [86, 83, 80, 72, 101, 97, 116, 105, 110, 103, 83, 112, 101, 101, 100]
-)
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [86, 83, 80, 84, 121, 112, 101])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-AXADXL = 174
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BDFSRO = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BDJQRJ = 167
-BEKBDF = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BEXLTP = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BGJFJN = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-BHZVOA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-BIAMJM = 57
-BJLOIN = "".join(chr(c) for c in [82, 69, 68])
-BMIKGN = 139
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 60
-BQNRXC = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-BQSNQL = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-BSIRYX = 1
-BSKSOK = 40
-BSSUHB = 162
-BVHDVR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-        48,
-    ]
-)
-BVNAXA = "".join(chr(c) for c in [80, 52])
-BWJYKL = 0
-BXYBQS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-CHWDAF = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-CMCVDS = "".join(chr(c) for c in [79, 70, 70])
-CPOUBM = 136
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-CRHYUA = 112
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CTTGCR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-CUGUCY = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-CVDSSR = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CYWONF = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-CZOLSI = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DAFIKJ = 106
-DDPMXF = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-DGKEAK = 82
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DKEYGG = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-DKHTZB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-DMPSCT = "".join(chr(c) for c in [73, 100, 111, 108])
-DNIBXT = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-DNQGVU = 92
-DPMXFU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-DRXAIV = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-DSBDJQ = 166
-DVRIDK = 123
-DXLUBG = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 52])
-DZXNQT = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-EAKSTS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-ECYXMP = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-EEZFET = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = 29
-EKBDFS = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = 31
-ELHBQN = 101
-ELWUEU = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-EMCGET = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EMVCYW = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        86,
-        83,
-        80,
-        70,
-        105,
-        108,
-        116,
-        101,
-        114,
-        105,
-        110,
-        103,
-        83,
-        112,
-        101,
-        101,
-        100,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-EUHNNX = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-EUTOPH = 83
-EVBVHD = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        57,
-    ]
-)
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EXLTPO = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-EZFETD = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-FCPOUB = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-FCRTFM = "".join(chr(c) for c in [105, 110, 89, 74])
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FFTTID = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-FIKJPU = 107
-FJNTTU = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-FJTACC = 43
-FLSIJU = 135
-FMNHTB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-FOUURI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        54,
-    ]
-)
-FSROGM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTTIDU = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-FUBJLO = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-FWRKIN = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FXQGLR = 16
-FYLJUI = 61
-FZCZOL = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-GCRHYU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-GETIXQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-GGVYKL = 124
-GJFJNT = 133
-GKEAKS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GMECYX = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-GNVFOU = 143
-GQPLSP = 32
-GSELHB = 100
-GTYIYW = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-GUCYRA = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-GVUNXN = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-GVYKLT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-GXXYOJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-GYOUSP = 56
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBQNRX = 102
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = "".join(chr(c) for c in [67, 69])
-HBXIBH = 160
-HDVRID = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-HSVSIB = "".join(chr(c) for c in [49])
-HTBJEU = 74
-HTZBBE = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HUGTYI = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = 105
-HWOGXX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-HYUAXN = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HZVOAC = 130
-IACQFF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-IAMJMA = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-IBHZVO = 128
-IBXTIA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-IBXYBQ = 30
-ICXQIE = 13
-IDKEYG = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-IDNIBX = 68
-IDUBSS = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IEFXQG = 15
-IEVBVH = 151
-IFJBIA = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-IGYOUS = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IHBXIB = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-IIDNIB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IJUGSE = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-IJUZMR = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-IKFWRK = "".join(chr(c) for c in [80, 49])
-IKGNVF = 141
-IKJPUN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-ILXWAJ = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-INELWU = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-IPOUYN = 47
-IRYXBQ = 58
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUVMKZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = 91
-IVEMVC = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 73
-IYWSKW = 88
-JBIAMJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-JEUTOP = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JFJNTT = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = 55
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-JJVGBX = 83
-JJVYFC = 170
-JLOINE = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JPUNRJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JQRJJJ = 168
-JQSGME = 172
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = 99
-JUIKFW = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JWMNZM = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JYKLGQ = 118
-JYMOUN = 2
-JZTATD = 4
-KBDFSR = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-KCWAON = 21
-KEAKST = 72
-KEYGGV = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-KGNVFO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        52,
-    ]
-)
-KHTZBB = 64
-KINEJN = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-KJPUNR = 108
-KLGQPL = 120
-KLTQLV = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-KMLOIJ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(chr(c) for c in [65, 109, 80, 109])
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KVFCPO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        66,
-        117,
-        111,
-        121,
-        97,
-        110,
-        99,
-        121,
-        80,
-        117,
-        109,
-        112,
-    ]
-)
-KVKZIL = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-KWIVDN = 90
-KXSJWM = 80
-KZHWOG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-LAIIDN = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LHBQNR = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-LIUXFE = 25
-LJUIKF = 62
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 33
-LOIJUG = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-LOINEL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-LSIPMD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-LSPFTS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTQLVH = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-LUBGJF = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 53])
-LVHSVS = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-MAOAWB = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-MCBFEG = 163
-MCGETI = 76
-MCVDSS = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-MDDPMX = 110
-MDMPSC = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-MEAOES = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        99,
-        107,
-        111,
-        95,
-        86,
-        77,
-        83,
-        95,
-        79,
-        110,
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-    ]
-)
-MECYXM = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-MFZDGK = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-MHXEKV = "".join(chr(c) for c in [67])
-MIKGNV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        51,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-MJMAOA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-MJVHFT = 12
-MKQTDK = 34
-MKZHWO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-MLOIJU = 97
-MNHTBJ = 122
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MPYDZQ = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-MVCYWO = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-MXFUBJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-NAXADX = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 50])
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NCUGUC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-NEJNIB = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-NELWUE = "".join(chr(c) for c in [67, 89, 65, 78])
-NFZCZO = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-NHTBJE = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-NIBXTI = 70
-NIBXYB = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-NKMLOI = 96
-NMHXEK = "".join(chr(c) for c in [70])
-NNXWEE = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQLNMH = 1
-NQTMFZ = 10
-NRJZTA = 3
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-NTTUVR = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-NVFOUU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        53,
-    ]
-)
-NXNKML = 95
-NXWEEZ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-NZMJIG = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OACMCV = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-OAWBSI = "".join(chr(c) for c in [72, 105])
-OCTHBS = 38
-OESVZS = 182
-OGMDDP = 7
-OGXXYO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-OIHBXI = 75
-OIJUGS = 98
-OINELW = "".join(chr(c) for c in [66, 76, 85, 69])
-OJQSGM = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-ONFZCZ = "".join(chr(c) for c in [80, 68, 67])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = 137
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = 81
-OUURIE = 147
-OUYNQJ = 48
-OXIUVM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-PHUGTY = 85
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-PMDMPS = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-PMXFUB = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-POUBMI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-    ]
-)
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-POXIUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-PUMEAO = 181
-PUNRJZ = 109
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-QGLRAH = 26
-QGVUNX = 93
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = 35
-QLNMHX = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QLVHSV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 103
-QPLSPF = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-QSGMEC = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-QSNQLN = 63
-QTDKHT = "".join(chr(c) for c in [50, 52, 104])
-QTMFZD = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QVXOIH = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 121
-RAZMKQ = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-RFLSIJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-RHYUAX = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-RIEVBV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        56,
-    ]
-)
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = 169
-RJZTAT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-RKVFCP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-ROGMDD = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-RURAZM = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-RXAIVE = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-RXCHWD = 104
-RYXBQF = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-SBVNAX = "".join(chr(c) for c in [80, 51])
-SCTTGC = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-SELHBQ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-SEMCGE = 5
-SGMECY = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-SIBEXL = "".join(chr(c) for c in [52])
-SIFJBI = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-SIJUZM = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-SIPMDM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-SIRYXB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SJWMNZ = 180
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-SNQLNM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [79, 119, 110])
-SPFTSI = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SROGMD = 6
-SRURAZ = 158
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(chr(c) for c in [80, 50])
-SSRURA = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SSUHBV = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-STSEMC = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-SUHBVW = 51
-SVSIBE = "".join(chr(c) for c in [50])
-SVZSSB = 183
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = 6
-TBJEUT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TDRXAI = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-TDZXNQ = 116
-TFMNHT = 53
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 77
-TIDUBS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-TIXQVX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-TMFZDG = 71
-TOPHUG = 84
-TPOXIU = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-TQLVHS = 126
-TSEMCG = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-TSIFJB = 27
-TTGCRH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-TTIDUB = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-TTUVRF = 134
-TUVRFL = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = 87
-TZBBEK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBGJFJ = 177
-UBJLOI = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-UBMIKG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        50,
-    ]
-)
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-UBYGDS = 52
-UCYRAP = 113
-UEUHNN = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-UGSELH = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UGTYIY = 86
-UHBVWV = "".join(chr(c) for c in [85, 76])
-UHNNXW = 111
-UIKFWR = 78
-UJUTYE = 18
-UMEAOE = "".join(chr(c) for c in [78, 111, 86, 115, 112])
-UNBLKX = 79
-UNRJZT = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-UNXNKM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-URIEVB = 149
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UTOPHU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-UTYEKC = 19
-UURIEV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        55,
-    ]
-)
-UVMKZH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-UVRFLS = "".join(
-    chr(c)
-    for c in [
-        85,
-        83,
-        69,
-        95,
-        86,
-        65,
-        82,
-        73,
-        65,
-        66,
-        76,
-        69,
-        95,
-        83,
-        80,
-        69,
-        69,
-        68,
-        95,
-        80,
-        85,
-        77,
-        80,
-        83,
-    ]
-)
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-VBVHDV = 153
-VCYWON = "".join(chr(c) for c in [76, 65])
-VDNQGV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-VDQLAI = 3
-VDSSRU = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-VEMVCY = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-VFCPOU = 178
-VFOUUR = 145
-VHDVRI = 155
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VHSVSI = 127
-VKZILX = 164
-VLASSA = "".join(chr(c) for c in [])
-VMKZHW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-VOACMC = 132
-VRIDKE = "".join(chr(c) for c in [82, 71, 66])
-VSIBEX = "".join(chr(c) for c in [51])
-VUBYGD = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-VUNXNK = 94
-VWVUBY = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-VYFCRT = 171
-VYKLTQ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 49])
-WAJVDQ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-WAONPY = 22
-WBSIRY = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WDAFIK = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-WEEZFE = "".join(chr(c) for c in [65, 108, 112, 115])
-WIVDNQ = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-WJYKLG = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-WMNZMJ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-WOGXXY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-WONFZC = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-WRKINE = 28
-WSKWIV = 89
-WUEUHN = 8
-WVUBYG = 114
-XADXLU = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 51])
-XAIVEM = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XIBHZV = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XIUVMK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-XLTPOX = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-XLUBGJ = 176
-XMPYDZ = 179
-XNCUGU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-XNKMLO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-XNQTMF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-XOIHBX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        83,
-        97,
-        102,
-        101,
-        116,
-        121,
-    ]
-)
-XTIACQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XWEEZF = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-XXYOJQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-XYBQSN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-XYOJQS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-YDZQJJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-YEKCWA = 20
-YFCRTF = "".join(chr(c) for c in [105, 110, 89, 84])
-YGDSBD = 165
-YGGVYK = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-YIYWSK = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-YKLGQP = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-YKLTQL = 125
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YLJUIK = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOJQSG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-YOUSPB = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-YUAXNC = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-YWONFZ = "".join(chr(c) for c in [77, 65, 65, 88])
-YWSKWI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-YXBQFY = 59
-YXMPYD = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-ZDGKEA = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ZFETDR = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ZHWOGX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-ZILXWA = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-ZMJIGY = 54
-ZMKQTD = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-ZMRKVF = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-ZOLSIP = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZSSBVN = 173
-ZTATDZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZXNQTM = 8
-AWBSIR = [AOAWBS, OAWBSI]
-AZMKQT = [URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BJEUTO = [BXYBQS, TBJEUT]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BVWVUB = [UHBVWV, HBVWVU]
-BXIBHZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-BXTIAC = [BXYBQS, IBXTIA]
-CRTFMN = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    YFCRTF,
-    VLASSA,
-    FCRTFM,
-]
-CYXMPY = [QSGMEC, SGMECY, GMECYX, MECYXM, ECYXMP]
-DFSROG = [KBDFSR, BDFSRO]
-DSSRUR = [JVHFTH, CMCVDS, MCVDSS, CVDSSR, VDSSRU]
-DUBSSU = [CQFFTT, QFFTTI, FFTTID, FTTIDU, TTIDUB, TIDUBS, IDUBSS]
-DZQJJV = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-    XSJWMN,
-]
-EAOESV = [UMEAOE, NNXWEE, MEAOES]
-ETIXQV = [CGETIX, GETIXQ]
-EYGGVY = [DKEYGG, KEYGGV]
-FJBIAM = [SIFJBI, IFJBIA]
-FZDGKE = [JVHFTH, SIFJBI, MFZDGK]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-HXEKVK = [NMHXEK, MHXEKV]
-IBEXLT = [VLASSA, HSVSIB, SVSIBE, VSIBEX, SIBEXL]
-INEJNI = [RKINEJ, KINEJN]
-JMAOAW = [IAMJMA, AMJMAO, MJMAOA]
-JNIBXY = [PIPIVL, IKFWRK]
-JNTTUV = [JFJNTT, FJNTTU]
-JVDQLA = [WAJVDQ, AJVDQL]
-KFWRKI = [JVHFTH, IKFWRK, PIPIVL]
-LTPOXI = [OINELW, ELWUEU, JLOINE, EXLTPO, LOINEL, NELWUE, XLTPOX, CMCVDS]
-LWUEUH = [CMCVDS, BJLOIN, JLOINE, LOINEL, OINELW, INELWU, NELWUE, ELWUEU]
-LXWAJV = [KZILXW, ZILXWA, ILXWAJ]
-MNZMJI = [JWMNZM, WMNZMJ]
-MRKVFC = [LSIJUZ, SIJUZM, IJUZMR, JUZMRK, UZMRKV, ZMRKVF, VLASSA, VLASSA]
-PBWJYK = [USPBWJ, SPBWJY]
-PFTSIF = [QPLSPF, PLSPFT, LSPFTS, SPFTSI]
-PYDZQJ = [MPYDZQ, ELWUEU, JLOINE, EXLTPO, LOINEL, NELWUE, XLTPOX, CMCVDS]
-QJJVGB = []
-RIDKEY = [VRIDKE, ELWUEU]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-TDKHTZ = [JVHFTH, KQTDKH, QTDKHT]
-TGCRHY = [
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-    CTTGCR,
-    TTGCRH,
-]
-UAXNCU = [HYUAXN, YUAXNC, VLASSA, VLASSA]
-UGUCYR = [JVHFTH, NCUGUC, CUGUCY, VLASSA]
-VNAXAD = [JVHFTH, IKFWRK, SSBVNA, SBVNAX, BVNAXA, YYPIPI]
-VRFLSI = [TUVRFL, UVRFLS]
-VXOIHB = [VLASSA, XQVXOI, QVXOIH]
-XCHWDA = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-XFUBJL = [PMXFUB, MXFUBJ]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-YBQSNQ = [BXYBQS, XYBQSN]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-ZQJJVG = [NBLKXS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -2168,450 +19,1619 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JJVGBX
+        return 83
 
     @property
     def output_keys(self):
-        return DZQJJV
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MNZMJI, None, None, None
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, BWJYKL, PBWJYK, None, JYMOUN, QBMJVH
-            ),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, JMAOAW, None, None, QBMJVH
-            ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, OUSPBW, JYMOUN, AWBSIR, None, JYMOUN, QBMJVH
-            ),
-            WBSIRY: GeckoBoolStructAccessor(
-                self.struct, WBSIRY, QJYMOU, BSIRYX, QBMJVH
-            ),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoByteStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
-            ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoEnumStructAccessor(
-                self.struct, NIBXYB, IBXYBQ, None, YBQSNQ, None, None, QBMJVH
-            ),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoTempStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, HXEKVK, None, None, QBMJVH
-            ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, JNIBXY, None, None, QBMJVH
-            ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, LXWAJV, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, OUSPBW, VDQLAI, JVDQLA, None, JYMOUN, QBMJVH
-            ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoTempStructAccessor(self.struct, LAIIDN, AIIDNI, QBMJVH),
-            IIDNIB: GeckoTempStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, DUBSSU, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, SUHBVW, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, CRTFMN, None, None, None
-            ),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, BJEUTO, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, XLSXUJ, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NKMLOI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, QBMJVH),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, QBMJVH),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, XCHWDA, None, None, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, XCHWDA, None, None, QBMJVH
-            ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, XCHWDA, None, None, QBMJVH
-            ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, None, XCHWDA, None, None, QBMJVH
-            ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, XCHWDA, None, None, QBMJVH
-            ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, XCHWDA, None, None, QBMJVH
-            ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, QBMJVH),
-            RJZTAT: GeckoTimeStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoTimeStructAccessor(self.struct, ZTATDZ, TATDZX, QBMJVH),
-            ATDZXN: GeckoTimeStructAccessor(self.struct, ATDZXN, TDZXNQ, QBMJVH),
-            DZXNQT: GeckoTimeStructAccessor(self.struct, DZXNQT, ZXNQTM, QBMJVH),
-            XNQTMF: GeckoTimeStructAccessor(self.struct, XNQTMF, NQTMFZ, QBMJVH),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, None, FZDGKE, None, None, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, BWJYKL, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, KEAKST, JYMOUN, QBMJVH
-            ),
-            EAKSTS: GeckoBoolStructAccessor(
-                self.struct, EAKSTS, KEAKST, BWJYKL, QBMJVH
-            ),
-            AKSTSE: GeckoBoolStructAccessor(
-                self.struct, AKSTSE, KEAKST, BSIRYX, QBMJVH
-            ),
-            KSTSEM: GeckoBoolStructAccessor(
-                self.struct, KSTSEM, KEAKST, VDQLAI, QBMJVH
-            ),
-            STSEMC: GeckoBoolStructAccessor(
-                self.struct, STSEMC, KEAKST, MOUNBL, QBMJVH
-            ),
-            TSEMCG: GeckoBoolStructAccessor(
-                self.struct, TSEMCG, KEAKST, SEMCGE, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, IXQVXO, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoByteStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, HBXIBH, None, BXIBHZ, None, None, QBMJVH
-            ),
-            XIBHZV: GeckoTimeStructAccessor(self.struct, XIBHZV, IBHZVO, QBMJVH),
-            BHZVOA: GeckoTimeStructAccessor(self.struct, BHZVOA, HZVOAC, QBMJVH),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, QBMJVH),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, ACMCVD, None, DSSRUR, None, None, QBMJVH
-            ),
-            SSRURA: GeckoTimeStructAccessor(self.struct, SSRURA, SRURAZ, QBMJVH),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, QJYMOU, VDQLAI, AZMKQT, None, JYMOUN, QBMJVH
-            ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, TDKHTZ, None, None, QBMJVH
-            ),
-            DKHTZB: GeckoWordStructAccessor(self.struct, DKHTZB, KHTZBB, QBMJVH),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, OUSPBW, BSIRYX, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, OUSPBW, MOUNBL, QBMJVH
-            ),
-            EKBDFS: GeckoEnumStructAccessor(
-                self.struct, EKBDFS, OUSPBW, SEMCGE, DFSROG, None, JYMOUN, QBMJVH
-            ),
-            FSROGM: GeckoBoolStructAccessor(
-                self.struct, FSROGM, OUSPBW, SROGMD, QBMJVH
-            ),
-            ROGMDD: GeckoBoolStructAccessor(
-                self.struct, ROGMDD, OUSPBW, OGMDDP, QBMJVH
-            ),
-            GMDDPM: GeckoBoolStructAccessor(
-                self.struct, GMDDPM, MDDPMX, BWJYKL, QBMJVH
-            ),
-            DDPMXF: GeckoBoolStructAccessor(
-                self.struct, DDPMXF, MDDPMX, BSIRYX, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, MDDPMX, JYMOUN, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            FUBJLO: GeckoEnumStructAccessor(
-                self.struct, FUBJLO, MDDPMX, VDQLAI, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            UBJLOI: GeckoEnumStructAccessor(
-                self.struct, UBJLOI, MDDPMX, MOUNBL, LWUEUH, None, WUEUHN, QBMJVH
-            ),
-            UEUHNN: GeckoEnumStructAccessor(
-                self.struct, UEUHNN, MDDPMX, OGMDDP, MNZMJI, None, JYMOUN, QBMJVH
-            ),
-            GCRHYU: GeckoBoolStructAccessor(
-                self.struct, GCRHYU, CRHYUA, BSIRYX, QBMJVH
-            ),
-            RHYUAX: GeckoEnumStructAccessor(
-                self.struct, RHYUAX, CRHYUA, JYMOUN, UAXNCU, None, MOUNBL, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, CRHYUA, MOUNBL, QBMJVH
-            ),
-            XNCUGU: GeckoEnumStructAccessor(
-                self.struct, XNCUGU, CRHYUA, SROGMD, UGUCYR, None, MOUNBL, QBMJVH
-            ),
-            GUCYRA: GeckoByteStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoBoolStructAccessor(
-                self.struct, CYRAPU, QJYMOU, BWJYKL, QBMJVH
-            ),
-            YRAPUM: GeckoByteStructAccessor(self.struct, YRAPUM, RAPUME, QBMJVH),
-            APUMEA: GeckoEnumStructAccessor(
-                self.struct, APUMEA, PUMEAO, None, EAOESV, None, None, QBMJVH
-            ),
-            AOESVZ: GeckoByteStructAccessor(self.struct, AOESVZ, OESVZS, QBMJVH),
-            ESVZSS: GeckoByteStructAccessor(self.struct, ESVZSS, SVZSSB, QBMJVH),
-            VZSSBV: GeckoEnumStructAccessor(
-                self.struct, VZSSBV, ZSSBVN, None, VNAXAD, None, None, QBMJVH
-            ),
-            NAXADX: GeckoEnumStructAccessor(
-                self.struct, NAXADX, AXADXL, None, VNAXAD, None, None, QBMJVH
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, ADXLUB, None, VNAXAD, None, None, QBMJVH
-            ),
-            DXLUBG: GeckoEnumStructAccessor(
-                self.struct, DXLUBG, XLUBGJ, None, VNAXAD, None, None, QBMJVH
-            ),
-            LUBGJF: GeckoEnumStructAccessor(
-                self.struct, LUBGJF, UBGJFJ, None, VNAXAD, None, None, QBMJVH
-            ),
-            BGJFJN: GeckoEnumStructAccessor(
-                self.struct, BGJFJN, GJFJNT, None, JNTTUV, None, None, QBMJVH
-            ),
-            NTTUVR: GeckoEnumStructAccessor(
-                self.struct, NTTUVR, TTUVRF, None, VRFLSI, None, None, QBMJVH
-            ),
-            RFLSIJ: GeckoEnumStructAccessor(
-                self.struct, RFLSIJ, FLSIJU, BWJYKL, MRKVFC, None, WUEUHN, QBMJVH
-            ),
-            RKVFCP: GeckoBoolStructAccessor(
-                self.struct, RKVFCP, FLSIJU, OGMDDP, QBMJVH
-            ),
-            KVFCPO: GeckoEnumStructAccessor(
-                self.struct, KVFCPO, VFCPOU, None, VNAXAD, None, None, QBMJVH
-            ),
-            FCPOUB: GeckoByteStructAccessor(self.struct, FCPOUB, CPOUBM, QBMJVH),
-            POUBMI: GeckoWordStructAccessor(self.struct, POUBMI, OUBMIK, QBMJVH),
-            UBMIKG: GeckoWordStructAccessor(self.struct, UBMIKG, BMIKGN, QBMJVH),
-            MIKGNV: GeckoWordStructAccessor(self.struct, MIKGNV, IKGNVF, QBMJVH),
-            KGNVFO: GeckoWordStructAccessor(self.struct, KGNVFO, GNVFOU, QBMJVH),
-            NVFOUU: GeckoWordStructAccessor(self.struct, NVFOUU, VFOUUR, QBMJVH),
-            FOUURI: GeckoWordStructAccessor(self.struct, FOUURI, OUURIE, QBMJVH),
-            UURIEV: GeckoWordStructAccessor(self.struct, UURIEV, URIEVB, QBMJVH),
-            RIEVBV: GeckoWordStructAccessor(self.struct, RIEVBV, IEVBVH, QBMJVH),
-            EVBVHD: GeckoWordStructAccessor(self.struct, EVBVHD, VBVHDV, QBMJVH),
-            BVHDVR: GeckoWordStructAccessor(self.struct, BVHDVR, VHDVRI, QBMJVH),
-            HDVRID: GeckoEnumStructAccessor(
-                self.struct, HDVRID, DVRIDK, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            IDKEYG: GeckoEnumStructAccessor(
-                self.struct, IDKEYG, DVRIDK, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            YGGVYK: GeckoEnumStructAccessor(
-                self.struct, YGGVYK, GGVYKL, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            GVYKLT: GeckoEnumStructAccessor(
-                self.struct, GVYKLT, GGVYKL, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            VYKLTQ: GeckoEnumStructAccessor(
-                self.struct, VYKLTQ, YKLTQL, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            KLTQLV: GeckoEnumStructAccessor(
-                self.struct, KLTQLV, YKLTQL, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            LTQLVH: GeckoEnumStructAccessor(
-                self.struct, LTQLVH, TQLVHS, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            QLVHSV: GeckoEnumStructAccessor(
-                self.struct, QLVHSV, TQLVHS, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            LVHSVS: GeckoEnumStructAccessor(
-                self.struct, LVHSVS, VHSVSI, BWJYKL, IBEXLT, None, WUEUHN, None
-            ),
-            BEXLTP: GeckoEnumStructAccessor(
-                self.struct, BEXLTP, VHSVSI, VDQLAI, LTPOXI, None, WUEUHN, QBMJVH
-            ),
-            TPOXIU: GeckoBoolStructAccessor(self.struct, TPOXIU, VHSVSI, OGMDDP, None),
-            POXIUV: GeckoBoolStructAccessor(self.struct, POXIUV, DVRIDK, MOUNBL, None),
-            OXIUVM: GeckoBoolStructAccessor(self.struct, OXIUVM, DVRIDK, SEMCGE, None),
-            XIUVMK: GeckoBoolStructAccessor(self.struct, XIUVMK, DVRIDK, SROGMD, None),
-            IUVMKZ: GeckoBoolStructAccessor(self.struct, IUVMKZ, DVRIDK, OGMDDP, None),
-            UVMKZH: GeckoBoolStructAccessor(self.struct, UVMKZH, GGVYKL, MOUNBL, None),
-            VMKZHW: GeckoBoolStructAccessor(self.struct, VMKZHW, GGVYKL, SEMCGE, None),
-            MKZHWO: GeckoBoolStructAccessor(self.struct, MKZHWO, GGVYKL, SROGMD, None),
-            KZHWOG: GeckoBoolStructAccessor(self.struct, KZHWOG, GGVYKL, OGMDDP, None),
-            ZHWOGX: GeckoBoolStructAccessor(self.struct, ZHWOGX, YKLTQL, MOUNBL, None),
-            HWOGXX: GeckoBoolStructAccessor(self.struct, HWOGXX, YKLTQL, SEMCGE, None),
-            WOGXXY: GeckoBoolStructAccessor(self.struct, WOGXXY, YKLTQL, SROGMD, None),
-            OGXXYO: GeckoBoolStructAccessor(self.struct, OGXXYO, YKLTQL, OGMDDP, None),
-            GXXYOJ: GeckoBoolStructAccessor(self.struct, GXXYOJ, TQLVHS, MOUNBL, None),
-            XXYOJQ: GeckoBoolStructAccessor(self.struct, XXYOJQ, TQLVHS, SEMCGE, None),
-            XYOJQS: GeckoBoolStructAccessor(self.struct, XYOJQS, TQLVHS, SROGMD, None),
-            YOJQSG: GeckoBoolStructAccessor(self.struct, YOJQSG, TQLVHS, OGMDDP, None),
-            OJQSGM: GeckoEnumStructAccessor(
-                self.struct, OJQSGM, JQSGME, None, CYXMPY, None, None, None
-            ),
-            YXMPYD: GeckoEnumStructAccessor(
-                self.struct, YXMPYD, XMPYDZ, MOUNBL, PYDZQJ, None, WUEUHN, QBMJVH
-            ),
-            YDZQJJ: GeckoBoolStructAccessor(self.struct, YDZQJJ, XMPYDZ, OGMDDP, None),
         }

--- a/src/geckolib/driver/packs/inye-v3-cfg-84.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-84.py
@@ -1,0 +1,1640 @@
+#!/usr/bin/python3
+"""
+    GeckoConfigStruct - A class to manage the ConfigStruct for 'inYE-V3 v84'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoConfigStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 84
+
+    @property
+    def output_keys(self):
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
+            ),
+            "StatusLightFading": GeckoBoolStructAccessor(
+                self.struct, "StatusLightFading", 184, 0, None
+            ),
+        }

--- a/src/geckolib/driver/packs/inye-v3-cfg-85.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-85.py
@@ -1,0 +1,1655 @@
+#!/usr/bin/python3
+"""
+    GeckoConfigStruct - A class to manage the ConfigStruct for 'inYE-V3 v85'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoConfigStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 85
+
+    @property
+    def output_keys(self):
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "MassageEnablePump1": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump1", 185, 0, None
+            ),
+            "MassageEnablePump2": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump2", 185, 1, None
+            ),
+            "MassageEnablePump3": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump3", 185, 2, None
+            ),
+            "MassageEnablePump4": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump4", 185, 3, None
+            ),
+            "MassageEnablePump5": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump5", 185, 4, None
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
+            ),
+            "StatusLightFading": GeckoBoolStructAccessor(
+                self.struct, "StatusLightFading", 184, 0, None
+            ),
+        }

--- a/src/geckolib/driver/packs/inye-v3-cfg-86.py
+++ b/src/geckolib/driver/packs/inye-v3-cfg-86.py
@@ -1,0 +1,1658 @@
+#!/usr/bin/python3
+"""
+    GeckoConfigStruct - A class to manage the ConfigStruct for 'inYE-V3 v86'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoConfigStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 86
+
+    @property
+    def output_keys(self):
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "GfciTestEnabled": GeckoBoolStructAccessor(
+                self.struct, "GfciTestEnabled", 119, 5, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "MassageEnablePump1": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump1", 185, 0, None
+            ),
+            "MassageEnablePump2": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump2", 185, 1, None
+            ),
+            "MassageEnablePump3": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump3", 185, 2, None
+            ),
+            "MassageEnablePump4": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump4", 185, 3, None
+            ),
+            "MassageEnablePump5": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump5", 185, 4, None
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
+            ),
+            "StatusLightFading": GeckoBoolStructAccessor(
+                self.struct, "StatusLightFading", 184, 0, None
+            ),
+        }

--- a/src/geckolib/driver/packs/inye-v3-log-80.py
+++ b/src/geckolib/driver/packs/inye-v3-log-80.py
@@ -12,1644 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-AFIKJP = "".join(chr(c) for c in [75, 56, 53])
-AIIDNI = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [80, 52, 76])
-AMJMAO = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116])
-AOESVZ = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-AONPYY = 310
-APUMEA = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-ATDZXN = 358
-AWBSIR = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AXNCUG = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-AZMKQT = 328
-BBEKBD = 333
-BDFSRO = 341
-BDJQRJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BEKBDF = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-BFEGZU = 261
-BHZVOA = 337
-BIAMJM = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-BJEUTO = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 48])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-BQNRXC = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-BQSNQL = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-BSIRYX = 280
-BSKSOK = 258
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-BVNAXA = 256
-BVWVUB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-BWJYKL = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-BXIBHZ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-BXTIAC = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-BXYBQS = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-BYGDSB = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-CHWDAF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-CMCVDS = 349
-CPQIPO = 263
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-CRHYUA = 475
-CRTFMN = 288
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = 473
-CUGUCY = 479
-CVDSSR = 325
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-CYWONF = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-CZOLSI = 467
-DAFIKJ = "".join(chr(c) for c in [75, 52, 48, 48])
-DDPMXF = 345
-DFSROG = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-DGKEAK = "".join(chr(c) for c in [80, 50, 76])
-DJQRJJ = 315
-DKHTZB = 331
-DMPSCT = 471
-DNIBXT = 283
-DPMXFU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-DRXAIV = 459
-DSBDJQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-DUBSSU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-DZXNQT = 360
-EAKSTS = "".join(chr(c) for c in [80, 52, 72])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 456
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = 379
-EKBDFS = 340
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-ELHBQN = 300
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 51])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EMVCYW = 462
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = 458
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 53])
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 57])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-FFTTID = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FIKJPU = "".join(chr(c) for c in [75, 56])
-FJBIAM = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-FJTACC = 262
-FMNHTB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-FSROGM = 342
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-FTTIDU = 351
-FUBJLO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-FWRKIN = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FZCZOL = 466
-FZDGKE = "".join(chr(c) for c in [80, 49, 76])
-GCRHYU = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-GDSBDJ = 311
-GETIXQ = 322
-GKEAKS = "".join(chr(c) for c in [80, 51, 72])
-GLRAHE = 259
-GMDDPM = 344
-GQPLSP = "".join(chr(c) for c in [78, 79])
-GSELHB = 299
-GTYIYW = "".join(chr(c) for c in [49, 54, 75])
-GUCYRA = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-GYOUSP = "".join(chr(c) for c in [70, 105, 108, 116, 82, 101, 113, 117, 101, 115, 116])
-HBQNRX = 301
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-HBXIBH = 335
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 54])
-HTBJEU = "".join(chr(c) for c in [77, 73, 65])
-HTZBBE = 332
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = 357
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-HYUAXN = 476
-HZVOAC = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-IACQFF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IAMJMA = 277
-IBHZVO = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-IBXTIA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-IBXYBQ = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-ICXQIE = 1
-IDNIBX = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-IGYOUS = 273
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-IIDNIB = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-IJUGSE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-IKFWRK = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-IKJPUN = "".join(chr(c) for c in [75, 52])
-ILXWAJ = 390
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50])
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 281
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = "".join(chr(c) for c in [52, 84, 72, 95, 71, 69, 78])
-IVEMVC = 461
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-IYWSKW = "".join(chr(c) for c in [54, 52, 75])
-JBIAMJ = 275
-JEUTOP = "".join(chr(c) for c in [105, 110, 88, 77])
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JLOINE = 448
-JMAOAW = "".join(chr(c) for c in [78, 101, 97, 114, 72, 76])
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-JPUNRJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JQRJJJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = 297
-JUIKFW = 378
-JUTYEK = 3
-JVDQLA = 350
-JVHFTH = 274
-JVYFCR = 285
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JYMOUN = 266
-JZTATD = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-KBDFSR = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KEAKST = "".join(chr(c) for c in [80, 51, 76])
-KFWRKI = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-KHTZBB = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(chr(c) for c in [75, 53])
-KLGQPL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-KMLOIJ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = "".join(chr(c) for c in [66, 76, 79])
-KVKZIL = "".join(chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87])
-KWIVDN = "".join(chr(c) for c in [50, 78, 68, 95, 71, 69, 78])
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = 313
-LHBQNR = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-LKXSJW = 270
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-LOIJUG = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 49])
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-LWUEUH = 451
-LXWAJV = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-MAOAWB = 279
-MCBFEG = 369
-MCGETI = 321
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-MDDPMX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-MDMPSC = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-MEAOES = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-MFZDGK = "".join(chr(c) for c in [80, 49, 72])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        67,
-        104,
-        101,
-        99,
-        107,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-MJIGYO = 381
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 329
-MLOIJU = 295
-MNHTBJ = "".join(chr(c) for c in [105, 110, 88, 69])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-MVCYWO = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MXFUBJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NBLKXS = 268
-NCUGUC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-NEJNIB = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-NELWUE = 450
-NFZCZO = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-NHTBJE = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NIBXTI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-NIBXYB = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-NKMLOI = 294
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-NNXWEE = 454
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = 8
-NQJYMO = 264
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        79,
-        117,
-        116,
-        108,
-        101,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-NRJZTA = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-NRSJMC = 306
-NRXCHW = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-NXNKML = 293
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 55])
-NZMJIG = 380
-OACMCV = 339
-OAWBSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-OCTHBS = 2
-OESVZS = 375
-OGMDDP = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-OIJUGS = 296
-OINELW = 449
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 468
-ONFZCZ = 465
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = "".join(chr(c) for c in [105, 110, 89, 84])
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(chr(c) for c in [67, 80, 79, 84])
-PFTSIF = 353
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PLSPFT = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-PMDMPS = 470
-PMXFUB = 346
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = 472
-PUMEAO = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-PUNRJZ = "".join(chr(c) for c in [75, 49, 48, 48])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-QFYLJU = 377
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 50, 53, 54, 75])
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = 383
-QLNMHX = 392
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = 316
-QPLSPF = "".join(chr(c) for c in [77, 69, 68])
-QRJJJV = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QSNQLN = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-QTDKHT = 330
-QTMFZD = 320
-QVXOIH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-RAZMKQ = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-RHYUAX = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RJZTAT = "".join(chr(c) for c in [75, 51, 48, 48])
-RKINEJ = "".join(chr(c) for c in [72, 69, 65, 84])
-ROGMDD = 343
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-RURAZM = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-RXCHWD = "".join(chr(c) for c in [70, 117, 108, 108])
-RYXBQF = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-SAKQXP = 386
-SBDJQR = 314
-SBVNAX = 80
-SCTTGC = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-SELHBQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SIFJBI = 355
-SIPMDM = 469
-SIRYXB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = "".join(chr(c) for c in [49, 83, 84, 95, 71, 69, 78])
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SROGMD = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-SRURAZ = 326
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SSUHBV = 387
-STSEMC = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SUHBVW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SVZSSB = "".join(chr(c) for c in [76, 73])
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-TBJEUT = "".join(chr(c) for c in [68, 74, 83, 52])
-TDKHTZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TDZXNQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-TFMNHT = 289
-TGCRHY = 474
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TIXQVX = 323
-TMFZDG = "".join(chr(c) for c in [78, 65])
-TOPHUG = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-TSEMCG = "".join(chr(c) for c in [65, 85, 88])
-TSIFJB = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-TTGCRH = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-TTIDUB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TYIYWS = "".join(chr(c) for c in [51, 50, 75])
-UAXNCU = 477
-UBJLOI = 348
-UBSSUH = 354
-UCYRAP = 371
-UEUHNN = 452
-UGSELH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-UGTYIY = 290
-UGUCYR = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-UHBVWV = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UHNNXW = 453
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UMEAOE = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = "".join(chr(c) for c in [75, 56, 48, 48])
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = 327
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = 463
-VDNQGV = "".join(chr(c) for c in [53, 84, 72, 95, 71, 69, 78])
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-VDSSRU = "".join(chr(c) for c in [70, 97, 110])
-VEMVCY = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [71, 69, 67, 75, 79, 55, 53, 48, 48, 87])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VNAXAD = 479
-VOACMC = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-VUBYGD = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-VUNXNK = 291
-VWVUBY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-VXOIHB = 334
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-WDAFIK = "".join(chr(c) for c in [75, 50, 48, 48])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 56])
-WIVDNQ = "".join(chr(c) for c in [51, 82, 68, 95, 71, 69, 78])
-WJYKLG = 282
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-WRKINE = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-WSKWIV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 71, 101, 110, 101, 114, 97, 116, 105, 111, 110]
-)
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 52])
-WVUBYG = 309
-XAIVEM = 460
-XBQFYL = 352
-XEKVKZ = 389
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = 347
-XIBHZV = 336
-XLSXUJ = 260
-XNCUGU = 478
-XNKMLO = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-XNQTMF = 361
-XOIHBX = "".join(chr(c) for c in [72, 84, 82])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = 324
-XSJWMN = 271
-XTIACQ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = 284
-XWEEZF = 455
-XYBQSN = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-YBQSNQ = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-YEKCWA = 5
-YFCRTF = 287
-YGDSBD = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YIYWSK = "".join(chr(c) for c in [52, 56, 75])
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = 384
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YRAPUM = 374
-YUAXNC = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-YWONFZ = 464
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ZDGKEA = "".join(chr(c) for c in [80, 50, 72])
-ZFETDR = 457
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-ZOLSIP = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = 338
-ZXNQTM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-DNQGVU = [SKWIVD, KWIVDN, HECVYY, WIVDNQ, HECVYY, IVDNQG, HECVYY, VDNQGV]
-DSSRUR = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    VDSSRU,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-EAOESV = [RAPUME, APUMEA, PUMEAO, UMEAOE, MEAOES]
-ESVZSS = []
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-INEJNI = [RKINEJ, KINEJN]
-KZILXW = [EKVKZI, KVKZIL, VKZILX]
-LSPFTS = [GQPLSP, LRAHEO, QPLSPF, RAHEOC, PLSPFT]
-LSXUJU = [FXQGLR, FEGZUQ]
-MJMAOA = [HECVYY, AMJMAO, AMJMAO, AMJMAO]
-OIHBXI = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XOIHBX,
-]
-OKPHUO = [FXQGLR, SOKPHU]
-PHUGTY = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-SEMCGE = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-SNQLNM = [
-    PQIPOU,
-    JNIBXY,
-    NIBXYB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-]
-SSBVNA = [
-    QRJJJV,
-    TTIDUB,
-    IDUBSS,
-    BXTIAC,
-    IFJBIA,
-    BYGDSB,
-    JQRJJJ,
-    RJJJVY,
-    OAWBSI,
-    SPBWJY,
-    QFFTTI,
-    IACQFF,
-    YXBQFY,
-    BDJQRJ,
-    TIACQF,
-    FFTTID,
-    CQFFTT,
-    NIBXTI,
-    DUBSSU,
-    IDNIBX,
-    AIIDNI,
-    HBVWVU,
-    TIDUBS,
-    IIDNIB,
-    BSSUHB,
-    ACQFFT,
-    XTIACQ,
-    IBXTIA,
-]
-TZBBEK = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-UBYGDS = [HECVYY, VUBYGD, VUBYGD, VUBYGD]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VZSSBV = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    SVZSSB,
-]
-XCHWDA = [NRXCHW, RXCHWD]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-YWSKWI = [GTYIYW, TYIYWS, YIYWSK, IYWSKW]
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-ZSSBVN = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-ZTATDZ = [
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1657,341 +19,1284 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return SBVNAX
+        return 80
 
     @property
     def begin(self):
-        return BVNAXA
+        return 256
 
     @property
     def end(self):
-        return VNAXAD
+        return 479
 
     @property
     def all_device_keys(self):
-        return VZSSBV
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ZSSBVN
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return SSBVNA
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, ICXQIE, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, OCTHBS, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, JUTYEK, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, HEOCTH, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, IGYOUS, YEKCWA, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, JVHFTH, OCTHBS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, WJYKLG, JUTYEK, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, WJYKLG, YEKCWA, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, WJYKLG, VHFTHE, None),
-            KLGQPL: GeckoEnumStructAccessor(
-                self.struct, KLGQPL, LGQPLS, None, LSPFTS, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, YEKCWA, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoWordStructAccessor(self.struct, TSIFJB, SIFJBI, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, ICXQIE, None),
-            FJBIAM: GeckoTempStructAccessor(self.struct, FJBIAM, JBIAMJ, None),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, None),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, XLSXUJ, YEKCWA, MJMAOA, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, XPICXQ, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, MAOAWB, ICXQIE, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, MAOAWB, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, MAOAWB, VHFTHE, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, OCTHBS, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoBoolStructAccessor(
-                self.struct, RYXBQF, IRYXBQ, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, ICXQIE, None),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YLJUIK, XPICXQ, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, JUIKFW, XPICXQ, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JUIKFW, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JUIKFW, HEOCTH, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, JUIKFW, YEKCWA, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, JUIKFW, VHFTHE, None),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, JUIKFW, CWAONP, INEJNI, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, SNQLNM, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QLNMHX, XPICXQ, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, QLNMHX, ICXQIE, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, QLNMHX, OCTHBS, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, QLNMHX, JUTYEK, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, KZILXW, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            ZILXWA: GeckoWordStructAccessor(self.struct, ZILXWA, ILXWAJ, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, XWAJVD, XPICXQ, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, XWAJVD, ICXQIE, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, JVDQLA, XPICXQ, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, JVDQLA, ICXQIE, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, QLAIID, XPICXQ, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, QLAIID, ICXQIE, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, WJYKLG, XPICXQ, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, WJYKLG, ICXQIE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, OCTHBS, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, DNIBXT, JUTYEK, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, XWAJVD, JUTYEK, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, XWAJVD, HEOCTH, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, XWAJVD, YEKCWA, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, XWAJVD, VHFTHE, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, JVDQLA, JUTYEK, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, JVDQLA, HEOCTH, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, JVDQLA, YEKCWA, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, JVDQLA, VHFTHE, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, FTTIDU, OCTHBS, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, FTTIDU, JUTYEK, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, PFTSIF, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, PFTSIF, ICXQIE, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, UBSSUH, XPICXQ, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, BSIRYX, XPICXQ, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, DNIBXT, XPICXQ, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, DNIBXT, ICXQIE, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, DNIBXT, HEOCTH, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, WVUBYG, XPICXQ, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, WVUBYG, ICXQIE, UBYGDS, None, HEOCTH, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, WVUBYG, JUTYEK, None),
-            YGDSBD: GeckoWordStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, SBDJQR, XPICXQ, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, DJQRJJ, XPICXQ, None),
-            JQRJJJ: GeckoBoolStructAccessor(self.struct, JQRJJJ, DJQRJJ, ICXQIE, None),
-            QRJJJV: GeckoBoolStructAccessor(self.struct, QRJJJV, FTTIDU, XPICXQ, None),
-            RJJJVY: GeckoBoolStructAccessor(self.struct, RJJJVY, FTTIDU, ICXQIE, None),
-            JJJVYF: GeckoBoolStructAccessor(self.struct, JJJVYF, FTTIDU, HEOCTH, None),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, PHUGTY, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, XPICXQ, YWSKWI, None, HEOCTH, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, UGTYIY, JUTYEK, DNQGVU, None, NQGVUN, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            QGVUNX: GeckoBoolStructAccessor(self.struct, QGVUNX, UGTYIY, VHFTHE, None),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, None),
-            IJUGSE: GeckoWordStructAccessor(self.struct, IJUGSE, JUGSEL, None),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, None),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, None),
-            LHBQNR: GeckoWordStructAccessor(self.struct, LHBQNR, HBQNRX, None),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, XCHWDA, None, OCTHBS, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, ZTATDZ, None, None, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TATDZX: GeckoWordStructAccessor(self.struct, TATDZX, ATDZXN, None),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, None),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, None),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, None, SEMCGE, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, SEMCGE, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, GETIXQ, None, SEMCGE, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, TIXQVX, None, SEMCGE, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, XQVXOI, None, SEMCGE, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, VXOIHB, None, OIHBXI, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IHBXIB: GeckoByteStructAccessor(self.struct, IHBXIB, HBXIBH, AKQXPI),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, AKQXPI),
-            IBHZVO: GeckoByteStructAccessor(self.struct, IBHZVO, BHZVOA, AKQXPI),
-            HZVOAC: GeckoByteStructAccessor(self.struct, HZVOAC, ZVOACM, AKQXPI),
-            VOACMC: GeckoByteStructAccessor(self.struct, VOACMC, OACMCV, AKQXPI),
-            ACMCVD: GeckoByteStructAccessor(self.struct, ACMCVD, CMCVDS, AKQXPI),
-            MCVDSS: GeckoEnumStructAccessor(
-                self.struct, MCVDSS, CVDSSR, None, DSSRUR, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            SSRURA: GeckoEnumStructAccessor(
-                self.struct, SSRURA, SRURAZ, None, DSSRUR, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
             ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, URAZMK, None, DSSRUR, None, None, AKQXPI
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            RAZMKQ: GeckoEnumStructAccessor(
-                self.struct, RAZMKQ, AZMKQT, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, QTDKHT, None, DSSRUR, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            TDKHTZ: GeckoEnumStructAccessor(
-                self.struct, TDKHTZ, DKHTZB, None, DSSRUR, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            KHTZBB: GeckoEnumStructAccessor(
-                self.struct, KHTZBB, HTZBBE, None, TZBBEK, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            ZBBEKB: GeckoEnumStructAccessor(
-                self.struct, ZBBEKB, BBEKBD, None, TZBBEK, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            BEKBDF: GeckoByteStructAccessor(self.struct, BEKBDF, EKBDFS, AKQXPI),
-            KBDFSR: GeckoByteStructAccessor(self.struct, KBDFSR, BDFSRO, AKQXPI),
-            DFSROG: GeckoByteStructAccessor(self.struct, DFSROG, FSROGM, AKQXPI),
-            SROGMD: GeckoByteStructAccessor(self.struct, SROGMD, ROGMDD, AKQXPI),
-            OGMDDP: GeckoByteStructAccessor(self.struct, OGMDDP, GMDDPM, AKQXPI),
-            MDDPMX: GeckoByteStructAccessor(self.struct, MDDPMX, DDPMXF, AKQXPI),
-            DPMXFU: GeckoByteStructAccessor(self.struct, DPMXFU, PMXFUB, AKQXPI),
-            MXFUBJ: GeckoByteStructAccessor(self.struct, MXFUBJ, XFUBJL, AKQXPI),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, AKQXPI),
-            UGUCYR: GeckoBoolStructAccessor(self.struct, UGUCYR, JVHFTH, YEKCWA, None),
-            GUCYRA: GeckoByteStructAccessor(self.struct, GUCYRA, UCYRAP, AKQXPI),
-            CYRAPU: GeckoEnumStructAccessor(
-                self.struct, CYRAPU, YRAPUM, None, EAOESV, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            AOESVZ: GeckoBoolStructAccessor(
-                self.struct, AOESVZ, OESVZS, XPICXQ, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inye-v3-log-81.py
+++ b/src/geckolib/driver/packs/inye-v3-log-81.py
@@ -12,1700 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 52])
-ACMCVD = 320
-ACQFFT = 390
-ADXLUB = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-AFIKJP = "".join(
-    chr(c) for c in [80, 97, 99, 107, 71, 101, 110, 101, 114, 97, 116, 105, 111, 110]
-)
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-AIVEMV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-AJVDQL = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-AMJMAO = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-AOAWBS = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-AOESVZ = 467
-AONPYY = "".join(chr(c) for c in [67, 80])
-APUMEA = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-ATDZXN = 293
-AWBSIR = "".join(chr(c) for c in [78, 79])
-AXADXL = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-AXNCUG = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-AZMKQT = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-BBEKBD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-BDFSRO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-BDJQRJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BEKBDF = 334
-BFEGZU = 304
-BGJFJN = 476
-BHZVOA = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [86, 83, 80, 50, 67, 111, 109, 109, 76, 111, 115, 116])
-BLKXSJ = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-BMIKGN = 479
-BMJVHF = 256
-BQFYLJ = 355
-BQNRXC = "".join(chr(c) for c in [105, 110, 89, 84])
-BQSNQL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BSIRYX = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-BSKSOK = 258
-BSSUHB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BVNAXA = 471
-BVWVUB = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-BWJYKL = 268
-BXTIAC = "".join(chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87])
-BXYBQS = 352
-BYGDSB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-CBFEGZ = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-CCPQIP = 401
-CGETIX = "".join(chr(c) for c in [75, 50, 48, 48])
-CHWDAF = "".join(chr(c) for c in [51, 50, 75])
-CMCVDS = "".join(chr(c) for c in [78, 65])
-CPQIPO = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 53])
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-CRHYUA = 457
-CRTFMN = "".join(chr(c) for c in [86, 83, 80, 51, 69, 114, 114, 111, 114, 73, 68])
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = 455
-CUGUCY = 461
-CVDSSR = "".join(chr(c) for c in [80, 49, 76])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = 463
-CYWONF = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-CZOLSI = 449
-DDPMXF = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-DFSROG = 335
-DGKEAK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-DKHTZB = 322
-DMPSCT = 453
-DNIBXT = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-DNQGVU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-DPMXFU = 339
-DRXAIV = 342
-DSBDJQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-DSSRUR = "".join(chr(c) for c in [80, 50, 76])
-DUBSSU = 383
-DXLUBG = 474
-DZXNQT = 294
-EAKSTS = 301
-EAOESV = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 333
-EFJTAC = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 50])
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = 305
-EJNIBX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-EKBDFS = "".join(chr(c) for c in [72, 84, 82])
-EKCWAO = "".join(chr(c) for c in [80, 53])
-EKVKZI = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-ELHBQN = "".join(chr(c) for c in [75, 54, 48, 48])
-ELWUEU = 328
-EMCGET = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-EMVCYW = 345
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ESVZSS = 468
-ETDRXA = 341
-ETIXQV = "".join(chr(c) for c in [75, 56, 53])
-EUHNNX = 330
-EUTOPH = "".join(chr(c) for c in [86, 83, 80, 52, 67, 111, 109, 109, 76, 111, 115, 116])
-EXLSXU = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-EZFETD = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-FCRTFM = 404
-FEFJTA = 398
-FEGZUQ = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-FETDRX = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-FIKJPU = "".join(chr(c) for c in [49, 83, 84, 95, 71, 69, 78])
-FJBIAM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-FJNTTU = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-FJTACC = 399
-FLSIJU = 374
-FMNHTB = 406
-FSROGM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-FUBJLO = 325
-FWRKIN = 279
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-FZCZOL = 448
-FZDGKE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GCRHYU = "".join(chr(c) for c in [67, 70, 71, 57])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-GETIXQ = "".join(chr(c) for c in [75, 52, 48, 48])
-GJFJNT = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-GKEAKS = 300
-GLRAHE = 259
-GMDDPM = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-GQPLSP = 272
-GSELHB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-GTYIYW = 309
-GUCYRA = 462
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-GZUQEX = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-HBQNRX = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-HBXIBH = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 49])
-HNNXWE = 331
-HTBJEU = "".join(chr(c) for c in [86, 83, 80, 49, 67, 111, 109, 109, 76, 111, 115, 116])
-HTZBBE = 323
-HUGTYI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [52, 56, 75])
-HXEKVK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-HYUAXN = 458
-HZVOAC = 360
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [67, 80, 79, 84])
-IBHZVO = 358
-IBXTIA = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-IBXYBQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-ICXQIE = 1
-IDNIBX = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        67,
-        104,
-        101,
-        99,
-        107,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-IGYOUS = 264
-IHBXIB = "".join(chr(c) for c in [75, 51, 48, 48])
-IIDNIB = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-IJUZMR = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-IKJPUN = "".join(chr(c) for c in [50, 78, 68, 95, 71, 69, 78])
-ILXWAJ = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-INEJNI = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-INELWU = 327
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(chr(c) for c in [67, 70, 71, 52])
-IPOUYN = 310
-IRYXBQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IUSOOQ = 393
-IUXFEF = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-IVDNQG = 315
-IVEMVC = 344
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [75, 52])
-IYWSKW = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [86, 83, 80, 51, 67, 111, 109, 109, 76, 111, 115, 116])
-JFJNTT = 477
-JHIUSO = 370
-JIGYOU = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-JJVYFC = 387
-JLOINE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-JMAOAW = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JMCBFE = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-JNIBXY = 281
-JNTTUV = 478
-JPUNRJ = "".join(chr(c) for c in [52, 84, 72, 95, 71, 69, 78])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 51])
-JUGSEL = "".join(chr(c) for c in [77, 73, 65])
-JUIKFW = 277
-JUZMRK = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-JVDQLA = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [86, 83, 80, 49, 69, 114, 114, 111, 114, 73, 68])
-JWMNZM = "".join(chr(c) for c in [73, 68, 76, 69])
-JYKLGQ = 270
-JYMOUN = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-JZTATD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-KCWAON = 260
-KEAKST = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-KFWRKI = "".join(chr(c) for c in [78, 101, 97, 114, 72, 76])
-KHTZBB = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-KINEJN = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KJPUNR = "".join(chr(c) for c in [51, 82, 68, 95, 71, 69, 78])
-KLGQPL = 271
-KMLOIJ = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = 316
-KWIVDN = 314
-KZILXW = 379
-LAIIDN = 392
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LHBQNR = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-LIUXFE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-LJUIKF = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-LKXSJW = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-LOIJUG = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-LOINEL = 326
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIJUZ = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-LSIPMD = "".join(chr(c) for c in [67, 70, 71, 51])
-LSPFTS = 380
-LSXUJU = "".join(chr(c) for c in [80, 49])
-LUBGJF = 475
-LWUEUH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-LXWAJV = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-MAOAWB = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MCBFEG = 303
-MCGETI = 357
-MCVDSS = "".join(chr(c) for c in [80, 49, 72])
-MDDPMX = 338
-MDMPSC = "".join(chr(c) for c in [67, 70, 71, 53])
-MEAOES = 466
-MFZDGK = 297
-MHXEKV = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-MJMAOA = 282
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = 289
-MNHTBJ = "".join(chr(c) for c in [86, 83, 80, 53, 69, 114, 114, 111, 114, 73, 68])
-MNZMJI = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-MOUNBL = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-MPSCTT = "".join(chr(c) for c in [67, 70, 71, 54])
-MRKVFC = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-MVCYWO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-MXFUBJ = 349
-NAXADX = 472
-NBLKXS = 262
-NCUGUC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-NEJNIB = 280
-NELWUE = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-NFZCZO = "".join(chr(c) for c in [67, 70, 71, 48])
-NHTBJE = 407
-NIBXTI = 389
-NIBXYB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-NKMLOI = 288
-NMHXEK = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-NNXWEE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-NPYYLI = 3
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-NQJYMO = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-NQLNMH = 378
-NQTMFZ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NRJZTA = 8
-NRSJMC = 396
-NRXCHW = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-NTTUVR = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-NXNKML = 287
-NXWEEZ = 332
-NZMJIG = "".join(chr(c) for c in [78, 69, 87])
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-OAWBSI = 313
-OCTHBS = 2
-OESVZS = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OGMDDP = 337
-OIHBXI = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-OIJUGS = "".join(chr(c) for c in [105, 110, 88, 69])
-OINELW = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 450
-ONFZCZ = 348
-ONPYYL = "".join(chr(c) for c in [79, 51])
-OOQNRS = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 51])
-OPHUGT = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-OQNRSJ = 395
-OUBMIK = 81
-OUNBLK = 367
-OUSPBW = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-OUYNQJ = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-PFTSIF = 381
-PHUGTY = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PLSPFT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-PMDMPS = 452
-PMXFUB = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-POUYNQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-PQIPOU = 402
-PSCTTG = 454
-PUMEAO = 465
-PUNRJZ = "".join(chr(c) for c in [53, 84, 72, 95, 71, 69, 78])
-PYYLIU = "".join(chr(c) for c in [76, 49, 50, 48])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 362
-QFFTTI = 284
-QFYLJU = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-QJYMOU = 364
-QLAIID = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        79,
-        117,
-        116,
-        108,
-        101,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 52])
-QPLSPF = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-QRJJJV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-QSNQLN = 384
-QTDKHT = 321
-QTMFZD = 296
-QVXOIH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = 464
-RAZMKQ = "".join(chr(c) for c in [66, 76, 79])
-RFLSIJ = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-RHYUAX = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = 354
-RJZTAT = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 50, 53, 54, 75])
-RKINEJ = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-RKVFCP = 375
-ROGMDD = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-RSJMCB = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 53])
-RTFMNH = 405
-RURAZM = "".join(chr(c) for c in [80, 52, 72])
-RXAIVE = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-RXCHWD = 290
-RYXBQF = 353
-SAKQXP = 386
-SBDJQR = 351
-SBVNAX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-SCTTGC = "".join(chr(c) for c in [67, 70, 71, 55])
-SELHBQ = "".join(chr(c) for c in [105, 110, 88, 77])
-SIFJBI = "".join(chr(c) for c in [70, 105, 108, 116, 82, 101, 113, 117, 101, 115, 116])
-SIJUZM = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-SIPMDM = 451
-SJMCBF = 397
-SJWMNZ = 263
-SKWIVD = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 394
-SPBWJY = 267
-SPFTSI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-SROGMD = 336
-SRURAZ = "".join(chr(c) for c in [80, 51, 76])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSBVNA = 470
-SSRURA = "".join(chr(c) for c in [80, 51, 72])
-SSUHBV = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-STSEMC = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-SUHBVW = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-SVZSSB = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-SXUJUT = 261
-TACCPQ = 400
-TATDZX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TBJEUT = 408
-TDKHTZ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-TDRXAI = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-TDZXNQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TFMNHT = "".join(chr(c) for c in [86, 83, 80, 52, 69, 114, 114, 111, 114, 73, 68])
-TGCRHY = 456
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-TIXQVX = "".join(chr(c) for c in [75, 56])
-TMFZDG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TOPHUG = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-TSEMCG = "".join(chr(c) for c in [70, 117, 108, 108])
-TSIFJB = 273
-TTGCRH = "".join(chr(c) for c in [67, 70, 71, 56])
-TTIDUB = 350
-TTUVRF = 479
-TUVRFL = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-TYEKCW = "".join(chr(c) for c in [80, 51])
-TYIYWS = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-TZBBEK = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-UAXNCU = 459
-UBGJFJ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-UBJLOI = "".join(chr(c) for c in [70, 97, 110])
-UBMIKG = 256
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-UBYGDS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-UCYRAP = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-UEUHNN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-UGSELH = "".join(chr(c) for c in [68, 74, 83, 52])
-UGTYIY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-UGUCYR = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-UHBVWV = 283
-UHNNXW = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-UIKFWR = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-UJUTYE = "".join(chr(c) for c in [76, 79, 87])
-UMEAOE = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-UNBLKX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-UOJRJH = 307
-UQEXLS = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-URAZMK = "".join(chr(c) for c in [80, 52, 76])
-USOOQN = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 50])
-USPBWJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-UTOPHU = "".join(chr(c) for c in [86, 83, 80, 53, 67, 111, 109, 109, 76, 111, 115, 116])
-UTYEKC = "".join(chr(c) for c in [80, 50])
-UVRFLS = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-UXFEFJ = 7
-UYNQJY = "".join(chr(c) for c in [70, 85, 76, 76])
-UZMRKV = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-VCYWON = 346
-VDNQGV = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-VDQLAI = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-VDSSRU = "".join(chr(c) for c in [80, 50, 72])
-VEMVCY = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-VFCPOU = "".join(chr(c) for c in [76, 73])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VNAXAD = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-VOACMC = 361
-VRFLSI = 371
-VUBYGD = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-VUNXNK = 285
-VWVUBY = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-VXOIHB = "".join(chr(c) for c in [75, 49, 48, 48])
-VYFCRT = 403
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-VZSSBV = 469
-WAJVDQ = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-WAONPY = "".join(chr(c) for c in [66, 76])
-WBSIRY = "".join(chr(c) for c in [77, 69, 68])
-WDAFIK = "".join(chr(c) for c in [54, 52, 75])
-WEEZFE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-WIVDNQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 84, 79, 80])
-WONFZC = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-WRKINE = "".join(chr(c) for c in [72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116])
-WSKWIV = 311
-WUEUHN = 329
-WVUBYG = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-XADXLU = 473
-XAIVEM = 343
-XBQFYL = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-XCHWDA = "".join(chr(c) for c in [49, 54, 75])
-XEKVKZ = "".join(chr(c) for c in [72, 69, 65, 84])
-XFEFJT = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 49])
-XFUBJL = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-XIBHZV = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-XLSXUJ = 369
-XLUBGJ = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-XNCUGU = 460
-XNKMLO = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-XNQTMF = 295
-XOIHBX = "".join(chr(c) for c in [75, 56, 48, 48])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = "".join(chr(c) for c in [75, 53])
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XTIACQ = "".join(chr(c) for c in [71, 69, 67, 75, 79, 55, 53, 48, 48, 87])
-XUJUTY = "".join(chr(c) for c in [72, 73, 71, 72])
-XWAJVD = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-XYBQSN = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-YBQSNQ = 377
-YEKCWA = "".join(chr(c) for c in [80, 52])
-YFCRTF = "".join(chr(c) for c in [86, 83, 80, 50, 69, 114, 114, 111, 114, 73, 68])
-YGDSBD = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-YKLGQP = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YLIUXF = 5
-YLJUIK = 275
-YMOUNB = 365
-YOUSPB = 266
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YRAPUM = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-YUAXNC = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-YWONFZ = 347
-YWSKWI = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YYLIUX = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 324
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [67, 70, 71, 49])
-ZDGKEA = 299
-ZFETDR = 340
-ZILXWA = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-ZMJIGY = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-ZMKQTD = "".join(chr(c) for c in [65, 85, 88])
-ZOLSIP = "".join(chr(c) for c in [67, 70, 71, 50])
-ZSSBVN = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ZTATDZ = 291
-ZUQEXL = 306
-ZVOACM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-ZXNQTM = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-BJLOIN = [
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    EKCWAO,
-    RAZMKQ,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    HECVYY,
-    HECVYY,
-    UBJLOI,
-    HECVYY,
-    HECVYY,
-    AZMKQT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IUXFEF,
-    ZMKQTD,
-]
-BXIBHZ = [
-    CGETIX,
-    GETIXQ,
-    ETIXQV,
-    TIXQVX,
-    IXQVXO,
-    XQVXOI,
-    QVXOIH,
-    VXOIHB,
-    XOIHBX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-]
-CPOUBM = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-    CBFEGZ,
-    FEGZUQ,
-    GZUQEX,
-    UQEXLS,
-    EXLSXU,
-]
-CWAONP = [FXQGLR, XUJUTY]
-DAFIKJ = [XCHWDA, CHWDAF, HWDAFI, WDAFIK]
-DQLAII = [
-    JWMNZM,
-    ZILXWA,
-    ILXWAJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-]
-FCPOUB = [
-    LSXUJU,
-    UTYEKC,
-    TYEKCW,
-    YEKCWA,
-    EKCWAO,
-    WAONPY,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    YYLIUX,
-    LIUXFE,
-    IUXFEF,
-    XFEFJT,
-    EFJTAC,
-    JTACCP,
-    ACCPQI,
-    CPQIPO,
-    QIPOUY,
-    NQJYMO,
-    JYMOUN,
-    MOUNBL,
-    VFCPOU,
-]
-IKFWRK = [HECVYY, UIKFWR, UIKFWR, UIKFWR]
-JUTYEK = [FXQGLR, XUJUTY, UJUTYE]
-KBDFSR = [
-    CMCVDS,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EKBDFS,
-]
-KVFCPO = []
-KVKZIL = [XEKVKZ, EKVKZI]
-KXSJWM = [BLKXSJ, LKXSJW]
-MJIGYO = [JWMNZM, WMNZMJ, MNZMJI, NZMJIG, ZMJIGY]
-MKQTDK = [
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    EKCWAO,
-    RAZMKQ,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    AZMKQT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IUXFEF,
-    ZMKQTD,
-]
-OKPHUO = [FXQGLR, SOKPHU]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-POUBMI = [
-    EUTOPH,
-    TFMNHT,
-    JEUTOP,
-    JVYFCR,
-    DNQGVU,
-    BDJQRJ,
-    JQRJJJ,
-    VWVUBY,
-    QFYLJU,
-    IYWSKW,
-    VDNQGV,
-    NQGVUN,
-    RKINEJ,
-    UTOPHU,
-    BIAMJM,
-    GDSBDJ,
-    UBYGDS,
-    IBXYBQ,
-    BJEUTO,
-    WIVDNQ,
-    VUBYGD,
-    DSBDJQ,
-    YGDSBD,
-    HBVWVU,
-    CRTFMN,
-    HTBJEU,
-    QRJJJV,
-    YFCRTF,
-    MNHTBJ,
-    SUHBVW,
-    BSSUHB,
-    PHUGTY,
-    DJQRJJ,
-    SSUHBV,
-    JJJVYF,
-    BYGDSB,
-    WVUBYG,
-    BVWVUB,
-]
-QNRXCH = [
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-]
-SEMCGE = [STSEMC, TSEMCG]
-SIRYXB = [AWBSIR, LRAHEO, WBSIRY, RAHEOC, BSIRYX]
-SKSOKP = [FXQGLR, RAHEOC]
-TIACQF = [IBXTIA, BXTIAC, XTIACQ]
-UNRJZT = [FIKJPU, IKJPUN, HECVYY, KJPUNR, HECVYY, JPUNRJ, HECVYY, PUNRJZ]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-XWEEZF = [
-    CMCVDS,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    AONPYY,
-]
-YIYWSK = [HECVYY, TYIYWS, TYIYWS, TYIYWS]
-YNQJYM = [POUYNQ, OUYNQJ, UYNQJY]
-ZMRKVF = [LSIJUZ, SIJUZM, IJUZMR, JUZMRK, UZMRKV]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1713,361 +19,1354 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return OUBMIK
+        return 81
 
     @property
     def begin(self):
-        return UBMIKG
+        return 256
 
     @property
     def end(self):
-        return BMIKGN
+        return 479
 
     @property
     def all_device_keys(self):
-        return FCPOUB
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "SpeedVSP1",
+            "SpeedVSP2",
+            "SpeedVSP3",
+            "SpeedVSP4",
+            "SpeedVSP5",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return CPOUBM
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdSpeedVSP1",
+            "UdSpeedVSP2",
+            "UdSpeedVSP3",
+            "UdSpeedVSP4",
+            "UdSpeedVSP5",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return POUBMI
+        return [
+            "SlaveNoFloErr",
+            "VSP2ErrorID",
+            "AmbiantOHLevel2",
+            "VSP5ErrorID",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "VSP1ErrorID",
+            "SlaveRegProbeErr",
+            "VSP4CommLost",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "VSP2CommLost",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "VSP4ErrorID",
+            "SlaveP1HStuck",
+            "VSP5CommLost",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "VSP1CommLost",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "VSP3CommLost",
+            "VSP3ErrorID",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, AKQXPI),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, AKQXPI),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, AKQXPI),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, AKQXPI),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, AKQXPI),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, XPICXQ, JUTYEK, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, SXUJUT, OCTHBS, JUTYEK, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, SXUJUT, HEOCTH, JUTYEK, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, SXUJUT, VHFTHE, JUTYEK, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, XPICXQ, CWAONP, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, KCWAON, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP1": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP1", 393, "ALL"
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, KCWAON, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP2": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP2", 394, "ALL"
             ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, KCWAON, NPYYLI, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP3": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP3", 395, "ALL"
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, KCWAON, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP4": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP4", 396, "ALL"
             ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, KCWAON, YLIUXF, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP5": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP5", 397, "ALL"
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, KCWAON, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, KCWAON, UXFEFJ, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, AKQXPI),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, AKQXPI),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, AKQXPI),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, AKQXPI),
-            QIPOUY: GeckoEnumStructAccessor(
-                self.struct, QIPOUY, IPOUYN, None, YNQJYM, None, None, AKQXPI
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, QJYMOU, None, YNQJYM, None, None, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            JYMOUN: GeckoWordStructAccessor(self.struct, JYMOUN, YMOUNB, None),
-            MOUNBL: GeckoWordStructAccessor(self.struct, MOUNBL, OUNBLK, AKQXPI),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, NBLKXS, XPICXQ, KXSJWM, None, OCTHBS, AKQXPI
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MJIGYO, None, None, AKQXPI
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JIGYOU: GeckoTimeStructAccessor(self.struct, JIGYOU, IGYOUS, AKQXPI),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, AKQXPI),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, NBLKXS, OCTHBS, KXSJWM, None, OCTHBS, AKQXPI
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, None, MJIGYO, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            PBWJYK: GeckoTimeStructAccessor(self.struct, PBWJYK, BWJYKL, AKQXPI),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, AKQXPI),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, AKQXPI),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, AKQXPI),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, NBLKXS, ICXQIE, KXSJWM, None, OCTHBS, AKQXPI
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, MJIGYO, None, None, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SPFTSI: GeckoTimeStructAccessor(self.struct, SPFTSI, PFTSIF, AKQXPI),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, XPICXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, TSIFJB, ICXQIE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, TSIFJB, OCTHBS, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, TSIFJB, NPYYLI, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, TSIFJB, HEOCTH, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, TSIFJB, YLIUXF, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, JVHFTH, OCTHBS, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, NPYYLI, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MJMAOA, YLIUXF, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, MJMAOA, VHFTHE, None),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, SIRYXB, None, None, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, YLIUXF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, RYXBQF, VHFTHE, None),
-            XBQFYL: GeckoWordStructAccessor(self.struct, XBQFYL, BQFYLJ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, JVHFTH, ICXQIE, None),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, None),
-            LJUIKF: GeckoTempStructAccessor(self.struct, LJUIKF, JUIKFW, None),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, KCWAON, YLIUXF, IKFWRK, None, HEOCTH, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, XPICXQ, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, FWRKIN, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, FWRKIN, OCTHBS, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, FWRKIN, VHFTHE, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, OCTHBS, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, JNIBXY, ICXQIE, None),
-            NIBXYB: GeckoBoolStructAccessor(
-                self.struct, NIBXYB, JNIBXY, OCTHBS, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, QSNQLN, XPICXQ, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, NQLNMH, XPICXQ, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, NQLNMH, ICXQIE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NQLNMH, HEOCTH, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NQLNMH, YLIUXF, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NQLNMH, VHFTHE, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, NQLNMH, UXFEFJ, KVKZIL, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, DQLAII, None, None, None
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LAIIDN, XPICXQ, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, LAIIDN, ICXQIE, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, LAIIDN, OCTHBS, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, LAIIDN, NPYYLI, None),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, TIACQF, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IACQFF: GeckoWordStructAccessor(self.struct, IACQFF, ACQFFT, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, QFFTTI, XPICXQ, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, QFFTTI, ICXQIE, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, TTIDUB, XPICXQ, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, TTIDUB, ICXQIE, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, DUBSSU, XPICXQ, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, DUBSSU, ICXQIE, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, MJMAOA, XPICXQ, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, MJMAOA, ICXQIE, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, UHBVWV, OCTHBS, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, UHBVWV, NPYYLI, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, QFFTTI, NPYYLI, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, QFFTTI, HEOCTH, None),
-            WVUBYG: GeckoBoolStructAccessor(self.struct, WVUBYG, QFFTTI, YLIUXF, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, QFFTTI, VHFTHE, None),
-            UBYGDS: GeckoBoolStructAccessor(self.struct, UBYGDS, TTIDUB, NPYYLI, None),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, TTIDUB, HEOCTH, None),
-            YGDSBD: GeckoBoolStructAccessor(self.struct, YGDSBD, TTIDUB, YLIUXF, None),
-            GDSBDJ: GeckoBoolStructAccessor(self.struct, GDSBDJ, TTIDUB, VHFTHE, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, SBDJQR, OCTHBS, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, SBDJQR, NPYYLI, None),
-            DJQRJJ: GeckoBoolStructAccessor(self.struct, DJQRJJ, RYXBQF, XPICXQ, None),
-            JQRJJJ: GeckoBoolStructAccessor(self.struct, JQRJJJ, RYXBQF, ICXQIE, None),
-            QRJJJV: GeckoBoolStructAccessor(self.struct, QRJJJV, RJJJVY, XPICXQ, None),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, None),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, AKQXPI),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, AKQXPI),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, AKQXPI),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, AKQXPI),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, AKQXPI),
-            HTBJEU: GeckoBoolStructAccessor(self.struct, HTBJEU, TBJEUT, XPICXQ, None),
-            BJEUTO: GeckoBoolStructAccessor(self.struct, BJEUTO, TBJEUT, ICXQIE, None),
-            JEUTOP: GeckoBoolStructAccessor(self.struct, JEUTOP, TBJEUT, OCTHBS, None),
-            EUTOPH: GeckoBoolStructAccessor(self.struct, EUTOPH, TBJEUT, NPYYLI, None),
-            UTOPHU: GeckoBoolStructAccessor(self.struct, UTOPHU, TBJEUT, HEOCTH, None),
-            TOPHUG: GeckoBoolStructAccessor(self.struct, TOPHUG, NEJNIB, XPICXQ, None),
-            OPHUGT: GeckoBoolStructAccessor(self.struct, OPHUGT, UHBVWV, XPICXQ, None),
-            PHUGTY: GeckoBoolStructAccessor(self.struct, PHUGTY, UHBVWV, ICXQIE, None),
-            HUGTYI: GeckoBoolStructAccessor(self.struct, HUGTYI, UHBVWV, HEOCTH, None),
-            UGTYIY: GeckoBoolStructAccessor(self.struct, UGTYIY, GTYIYW, XPICXQ, None),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, GTYIYW, ICXQIE, YIYWSK, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IYWSKW: GeckoBoolStructAccessor(self.struct, IYWSKW, GTYIYW, NPYYLI, None),
-            YWSKWI: GeckoWordStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoBoolStructAccessor(self.struct, SKWIVD, KWIVDN, XPICXQ, None),
-            WIVDNQ: GeckoBoolStructAccessor(self.struct, WIVDNQ, IVDNQG, XPICXQ, None),
-            VDNQGV: GeckoBoolStructAccessor(self.struct, VDNQGV, IVDNQG, ICXQIE, None),
-            DNQGVU: GeckoBoolStructAccessor(self.struct, DNQGVU, SBDJQR, XPICXQ, None),
-            NQGVUN: GeckoBoolStructAccessor(self.struct, NQGVUN, SBDJQR, ICXQIE, None),
-            QGVUNX: GeckoBoolStructAccessor(self.struct, QGVUNX, SBDJQR, HEOCTH, None),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, QNRXCH, None, None, None
+            "SpeedVSP1": GeckoByteStructAccessor(self.struct, "SpeedVSP1", 398, "ALL"),
+            "SpeedVSP2": GeckoByteStructAccessor(self.struct, "SpeedVSP2", 399, "ALL"),
+            "SpeedVSP3": GeckoByteStructAccessor(self.struct, "SpeedVSP3", 400, "ALL"),
+            "SpeedVSP4": GeckoByteStructAccessor(self.struct, "SpeedVSP4", 401, "ALL"),
+            "SpeedVSP5": GeckoByteStructAccessor(self.struct, "SpeedVSP5", 402, "ALL"),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, XPICXQ, DAFIKJ, None, HEOCTH, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, RXCHWD, NPYYLI, UNRJZT, None, NRJZTA, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            RJZTAT: GeckoBoolStructAccessor(self.struct, RJZTAT, RXCHWD, VHFTHE, None),
-            JZTATD: GeckoWordStructAccessor(self.struct, JZTATD, ZTATDZ, None),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, None),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, None),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, None),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, None),
-            TMFZDG: GeckoWordStructAccessor(self.struct, TMFZDG, MFZDGK, None),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, None),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, None),
-            KEAKST: GeckoWordStructAccessor(self.struct, KEAKST, EAKSTS, None),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, SEMCGE, None, OCTHBS, AKQXPI
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, BXIBHZ, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XIBHZV: GeckoWordStructAccessor(self.struct, XIBHZV, IBHZVO, None),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, None),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, None),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, ACMCVD, None, MKQTDK, None, None, AKQXPI
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, QTDKHT, None, MKQTDK, None, None, AKQXPI
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            TDKHTZ: GeckoEnumStructAccessor(
-                self.struct, TDKHTZ, DKHTZB, None, MKQTDK, None, None, AKQXPI
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            KHTZBB: GeckoEnumStructAccessor(
-                self.struct, KHTZBB, HTZBBE, None, MKQTDK, None, None, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            TZBBEK: GeckoEnumStructAccessor(
-                self.struct, TZBBEK, ZBBEKB, None, MKQTDK, None, None, AKQXPI
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BBEKBD: GeckoEnumStructAccessor(
-                self.struct, BBEKBD, BEKBDF, None, KBDFSR, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            BDFSRO: GeckoByteStructAccessor(self.struct, BDFSRO, DFSROG, AKQXPI),
-            FSROGM: GeckoByteStructAccessor(self.struct, FSROGM, SROGMD, AKQXPI),
-            ROGMDD: GeckoByteStructAccessor(self.struct, ROGMDD, OGMDDP, AKQXPI),
-            GMDDPM: GeckoByteStructAccessor(self.struct, GMDDPM, MDDPMX, AKQXPI),
-            DDPMXF: GeckoByteStructAccessor(self.struct, DDPMXF, DPMXFU, AKQXPI),
-            PMXFUB: GeckoByteStructAccessor(self.struct, PMXFUB, MXFUBJ, AKQXPI),
-            XFUBJL: GeckoEnumStructAccessor(
-                self.struct, XFUBJL, FUBJLO, None, BJLOIN, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            JLOINE: GeckoEnumStructAccessor(
-                self.struct, JLOINE, LOINEL, None, BJLOIN, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            OINELW: GeckoEnumStructAccessor(
-                self.struct, OINELW, INELWU, None, BJLOIN, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NELWUE: GeckoEnumStructAccessor(
-                self.struct, NELWUE, ELWUEU, None, BJLOIN, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            LWUEUH: GeckoEnumStructAccessor(
-                self.struct, LWUEUH, WUEUHN, None, BJLOIN, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            UEUHNN: GeckoEnumStructAccessor(
-                self.struct, UEUHNN, EUHNNX, None, BJLOIN, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            UHNNXW: GeckoEnumStructAccessor(
-                self.struct, UHNNXW, HNNXWE, None, BJLOIN, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
             ),
-            NNXWEE: GeckoEnumStructAccessor(
-                self.struct, NNXWEE, NXWEEZ, None, XWEEZF, None, None, AKQXPI
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            WEEZFE: GeckoEnumStructAccessor(
-                self.struct, WEEZFE, EEZFET, None, XWEEZF, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            EZFETD: GeckoByteStructAccessor(self.struct, EZFETD, ZFETDR, AKQXPI),
-            FETDRX: GeckoByteStructAccessor(self.struct, FETDRX, ETDRXA, AKQXPI),
-            TDRXAI: GeckoByteStructAccessor(self.struct, TDRXAI, DRXAIV, AKQXPI),
-            RXAIVE: GeckoByteStructAccessor(self.struct, RXAIVE, XAIVEM, AKQXPI),
-            AIVEMV: GeckoByteStructAccessor(self.struct, AIVEMV, IVEMVC, AKQXPI),
-            VEMVCY: GeckoByteStructAccessor(self.struct, VEMVCY, EMVCYW, AKQXPI),
-            MVCYWO: GeckoByteStructAccessor(self.struct, MVCYWO, VCYWON, AKQXPI),
-            CYWONF: GeckoByteStructAccessor(self.struct, CYWONF, YWONFZ, AKQXPI),
-            WONFZC: GeckoByteStructAccessor(self.struct, WONFZC, ONFZCZ, AKQXPI),
-            TUVRFL: GeckoBoolStructAccessor(self.struct, TUVRFL, JVHFTH, YLIUXF, None),
-            UVRFLS: GeckoByteStructAccessor(self.struct, UVRFLS, VRFLSI, AKQXPI),
-            RFLSIJ: GeckoEnumStructAccessor(
-                self.struct, RFLSIJ, FLSIJU, None, ZMRKVF, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            MRKVFC: GeckoBoolStructAccessor(
-                self.struct, MRKVFC, RKVFCP, XPICXQ, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "VSP1ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP1ErrorID", 403, "ALL"
+            ),
+            "VSP2ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP2ErrorID", 404, "ALL"
+            ),
+            "VSP3ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP3ErrorID", 405, "ALL"
+            ),
+            "VSP4ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP4ErrorID", 406, "ALL"
+            ),
+            "VSP5ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP5ErrorID", 407, "ALL"
+            ),
+            "VSP1CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP1CommLost", 408, 0, None
+            ),
+            "VSP2CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP2CommLost", 408, 1, None
+            ),
+            "VSP3CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP3CommLost", 408, 2, None
+            ),
+            "VSP4CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP4CommLost", 408, 3, None
+            ),
+            "VSP5CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP5CommLost", 408, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inye-v3-log-82.py
+++ b/src/geckolib/driver/packs/inye-v3-log-82.py
@@ -1,0 +1,1375 @@
+#!/usr/bin/python3
+"""
+    GeckoLogStruct - A class to manage the LogStruct for 'inYE-V3 v82'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoLogStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 82
+
+    @property
+    def begin(self):
+        return 256
+
+    @property
+    def end(self):
+        return 479
+
+    @property
+    def all_device_keys(self):
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "SpeedVSP1",
+            "SpeedVSP2",
+            "SpeedVSP3",
+            "SpeedVSP4",
+            "SpeedVSP5",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
+
+    @property
+    def user_demand_keys(self):
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdSpeedVSP1",
+            "UdSpeedVSP2",
+            "UdSpeedVSP3",
+            "UdSpeedVSP4",
+            "UdSpeedVSP5",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
+
+    @property
+    def error_keys(self):
+        return [
+            "SlaveNoFloErr",
+            "VSP2ErrorID",
+            "AmbiantOHLevel2",
+            "VSP5ErrorID",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "VSP1ErrorID",
+            "SlaveRegProbeErr",
+            "VSP4CommLost",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "VSP2CommLost",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "VSP4ErrorID",
+            "SlaveP1HStuck",
+            "VSP5CommLost",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "VSP1CommLost",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "VSP3CommLost",
+            "VSP3ErrorID",
+            "OverTemp",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
+            ),
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
+            ),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
+            ),
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
+            ),
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
+            ),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
+            ),
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
+            ),
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
+            ),
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdSpeedVSP1": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP1", 393, "ALL"
+            ),
+            "UdSpeedVSP2": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP2", 394, "ALL"
+            ),
+            "UdSpeedVSP3": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP3", 395, "ALL"
+            ),
+            "UdSpeedVSP4": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP4", 396, "ALL"
+            ),
+            "UdSpeedVSP5": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP5", 397, "ALL"
+            ),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
+            ),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
+            ),
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
+            ),
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
+            ),
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
+            ),
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
+            ),
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
+            ),
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
+            ),
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
+            ),
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
+            ),
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
+            ),
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
+            ),
+            "SpeedVSP1": GeckoByteStructAccessor(self.struct, "SpeedVSP1", 398, "ALL"),
+            "SpeedVSP2": GeckoByteStructAccessor(self.struct, "SpeedVSP2", 399, "ALL"),
+            "SpeedVSP3": GeckoByteStructAccessor(self.struct, "SpeedVSP3", 400, "ALL"),
+            "SpeedVSP4": GeckoByteStructAccessor(self.struct, "SpeedVSP4", 401, "ALL"),
+            "SpeedVSP5": GeckoByteStructAccessor(self.struct, "SpeedVSP5", 402, "ALL"),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
+            ),
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
+            ),
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
+            ),
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
+            ),
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
+            ),
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
+            ),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
+            ),
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "ColdpumpInstalled": GeckoBoolStructAccessor(
+                self.struct, "ColdpumpInstalled", 378, 2, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "VSP1ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP1ErrorID", 403, "ALL"
+            ),
+            "VSP2ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP2ErrorID", 404, "ALL"
+            ),
+            "VSP3ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP3ErrorID", 405, "ALL"
+            ),
+            "VSP4ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP4ErrorID", 406, "ALL"
+            ),
+            "VSP5ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP5ErrorID", 407, "ALL"
+            ),
+            "VSP1CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP1CommLost", 408, 0, None
+            ),
+            "VSP2CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP2CommLost", 408, 1, None
+            ),
+            "VSP3CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP3CommLost", 408, 2, None
+            ),
+            "VSP4CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP4CommLost", 408, 3, None
+            ),
+            "VSP5CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP5CommLost", 408, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+        }

--- a/src/geckolib/driver/packs/inye-v3-log-83.py
+++ b/src/geckolib/driver/packs/inye-v3-log-83.py
@@ -1,0 +1,1394 @@
+#!/usr/bin/python3
+"""
+    GeckoLogStruct - A class to manage the LogStruct for 'inYE-V3 v83'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoLogStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 83
+
+    @property
+    def begin(self):
+        return 256
+
+    @property
+    def end(self):
+        return 479
+
+    @property
+    def all_device_keys(self):
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "SpeedVSP1",
+            "SpeedVSP2",
+            "SpeedVSP3",
+            "SpeedVSP4",
+            "SpeedVSP5",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
+
+    @property
+    def user_demand_keys(self):
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdSpeedVSP1",
+            "UdSpeedVSP2",
+            "UdSpeedVSP3",
+            "UdSpeedVSP4",
+            "UdSpeedVSP5",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
+
+    @property
+    def error_keys(self):
+        return [
+            "SlaveNoFloErr",
+            "VSP2ErrorID",
+            "AmbiantOHLevel2",
+            "VSP5ErrorID",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "VSP1ErrorID",
+            "SlaveRegProbeErr",
+            "VSP4CommLost",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "VSP2CommLost",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "VSP4ErrorID",
+            "SlaveP1HStuck",
+            "VSP5CommLost",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "VSP1CommLost",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "VSP3CommLost",
+            "VSP3ErrorID",
+            "OverTemp",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
+            ),
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
+            ),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
+            ),
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
+            ),
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
+            ),
+            "GfciTestStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "GfciTestStatus",
+                409,
+                None,
+                [
+                    "NOT_SUPPORTED",
+                    "CONFIG_DISABLED",
+                    "TEST_REQUIRED",
+                    "TEST_IN_PROGRESS",
+                    "LAST_TEST_PASSED",
+                    "LAST_TEST_FAILED",
+                    "WAINTING_TEST_SUPPORTED_RESPONSE",
+                    "TEST_BY_PASSED",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
+            ),
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
+            ),
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
+            ),
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdSpeedVSP1": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP1", 393, "ALL"
+            ),
+            "UdSpeedVSP2": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP2", 394, "ALL"
+            ),
+            "UdSpeedVSP3": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP3", 395, "ALL"
+            ),
+            "UdSpeedVSP4": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP4", 396, "ALL"
+            ),
+            "UdSpeedVSP5": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP5", 397, "ALL"
+            ),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
+            ),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
+            ),
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
+            ),
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
+            ),
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
+            ),
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
+            ),
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
+            ),
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
+            ),
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
+            ),
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
+            ),
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
+            ),
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
+            ),
+            "SpeedVSP1": GeckoByteStructAccessor(self.struct, "SpeedVSP1", 398, "ALL"),
+            "SpeedVSP2": GeckoByteStructAccessor(self.struct, "SpeedVSP2", 399, "ALL"),
+            "SpeedVSP3": GeckoByteStructAccessor(self.struct, "SpeedVSP3", 400, "ALL"),
+            "SpeedVSP4": GeckoByteStructAccessor(self.struct, "SpeedVSP4", 401, "ALL"),
+            "SpeedVSP5": GeckoByteStructAccessor(self.struct, "SpeedVSP5", 402, "ALL"),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
+            ),
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
+            ),
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
+            ),
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
+            ),
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
+            ),
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
+            ),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
+            ),
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "ColdpumpInstalled": GeckoBoolStructAccessor(
+                self.struct, "ColdpumpInstalled", 378, 2, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "VSP1ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP1ErrorID", 403, "ALL"
+            ),
+            "VSP2ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP2ErrorID", 404, "ALL"
+            ),
+            "VSP3ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP3ErrorID", 405, "ALL"
+            ),
+            "VSP4ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP4ErrorID", 406, "ALL"
+            ),
+            "VSP5ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP5ErrorID", 407, "ALL"
+            ),
+            "VSP1CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP1CommLost", 408, 0, None
+            ),
+            "VSP2CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP2CommLost", 408, 1, None
+            ),
+            "VSP3CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP3CommLost", 408, 2, None
+            ),
+            "VSP4CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP4CommLost", 408, 3, None
+            ),
+            "VSP5CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP5CommLost", 408, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+        }

--- a/src/geckolib/driver/packs/inye-v3.py
+++ b/src/geckolib/driver/packs/inye-v3.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inyj-cfg-53.py
+++ b/src/geckolib/driver/packs/inyj-cfg-53.py
@@ -12,457 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 63
-AHEOCT = 39
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 3
-AOAWBS = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-AWBSIR = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-BFEGZU = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-BIAMJM = 1
-BLKXSJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 34
-BQSNQL = 45
-BSIRYX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-BSKSOK = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-BWJYKL = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-BXYBQS = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-CBFEGZ = 57
-CCPQIP = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-CPQIPO = 1
-CQBMJV = 0
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 78
-CXQIEF = 36
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-EFXQGL = 38
-EGZUQE = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-EKCWAO = 62
-EOCTHB = 79
-FEFJTA = 30
-FEGZUQ = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-FJTACC = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [50, 52, 104])
-GLRAHE = 15
-GQPLSP = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-GYOUSP = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-HBSKSO = 80
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-HUOJRJ = 81
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-IBXYBQ = 43
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-IFJBIA = 72
-IGYOUS = 53
-IKFWRK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-INEJNI = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [70])
-IUSOOQ = 32
-IUXFEF = 29
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JHIUSO = 2
-JIGYOU = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-JMAOAW = 76
-JNIBXY = 5
-JUIKFW = 64
-JUTYEK = 60
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 51
-JYKLGQ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JYMOUN = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-KCWAON = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-KFWRKI = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-KINEJN = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-KLGQPL = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-KPHUOJ = 56
-KQXPIC = 14
-KSOKPH = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-KXSJWM = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 8
-LIUXFE = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-LJUIKF = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-LSPFTS = 71
-LSXUJU = 58
-MAOAWB = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MCBFEG = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MJIGYO = 52
-MJMAOA = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-MJVHFT = 12
-MNZMJI = "".join(chr(c) for c in [67, 69])
-MOUNBL = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-NBLKXS = 70
-NEJNIB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NIBXYB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-NMHXEK = 53
-NPYYLI = 28
-NQJYMO = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-NRSJMC = 27
-OCTHBS = "".join(chr(c) for c in [76, 73])
-OJRJHI = "".join(chr(c) for c in [79, 119, 110])
-OKPHUO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-ONPYYL = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-OOQNRS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OUNBLK = 68
-OUSPBW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-PBWJYK = 3
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-POUYNQ = "".join(chr(c) for c in [67])
-PQIPOU = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-PYYLIU = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [72, 105])
-QFYLJU = "".join(chr(c) for c in [65, 109, 80, 109])
-QGLRAH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-QIEFXQ = 37
-QIPOUY = 33
-QJYMOU = 35
-QNRSJM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-QPLSPF = 10
-QSNQLN = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-RAHEOC = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-RJHIUS = 0
-RKINEJ = 4
-RSJMCB = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-RYXBQF = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-SAKQXP = 13
-SIFJBI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-SIRYXB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-SJMCBF = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-SJWMNZ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-SKSOKP = 54
-SNQLNM = 46
-SOKPHU = 55
-SOOQNR = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-SPBWJY = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-SPFTSI = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SXUJUT = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TACCPQ = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-THBSKS = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = 82
-TYEKCW = 61
-UIKFWR = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UJUTYE = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UNBLKX = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-UOJRJH = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UQEXLS = "".join(chr(c) for c in [76, 111])
-USOOQN = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UTYEKC = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UYNQJY = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [80, 49])
-WBSIRY = 73
-WJYKLG = 4
-WMNZMJ = "".join(chr(c) for c in [85, 76])
-WRKINE = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-XBQFYL = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XFEFJT = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-XLSXUJ = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-XPICXQ = 16
-XQGLRA = 40
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-XSJWMN = 77
-XUJUTY = 59
-XYBQSN = 44
-YBQSNQ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-YEKCWA = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YKLGQP = 6
-YMOUNB = 66
-YNQJYM = 31
-YOUSPB = 74
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 75
-YYLIUX = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-ZUQEXL = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-AONPYY = [JVHFTH, WAONPY, PIPIVL]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-CTHBSK = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OCTHBS,
-]
-EJNIBX = [INEJNI, NEJNIB]
-EXLSXU = [UQEXLS, QEXLSX]
-FWRKIN = [IKFWRK, KFWRKI]
-GZUQEX = [BFEGZU, FEGZUQ, EGZUQE]
-IRYXBQ = [VLASSA, BSIRYX, SIRYXB]
-JMCBFE = [RSJMCB, SJMCBF]
-JRJHIU = [UOJRJH, OJRJHI]
-JTACCP = [EFJTAC, FJTACC]
-LKXSJW = [EFJTAC, BLKXSJ]
-LNMHXE = []
-LRAHEO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-NQLNMH = [BMJVHF, SSAKQX, AKQXPI, QXPICX, QGLRAH, HEOCTH]
-NZMJIG = [WMNZMJ, MNZMJI]
-OAWBSI = [MAOAWB, AOAWBS]
-OQNRSJ = [USOOQN, SOOQNR, OOQNRS]
-OUYNQJ = [IPOUYN, POUYNQ]
-PFTSIF = [JVHFTH, SPFTSI]
-PICXQI = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QLNMHX = [OCTHBS]
-USPBWJ = [EFJTAC, OUSPBW]
-UXFEFJ = [PIPIVL, WAONPY]
-YLIUXF = [PYYLIU, YYLIUX]
-YLJUIK = [JVHFTH, QFYLJU, FYLJUI]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -470,143 +19,386 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return NMHXEK
+        return 53
 
     @property
     def output_keys(self):
-        return NQLNMH
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, PICXQI, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoByteStructAccessor(self.struct, ICXQIE, CXQIEF, QBMJVH),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, None, LRAHEO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, CTHBSK, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, None),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, RJHIUS, JRJHIU, None, JHIUSO, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, IUSOOQ, None, OQNRSJ, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, JMCBFE, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, GZUQEX, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, HUOJRJ, JHIUSO, EXLSXU, None, JHIUSO, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, QBMJVH),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, QBMJVH),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, AONPYY, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, YLIUXF, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, UXFEFJ, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            XFEFJT: GeckoEnumStructAccessor(
-                self.struct, XFEFJT, FEFJTA, None, JTACCP, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoTempStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, UXFEFJ, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            NQJYMO: GeckoByteStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoTempStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoTempStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, NBLKXS, None, LKXSJW, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, NZMJIG, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, USPBWJ, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoTimeStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoTimeStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoTimeStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoTimeStructAccessor(self.struct, GQPLSP, QPLSPF, QBMJVH),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, PFTSIF, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, RJHIUS, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SIFJBI: GeckoBoolStructAccessor(
-                self.struct, SIFJBI, IFJBIA, JHIUSO, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            FJBIAM: GeckoBoolStructAccessor(
-                self.struct, FJBIAM, IFJBIA, RJHIUS, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, IFJBIA, BIAMJM, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            IAMJMA: GeckoBoolStructAccessor(
-                self.struct, IAMJMA, IFJBIA, AMJMAO, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, OAWBSI, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, IRYXBQ, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, YLJUIK, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            LJUIKF: GeckoWordStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, HUOJRJ, BIAMJM, FWRKIN, None, JHIUSO, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(
-                self.struct, WRKINE, HUOJRJ, RKINEJ, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, HUOJRJ, JNIBXY, EJNIBX, None, JHIUSO, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoByteStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoByteStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoByteStructAccessor(self.struct, QSNQLN, SNQLNM, QBMJVH),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-54.py
+++ b/src/geckolib/driver/packs/inyj-cfg-54.py
@@ -12,543 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ACQFFT = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-AHEOCT = 39
-AJVDQL = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AOAWBS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-AONPYY = "".join(chr(c) for c in [80, 49])
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-BFEGZU = 57
-BIAMJM = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-BLKXSJ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-BSIRYX = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-BSKSOK = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-BSSUHB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-BVWVUB = 46
-BWJYKL = 51
-BXYBQS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-CCPQIP = 63
-CPQIPO = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-CXQIEF = 36
-DNIBXT = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-DQLAII = 34
-DUBSSU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 30
-EFXQGL = 38
-EGZUQE = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-EJNIBX = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-EKCWAO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-EKVKZI = 76
-EOCTHB = 79
-EXLSXU = "".join(chr(c) for c in [72, 105])
-FEFJTA = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-FEGZUQ = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-FFTTID = 5
-FJBIAM = "".join(chr(c) for c in [70, 51])
-FJTACC = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FTTIDU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-FWRKIN = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-GLRAHE = 15
-GQPLSP = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-GZUQEX = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-HBSKSO = 80
-HBVWVU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-HUOJRJ = 81
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-IACQFF = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-IBXTIA = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IBXYBQ = 10
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IDNIBX = 64
-IDUBSS = 7
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [70, 50])
-IGYOUS = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-IIDNIB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-IKFWRK = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-ILXWAJ = 73
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 33
-IRYXBQ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-IUSOOQ = 32
-IUXFEF = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-JHIUSO = 2
-JIGYOU = 70
-JMAOAW = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-JMCBFE = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JNIBXY = 8
-JTACCP = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-JUIKFW = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-JUTYEK = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-JVDQLA = 75
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 35
-JYKLGQ = "".join(chr(c) for c in [67, 69])
-JYMOUN = 25
-KCWAON = 62
-KFWRKI = 3
-KINEJN = 6
-KLGQPL = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-KPHUOJ = 56
-KQXPIC = 14
-KSOKPH = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-KVKZIL = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-LAIIDN = "".join(chr(c) for c in [50, 52, 104])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 52
-LJUIKF = 105
-LKXSJW = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-LNMHXE = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-LSPFTS = 74
-LSXUJU = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-LXWAJV = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-MAOAWB = 85
-MHXEKV = 1
-MJIGYO = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-MJMAOA = 84
-MJVHFT = 12
-MNZMJI = 66
-MOUNBL = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-NBLKXS = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-NEJNIB = 23
-NIBXTI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-NIBXYB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-NMHXEK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NPYYLI = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-NQJYMO = 31
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-NRSJMC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-NZMJIG = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-OAWBSI = 86
-OCTHBS = "".join(chr(c) for c in [76, 73])
-OJRJHI = "".join(chr(c) for c in [79, 119, 110])
-OKPHUO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OQNRSJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-OUNBLK = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-OUSPBW = 77
-OUYNQJ = "".join(chr(c) for c in [67])
-PBWJYK = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-POUYNQ = "".join(chr(c) for c in [70])
-PQIPOU = 1
-PYYLIU = 28
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 111])
-QFYLJU = 104
-QGLRAH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-QIEFXQ = 37
-QIPOUY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QJYMOU = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-QLAIID = "".join(chr(c) for c in [65, 109, 80, 109])
-QLNMHX = 72
-QPLSPF = 53
-QSNQLN = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-RAHEOC = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-RJHIUS = 0
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-RSJMCB = 27
-RYXBQF = 99
-SAKQXP = 13
-SIFJBI = "".join(chr(c) for c in [70, 49])
-SIRYXB = 98
-SJMCBF = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-SJWMNZ = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-SKSOKP = 54
-SNQLNM = 82
-SOKPHU = 55
-SOOQNR = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-SPBWJY = 26
-SPFTSI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = 44
-SUHBVW = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-SXUJUT = 58
-THBSKS = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 4
-TIDUBS = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-TSIFJB = 83
-TTIDUB = 6
-TYEKCW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UBSSUH = 43
-UBYGDS = 54
-UHBVWV = 45
-UIKFWR = 106
-UJUTYE = 59
-UOJRJH = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UQEXLS = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-USOOQN = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-UTYEKC = 60
-UXFEFJ = 29
-VDQLAI = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-VLASSA = "".join(chr(c) for c in [])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = 78
-WBSIRY = 87
-WJYKLG = "".join(chr(c) for c in [85, 76])
-WMNZMJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-WRKINE = 4
-XBQFYL = 100
-XEKVKZ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XPICXQ = 16
-XQGLRA = 40
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-XSJWMN = 3
-XTIACQ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-XUJUTY = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-XWAJVD = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-XYBQSN = 71
-YBQSNQ = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-YEKCWA = 61
-YLIUXF = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-YLJUIK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-YMOUNB = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-YNQJYM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YOUSPB = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-ZMJIGY = 68
-AIIDNI = [JVHFTH, QLAIID, LAIIDN]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BQSNQL = [JVHFTH, SJMCBF, YBQSNQ]
-BXTIAC = [NIBXTI, IBXTIA]
-CTHBSK = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    OCTHBS,
-]
-FYLJUI = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, JBIAMJ, BIAMJM]
-GYOUSP = [FJTACC, IGYOUS]
-IAMJMA = [SIFJBI, IFJBIA, FJBIAM, VLASSA, VLASSA, VLASSA, JBIAMJ, BIAMJM]
-JRJHIU = [UOJRJH, OJRJHI]
-KXSJWM = [BLKXSJ, LKXSJW]
-KZILXW = [KVKZIL, VKZILX]
-LIUXFE = [YYLIUX, YLIUXF]
-LRAHEO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-MCBFEG = [SJMCBF, JMCBFE]
-ONPYYL = [JVHFTH, AONPYY, PIPIVL]
-PFTSIF = [FJTACC, SPFTSI]
-PICXQI = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QFFTTI = [ACQFFT, CQFFTT]
-QNRSJM = [USOOQN, SOOQNR, OOQNRS, OQNRSJ]
-TACCPQ = [FJTACC, JTACCP]
-UNBLKX = [YMOUNB, MOUNBL, OUNBLK]
-UYNQJY = [POUYNQ, OUYNQJ]
-VUBYGD = []
-VWVUBY = [BMJVHF, SSAKQX, AKQXPI, QXPICX, QGLRAH, HEOCTH]
-WAJVDQ = [VLASSA, LXWAJV, XWAJVD]
-WVUBYG = [OCTHBS]
-XFEFJT = [PIPIVL, AONPYY]
-XLSXUJ = [QEXLSX, EXLSXU]
-YKLGQP = [WJYKLG, JYKLGQ]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -556,184 +19,499 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return UBYGDS
+        return 54
 
     @property
     def output_keys(self):
-        return VWVUBY
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, PICXQI, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoByteStructAccessor(self.struct, ICXQIE, CXQIEF, QBMJVH),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, None, LRAHEO, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, CTHBSK, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, None),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, RJHIUS, JRJHIU, None, JHIUSO, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, IUSOOQ, None, QNRSJM, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, RSJMCB, None, MCBFEG, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, HUOJRJ, JHIUSO, XLSXUJ, None, JHIUSO, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, ONPYYL, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, LIUXFE, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, None, XFEFJT, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, TACCPQ, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoTempStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoEnumStructAccessor(
-                self.struct, QIPOUY, IPOUYN, None, UYNQJY, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, XFEFJT, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, UNBLKX, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, HUOJRJ, XSJWMN, KXSJWM, None, JHIUSO, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoTempStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoTempStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoEnumStructAccessor(
-                self.struct, MJIGYO, JIGYOU, None, GYOUSP, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, YKLGQP, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            KLGQPL: GeckoByteStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoByteStructAccessor(self.struct, GQPLSP, QPLSPF, QBMJVH),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, PFTSIF, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IAMJMA, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, IAMJMA, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            JMAOAW: GeckoEnumStructAccessor(
-                self.struct, JMAOAW, MAOAWB, None, IAMJMA, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, IAMJMA, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, IAMJMA, None, None, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
             ),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, FYLJUI, None, None, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, FYLJUI, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, FYLJUI, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            IKFWRK: GeckoByteStructAccessor(self.struct, IKFWRK, KFWRKI, QBMJVH),
-            FWRKIN: GeckoTimeStructAccessor(self.struct, FWRKIN, WRKINE, QBMJVH),
-            RKINEJ: GeckoTimeStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, BQSNQL, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            QSNQLN: GeckoBoolStructAccessor(
-                self.struct, QSNQLN, SNQLNM, RJHIUS, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            NQLNMH: GeckoBoolStructAccessor(
-                self.struct, NQLNMH, QLNMHX, JHIUSO, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, QLNMHX, RJHIUS, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, QLNMHX, MHXEKV, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, QLNMHX, XSJWMN, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, KZILXW, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, ILXWAJ, None, WAJVDQ, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, None, AIIDNI, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IIDNIB: GeckoWordStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, HUOJRJ, MHXEKV, BXTIAC, None, JHIUSO, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            XTIACQ: GeckoBoolStructAccessor(
-                self.struct, XTIACQ, HUOJRJ, TIACQF, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, HUOJRJ, FFTTID, QFFTTI, None, JHIUSO, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            FTTIDU: GeckoBoolStructAccessor(
-                self.struct, FTTIDU, HUOJRJ, TTIDUB, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            TIDUBS: GeckoBoolStructAccessor(
-                self.struct, TIDUBS, HUOJRJ, IDUBSS, QBMJVH
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-55.py
+++ b/src/geckolib/driver/packs/inyj-cfg-55.py
@@ -12,551 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-ACQFFT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-AHEOCT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-AIIDNI = 34
-AJVDQL = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-AKQXPI = 13
-AMJMAO = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-AOAWBS = 84
-AONPYY = 62
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-AWBSIR = 85
-BFEGZU = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-BIAMJM = "".join(chr(c) for c in [70, 50])
-BLKXSJ = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 99
-BQSNQL = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-BSIRYX = 86
-BSKSOK = 80
-BSSUHB = 7
-BVWVUB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-BWJYKL = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-BXTIAC = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-BXYBQS = 8
-CBFEGZ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-CCPQIP = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = 4
-CTHBSK = "".join(chr(c) for c in [76, 73])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 61
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-DQLAII = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-DUBSSU = 6
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 29
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-EGZUQE = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-EJNIBX = 6
-EKCWAO = 60
-EKVKZI = 1
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-FEFJTA = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-FFTTID = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-FJBIAM = 83
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 74
-FTTIDU = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-FWRKIN = 106
-FXQGLR = 38
-FYLJUI = 100
-GDSBDJ = 55
-GLRAHE = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-GYOUSP = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-GZUQEX = 57
-HBSKSO = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-HBVWVU = 44
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-HXEKVK = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 51])
-IBXTIA = 64
-IBXYBQ = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-IDNIBX = "".join(chr(c) for c in [50, 52, 104])
-IDUBSS = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-IEFXQG = 37
-IFJBIA = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-IGYOUS = 68
-IIDNIB = "".join(chr(c) for c in [65, 109, 80, 109])
-IKFWRK = 105
-ILXWAJ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-INEJNI = 4
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-IRYXBQ = 87
-IUSOOQ = 0
-IUXFEF = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [70, 49])
-JHIUSO = "".join(chr(c) for c in [79, 119, 110])
-JIGYOU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JMCBFE = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-JNIBXY = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-JRJHIU = 81
-JTACCP = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-JUTYEK = 58
-JVDQLA = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JYKLGQ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-JYMOUN = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-KFWRKI = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-KINEJN = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KLGQPL = "".join(chr(c) for c in [85, 76])
-KPHUOJ = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 51])
-KSOKPH = 54
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KXSJWM = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-KZILXW = 76
-LAIIDN = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [67, 69])
-LIUXFE = 28
-LJUIKF = 104
-LNMHXE = 82
-LRAHEO = 15
-LSPFTS = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-LSXUJU = "".join(chr(c) for c in [76, 111])
-MAOAWB = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-MCBFEG = 27
-MHXEKV = 72
-MJIGYO = 66
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-MJVHFT = 12
-MNZMJI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-MOUNBL = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-NBLKXS = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-NEJNIB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-NIBXTI = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-NIBXYB = 23
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-NPYYLI = 78
-NQJYMO = "".join(chr(c) for c in [67])
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-NZMJIG = 35
-OAWBSI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-OCTHBS = 79
-OJRJHI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-OKPHUO = 22
-ONPYYL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-OOQNRS = 32
-OQNRSJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-OUNBLK = 25
-OUSPBW = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-OUYNQJ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-PBWJYK = 77
-PFTSIF = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-PHUOJR = 55
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 52
-POUYNQ = 1
-PQIPOU = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-PYYLIU = "".join(chr(c) for c in [80, 49])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-QFFTTI = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-QFYLJU = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-QGLRAH = 40
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QIPOUY = 63
-QLAIID = 75
-QLNMHX = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-QNRSJM = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-QPLSPF = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-QSNQLN = 71
-QXPICX = 14
-RJHIUS = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-RKINEJ = 3
-RSJMCB = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-RYXBQF = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 50])
-SIRYXB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SKSOKP = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-SNQLNM = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SOKPHU = "".join(chr(c) for c in [80, 49, 76, 84, 105, 109, 101, 79, 117, 116])
-SOOQNR = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-SPBWJY = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-SPFTSI = 53
-SSUHBV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-SUHBVW = 43
-SXUJUT = "".join(chr(c) for c in [72, 105])
-TACCPQ = 30
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TIDUBS = 5
-TSIFJB = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TYEKCW = 59
-UBSSUH = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-UHBVWV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-UIKFWR = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-UJUTYE = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-UNBLKX = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-UOJRJH = 56
-UQEXLS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-USOOQN = 2
-UTYEKC = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-UXFEFJ = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-UYNQJY = 33
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = 46
-VWVUBY = 45
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 73
-WAONPY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-WBSIRY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-WJYKLG = 26
-WMNZMJ = 3
-WRKINE = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-WVUBYG = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-XBQFYL = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-XEKVKZ = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XLSXUJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-XQIEFX = 36
-XSJWMN = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-XTIACQ = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-XWAJVD = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-XYBQSN = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YBQSNQ = 10
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YKLGQP = 51
-YLIUXF = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLJUIK = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-YMOUNB = 31
-YNQJYM = "".join(chr(c) for c in [70])
-YOUSPB = 70
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 98
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZUQEXL = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-BYGDSB = [CTHBSK]
-CPQIPO = [ACCPQI, CCPQIP]
-DNIBXT = [JVHFTH, IIDNIB, IDNIBX]
-EXLSXU = [ZUQEXL, UQEXLS, QEXLSX]
-FEGZUQ = [CBFEGZ, BFEGZU]
-FJTACC = [PIPIVL, PYYLIU]
-GQPLSP = [KLGQPL, LGQPLS]
-HIUSOO = [RJHIUS, JHIUSO]
-IACQFF = [XTIACQ, TIACQF]
-ICXQIE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-JMAOAW = [JBIAMJ, BIAMJM, IAMJMA, VLASSA, VLASSA, VLASSA, AMJMAO, MJMAOA]
-JUIKFW = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, AMJMAO, MJMAOA]
-JWMNZM = [XSJWMN, SJWMNZ]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-LXWAJV = [ZILXWA, ILXWAJ]
-NQLNMH = [JVHFTH, CBFEGZ, SNQLNM]
-QJYMOU = [YNQJYM, NQJYMO]
-RAHEOC = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-SIFJBI = [ACCPQI, TSIFJB]
-SJMCBF = [OQNRSJ, QNRSJM, NRSJMC, RSJMCB]
-SSAKQX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-]
-THBSKS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    CTHBSK,
-]
-TTIDUB = [FFTTID, FTTIDU]
-UBYGDS = [BMJVHF, SAKQXP, KQXPIC, XPICXQ, GLRAHE, EOCTHB]
-USPBWJ = [ACCPQI, OUSPBW]
-VDQLAI = [VLASSA, AJVDQL, JVDQLA]
-XFEFJT = [IUXFEF, UXFEFJ]
-XUJUTY = [LSXUJU, SXUJUT]
-YGDSBD = []
-YYLIUX = [JVHFTH, PYYLIU, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -564,185 +19,515 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GDSBDJ
+        return 55
 
     @property
     def output_keys(self):
-        return UBYGDS
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SSAKQX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, SSAKQX, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, SSAKQX, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, ICXQIE, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoByteStructAccessor(self.struct, CXQIEF, XQIEFX, QBMJVH),
-            QIEFXQ: GeckoByteStructAccessor(self.struct, QIEFXQ, IEFXQG, QBMJVH),
-            EFXQGL: GeckoByteStructAccessor(self.struct, EFXQGL, FXQGLR, QBMJVH),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, None, RAHEOC, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, OCTHBS, None, THBSKS, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, None),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoByteStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoByteStructAccessor(self.struct, KPHUOJ, PHUOJR, QBMJVH),
-            HUOJRJ: GeckoByteStructAccessor(self.struct, HUOJRJ, UOJRJH, QBMJVH),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, IUSOOQ, HIUSOO, None, USOOQN, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, SJMCBF, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, FEGZUQ, None, None, QBMJVH
+            "P1LTimeOut": GeckoByteStructAccessor(self.struct, "P1LTimeOut", 22, "ALL"),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, GZUQEX, None, EXLSXU, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, JRJHIU, USOOQN, XUJUTY, None, USOOQN, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, QBMJVH),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, YYLIUX, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, XFEFJT, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            FEFJTA: GeckoEnumStructAccessor(
-                self.struct, FEFJTA, EFJTAC, None, FJTACC, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, CPQIPO, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoTempStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, QJYMOU, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, FJTACC, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, JRJHIU, WMNZMJ, JWMNZM, None, USOOQN, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoTempStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoTempStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, USPBWJ, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoByteStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, SIFJBI, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, JMAOAW, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, AOAWBS, None, JMAOAW, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, JMAOAW, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, BSIRYX, None, JMAOAW, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, JMAOAW, None, None, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
             ),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoByteStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, JUIKFW, None, None, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, JUIKFW, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, JUIKFW, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoTimeStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoTimeStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoTimeStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoTimeStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, NQLNMH, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            QLNMHX: GeckoBoolStructAccessor(
-                self.struct, QLNMHX, LNMHXE, IUSOOQ, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, MHXEKV, USOOQN, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, MHXEKV, IUSOOQ, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, MHXEKV, EKVKZI, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            KVKZIL: GeckoBoolStructAccessor(
-                self.struct, KVKZIL, MHXEKV, WMNZMJ, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, LXWAJV, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, None, VDQLAI, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, None, DNIBXT, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, QBMJVH),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, JRJHIU, EKVKZI, IACQFF, None, USOOQN, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            ACQFFT: GeckoBoolStructAccessor(
-                self.struct, ACQFFT, JRJHIU, CQFFTT, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, JRJHIU, TIDUBS, TTIDUB, None, USOOQN, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IDUBSS: GeckoBoolStructAccessor(
-                self.struct, IDUBSS, JRJHIU, DUBSSU, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, JRJHIU, BSSUHB, QBMJVH
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-56.py
+++ b/src/geckolib/driver/packs/inyj-cfg-56.py
@@ -12,549 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACQFFT = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AHEOCT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [50, 52, 104])
-AKQXPI = 13
-AOAWBS = 85
-AONPYY = 78
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-AWBSIR = 86
-BFEGZU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-BIAMJM = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-BLKXSJ = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 100
-BQSNQL = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-BSIRYX = 87
-BSKSOK = 80
-BSSUHB = 43
-BVWVUB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-BWJYKL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BXTIAC = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-BXYBQS = 10
-BYGDSB = 56
-CCPQIP = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-CPQIPO = 63
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-CTHBSK = "".join(chr(c) for c in [76, 73])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 62
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-DNIBXT = 64
-DQLAII = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-DUBSSU = 7
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-EGZUQE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-EJNIBX = 23
-EKCWAO = 61
-EKVKZI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-EXLSXU = "".join(chr(c) for c in [76, 111])
-FEGZUQ = 57
-FJBIAM = "".join(chr(c) for c in [70, 50])
-FJTACC = 30
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTTIDU = 5
-FWRKIN = 3
-FXQGLR = 38
-FYLJUI = 104
-GLRAHE = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-GQPLSP = 52
-GYOUSP = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-GZUQEX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-HBSKSO = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-HBVWVU = 45
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 2
-HUOJRJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-HXEKVK = 1
-IACQFF = 4
-IAMJMA = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-IBXTIA = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-IBXYBQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-IDNIBX = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-IDUBSS = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-IEFXQG = 37
-IFJBIA = "".join(chr(c) for c in [70, 49])
-IGYOUS = 70
-IKFWRK = 106
-ILXWAJ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-INEJNI = 6
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-IRYXBQ = 98
-IUSOOQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [70, 51])
-JHIUSO = 0
-JIGYOU = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-JMAOAW = 84
-JMCBFE = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-JNIBXY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-JRJHIU = "".join(chr(c) for c in [79, 119, 110])
-JTACCP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-JUIKFW = 105
-JUTYEK = 59
-JVDQLA = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-JYKLGQ = "".join(chr(c) for c in [85, 76])
-JYMOUN = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-KCWAON = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KFWRKI = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-KINEJN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-KPHUOJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 51])
-KSOKPH = 54
-KVKZIL = 76
-KXSJWM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-KZILXW = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LAIIDN = "".join(chr(c) for c in [65, 109, 80, 109])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LIUXFE = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-LJUIKF = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-LKXSJW = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-LNMHXE = 72
-LRAHEO = 15
-LSPFTS = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-LXWAJV = 73
-MAOAWB = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-MCBFEG = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-MHXEKV = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-MJIGYO = 68
-MJMAOA = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-MJVHFT = 12
-MNZMJI = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MOUNBL = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NIBXTI = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NIBXYB = 8
-NMHXEK = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NQLNMH = 82
-NZMJIG = 66
-OAWBSI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-OCTHBS = 79
-OJRJHI = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OKPHUO = 55
-ONPYYL = "".join(chr(c) for c in [80, 49])
-OOQNRS = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-OQNRSJ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OUNBLK = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-OUSPBW = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-OUYNQJ = "".join(chr(c) for c in [70])
-PBWJYK = 26
-PFTSIF = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-PHUOJR = 56
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 53
-POUYNQ = 33
-PQIPOU = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PYYLIU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-QFFTTI = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-QFYLJU = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-QGLRAH = 40
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QIPOUY = 1
-QJYMOU = 31
-QLAIID = 34
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-QNRSJM = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-QPLSPF = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-QXPICX = 14
-RKINEJ = 4
-RSJMCB = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-RYXBQF = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 50])
-SIFJBI = 83
-SIRYXB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-SJMCBF = 27
-SJWMNZ = 3
-SKSOKP = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-SNQLNM = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-SOKPHU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SOOQNR = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-SPBWJY = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-SPFTSI = 74
-SSUHBV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-SUHBVW = 44
-SXUJUT = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-TACCPQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-TIDUBS = 6
-TSIFJB = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-TTIDUB = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-TYEKCW = 60
-UBSSUH = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-UHBVWV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-UIKFWR = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-UJUTYE = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-UNBLKX = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-UOJRJH = 81
-USOOQN = 32
-USPBWJ = 77
-UTYEKC = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UXFEFJ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-UYNQJY = "".join(chr(c) for c in [67])
-VDQLAI = 75
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-VLASSA = "".join(chr(c) for c in [])
-VWVUBY = 46
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-WAONPY = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-WBSIRY = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-WJYKLG = 51
-WMNZMJ = 35
-WRKINE = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-XBQFYL = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-XFEFJT = 29
-XLSXUJ = "".join(chr(c) for c in [72, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-XQIEFX = 36
-XUJUTY = 58
-XWAJVD = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YBQSNQ = 71
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YKLGQP = "".join(chr(c) for c in [67, 69])
-YLIUXF = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-YMOUNB = 25
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 99
-YYLIUX = 28
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZUQEXL = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-ACCPQI = [JTACCP, TACCPQ]
-AJVDQL = [VLASSA, XWAJVD, WAJVDQ]
-AMJMAO = [IFJBIA, FJBIAM, JBIAMJ, VLASSA, VLASSA, VLASSA, BIAMJM, IAMJMA]
-CBFEGZ = [JMCBFE, MCBFEG]
-FEFJTA = [PIPIVL, ONPYYL]
-FFTTID = [CQFFTT, QFFTTI]
-FTSIFJ = [JTACCP, PFTSIF]
-ICXQIE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-IIDNIB = [JVHFTH, LAIIDN, AIIDNI]
-IUXFEF = [YLIUXF, LIUXFE]
-KLGQPL = [JYKLGQ, YKLGQP]
-LSXUJU = [EXLSXU, XLSXUJ]
-NBLKXS = [MOUNBL, OUNBLK, UNBLKX]
-NPYYLI = [JVHFTH, ONPYYL, PIPIVL]
-NRSJMC = [SOOQNR, OOQNRS, OQNRSJ, QNRSJM]
-QSNQLN = [JVHFTH, JMCBFE, BQSNQL]
-RAHEOC = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-RJHIUS = [OJRJHI, JRJHIU]
-SSAKQX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-]
-THBSKS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    CTHBSK,
-]
-UBYGDS = []
-UQEXLS = [EGZUQE, GZUQEX, ZUQEXL]
-VUBYGD = [CTHBSK]
-WVUBYG = [BMJVHF, SAKQXP, KQXPIC, XPICXQ, GLRAHE, EOCTHB]
-XSJWMN = [LKXSJW, KXSJWM]
-XTIACQ = [IBXTIA, BXTIAC]
-YLJUIK = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, BIAMJM, IAMJMA]
-YNQJYM = [OUYNQJ, UYNQJY]
-YOUSPB = [JTACCP, GYOUSP]
-ZILXWA = [VKZILX, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -562,184 +19,514 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return BYGDSB
+        return 56
 
     @property
     def output_keys(self):
-        return WVUBYG
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SSAKQX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, SSAKQX, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, SSAKQX, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, ICXQIE, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoByteStructAccessor(self.struct, CXQIEF, XQIEFX, QBMJVH),
-            QIEFXQ: GeckoByteStructAccessor(self.struct, QIEFXQ, IEFXQG, QBMJVH),
-            EFXQGL: GeckoByteStructAccessor(self.struct, EFXQGL, FXQGLR, QBMJVH),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, None, RAHEOC, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, OCTHBS, None, THBSKS, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, None),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoByteStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoByteStructAccessor(self.struct, KPHUOJ, PHUOJR, QBMJVH),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, JHIUSO, RJHIUS, None, HIUSOO, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, NRSJMC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, CBFEGZ, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, UQEXLS, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, UOJRJH, HIUSOO, LSXUJU, None, HIUSOO, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, QBMJVH),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, NPYYLI, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, YYLIUX, None, IUXFEF, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, FEFJTA, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, ACCPQI, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoTempStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, POUYNQ, None, YNQJYM, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, QJYMOU, None, FEFJTA, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, NBLKXS, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, UOJRJH, SJWMNZ, XSJWMN, None, HIUSOO, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoTempStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoTempStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, YOUSPB, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, KLGQPL, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, FTSIFJ, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            TSIFJB: GeckoEnumStructAccessor(
-                self.struct, TSIFJB, SIFJBI, None, AMJMAO, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, AMJMAO, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, AOAWBS, None, AMJMAO, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, AMJMAO, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, BSIRYX, None, AMJMAO, None, None, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, None, YLJUIK, None, None, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, YLJUIK, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, YLJUIK, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoTimeStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoTimeStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoTimeStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoTimeStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, QSNQLN, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            SNQLNM: GeckoBoolStructAccessor(
-                self.struct, SNQLNM, NQLNMH, JHIUSO, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            QLNMHX: GeckoBoolStructAccessor(
-                self.struct, QLNMHX, LNMHXE, HIUSOO, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, LNMHXE, JHIUSO, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, LNMHXE, HXEKVK, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, LNMHXE, SJWMNZ, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, ZILXWA, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, IIDNIB, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IDNIBX: GeckoWordStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, UOJRJH, HXEKVK, XTIACQ, None, HIUSOO, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            TIACQF: GeckoBoolStructAccessor(
-                self.struct, TIACQF, UOJRJH, IACQFF, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, UOJRJH, FTTIDU, FFTTID, None, HIUSOO, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            TTIDUB: GeckoBoolStructAccessor(
-                self.struct, TTIDUB, UOJRJH, TIDUBS, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IDUBSS: GeckoBoolStructAccessor(
-                self.struct, IDUBSS, UOJRJH, DUBSSU, QBMJVH
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 43, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-57.py
+++ b/src/geckolib/driver/packs/inyj-cfg-57.py
@@ -12,594 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACQFFT = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AHEOCT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [50, 52, 104])
-AKQXPI = 13
-AOAWBS = 85
-AONPYY = 78
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-AWBSIR = 86
-BFEGZU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-BIAMJM = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-BLKXSJ = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 100
-BQSNQL = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-BSIRYX = 87
-BSKSOK = 80
-BSSUHB = 43
-BVWVUB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-BWJYKL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BXTIAC = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-BXYBQS = 10
-CCPQIP = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-CPQIPO = 63
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-CTHBSK = "".join(chr(c) for c in [76, 73])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 62
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-DNIBXT = 64
-DQLAII = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-DUBSSU = 7
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-EGZUQE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-EJNIBX = 23
-EKCWAO = 61
-EKVKZI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-EXLSXU = "".join(chr(c) for c in [76, 111])
-FEGZUQ = 57
-FJBIAM = "".join(chr(c) for c in [70, 50])
-FJTACC = 30
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTTIDU = 5
-FWRKIN = 3
-FXQGLR = 38
-FYLJUI = 104
-GDSBDJ = 57
-GLRAHE = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-GQPLSP = 52
-GYOUSP = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-GZUQEX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-HBSKSO = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-HBVWVU = 45
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 39
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 2
-HUOJRJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-HXEKVK = 1
-IACQFF = 4
-IAMJMA = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-IBXTIA = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-IBXYBQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-IDNIBX = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-IDUBSS = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-IEFXQG = 37
-IFJBIA = "".join(chr(c) for c in [70, 49])
-IGYOUS = 70
-IKFWRK = 106
-ILXWAJ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-INEJNI = 6
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-IRYXBQ = 98
-IUSOOQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(chr(c) for c in [70, 51])
-JHIUSO = 0
-JIGYOU = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-JMAOAW = 84
-JMCBFE = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-JNIBXY = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-JRJHIU = "".join(chr(c) for c in [79, 119, 110])
-JTACCP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-JUIKFW = 105
-JUTYEK = 59
-JVDQLA = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-JYKLGQ = "".join(chr(c) for c in [85, 76])
-JYMOUN = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-KCWAON = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KFWRKI = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-KINEJN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-KPHUOJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 51])
-KSOKPH = 54
-KVKZIL = 76
-KXSJWM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-KZILXW = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LAIIDN = "".join(chr(c) for c in [65, 109, 80, 109])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LIUXFE = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-LJUIKF = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-LKXSJW = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-LNMHXE = 72
-LRAHEO = 15
-LSPFTS = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-LXWAJV = 73
-MAOAWB = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-MCBFEG = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-MHXEKV = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-MJIGYO = 68
-MJMAOA = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-MJVHFT = 12
-MNZMJI = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MOUNBL = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NIBXTI = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NIBXYB = 8
-NMHXEK = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NQLNMH = 82
-NZMJIG = 66
-OAWBSI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-OCTHBS = 79
-OJRJHI = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OKPHUO = 55
-ONPYYL = "".join(chr(c) for c in [80, 49])
-OOQNRS = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-OQNRSJ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-OUNBLK = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-OUSPBW = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-OUYNQJ = "".join(chr(c) for c in [70])
-PBWJYK = 26
-PFTSIF = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-PHUOJR = 56
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 53
-POUYNQ = 33
-PQIPOU = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PYYLIU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-QFFTTI = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-QFYLJU = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-QGLRAH = 40
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-QIPOUY = 1
-QJYMOU = 31
-QLAIID = 34
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-QNRSJM = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-QPLSPF = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-QXPICX = 14
-RKINEJ = 4
-RSJMCB = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-RYXBQF = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 50])
-SIFJBI = 83
-SIRYXB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-SJMCBF = 27
-SJWMNZ = 3
-SKSOKP = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-SNQLNM = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-SOKPHU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SOOQNR = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-SPBWJY = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-SPFTSI = 74
-SSUHBV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-SUHBVW = 44
-SXUJUT = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-TACCPQ = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-TIDUBS = 6
-TSIFJB = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-TTIDUB = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-TYEKCW = 60
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UHBVWV = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-UIKFWR = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-UJUTYE = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-UNBLKX = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-UOJRJH = 81
-USOOQN = 32
-USPBWJ = 77
-UTYEKC = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UXFEFJ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-UYNQJY = "".join(chr(c) for c in [67])
-VDQLAI = 75
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = 47
-VWVUBY = 46
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-WAONPY = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-WBSIRY = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-WJYKLG = 51
-WMNZMJ = 35
-WRKINE = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XBQFYL = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-XFEFJT = 29
-XLSXUJ = "".join(chr(c) for c in [72, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-XQIEFX = 36
-XUJUTY = 58
-XWAJVD = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YBQSNQ = 71
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YKLGQP = "".join(chr(c) for c in [67, 69])
-YLIUXF = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-YMOUNB = 25
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = 99
-YYLIUX = 28
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZMJIGY = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZUQEXL = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-ACCPQI = [JTACCP, TACCPQ]
-AJVDQL = [VLASSA, XWAJVD, WAJVDQ]
-AMJMAO = [IFJBIA, FJBIAM, JBIAMJ, VLASSA, VLASSA, VLASSA, BIAMJM, IAMJMA]
-BYGDSB = [CTHBSK]
-CBFEGZ = [JMCBFE, MCBFEG]
-FEFJTA = [PIPIVL, ONPYYL]
-FFTTID = [CQFFTT, QFFTTI]
-FTSIFJ = [JTACCP, PFTSIF]
-ICXQIE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-IIDNIB = [JVHFTH, LAIIDN, AIIDNI]
-IUXFEF = [YLIUXF, LIUXFE]
-KLGQPL = [JYKLGQ, YKLGQP]
-LSXUJU = [EXLSXU, XLSXUJ]
-NBLKXS = [MOUNBL, OUNBLK, UNBLKX]
-NPYYLI = [JVHFTH, ONPYYL, PIPIVL]
-NRSJMC = [SOOQNR, OOQNRS, OQNRSJ, QNRSJM]
-QSNQLN = [JVHFTH, JMCBFE, BQSNQL]
-RAHEOC = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-RJHIUS = [OJRJHI, JRJHIU]
-SSAKQX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-]
-THBSKS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    CTHBSK,
-]
-UBYGDS = [BMJVHF, SAKQXP, KQXPIC, XPICXQ, GLRAHE, EOCTHB]
-UQEXLS = [EGZUQE, GZUQEX, ZUQEXL]
-XSJWMN = [LKXSJW, KXSJWM]
-XTIACQ = [IBXTIA, BXTIAC]
-YGDSBD = []
-YLJUIK = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, BIAMJM, IAMJMA]
-YNQJYM = [OUYNQJ, UYNQJY]
-YOUSPB = [JTACCP, GYOUSP]
-ZILXWA = [VKZILX, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -607,189 +19,517 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GDSBDJ
+        return 57
 
     @property
     def output_keys(self):
-        return UBYGDS
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SSAKQX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, SSAKQX, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, SSAKQX, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, ICXQIE, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            CXQIEF: GeckoByteStructAccessor(self.struct, CXQIEF, XQIEFX, QBMJVH),
-            QIEFXQ: GeckoByteStructAccessor(self.struct, QIEFXQ, IEFXQG, QBMJVH),
-            EFXQGL: GeckoByteStructAccessor(self.struct, EFXQGL, FXQGLR, QBMJVH),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, LRAHEO, None, RAHEOC, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, OCTHBS, None, THBSKS, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, None),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoByteStructAccessor(self.struct, SOKPHU, OKPHUO, QBMJVH),
-            KPHUOJ: GeckoByteStructAccessor(self.struct, KPHUOJ, PHUOJR, QBMJVH),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, JHIUSO, RJHIUS, None, HIUSOO, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, NRSJMC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, SJMCBF, None, CBFEGZ, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, FEGZUQ, None, UQEXLS, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, UOJRJH, HIUSOO, LSXUJU, None, HIUSOO, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, QBMJVH),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, NPYYLI, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, YYLIUX, None, IUXFEF, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, FEFJTA, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, ACCPQI, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoTempStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, POUYNQ, None, YNQJYM, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, QJYMOU, None, FEFJTA, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            JYMOUN: GeckoEnumStructAccessor(
-                self.struct, JYMOUN, YMOUNB, None, NBLKXS, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, UOJRJH, SJWMNZ, XSJWMN, None, HIUSOO, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoTempStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoTempStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, YOUSPB, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, KLGQPL, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, FTSIFJ, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            TSIFJB: GeckoEnumStructAccessor(
-                self.struct, TSIFJB, SIFJBI, None, AMJMAO, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, AMJMAO, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, AOAWBS, None, AMJMAO, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, AMJMAO, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, BSIRYX, None, AMJMAO, None, None, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, None, YLJUIK, None, None, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, YLJUIK, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, YLJUIK, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoTimeStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoTimeStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoTimeStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoTimeStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, QSNQLN, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            SNQLNM: GeckoBoolStructAccessor(
-                self.struct, SNQLNM, NQLNMH, JHIUSO, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            QLNMHX: GeckoBoolStructAccessor(
-                self.struct, QLNMHX, LNMHXE, HIUSOO, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, LNMHXE, JHIUSO, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, LNMHXE, HXEKVK, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, LNMHXE, SJWMNZ, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, ZILXWA, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, IIDNIB, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IDNIBX: GeckoWordStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, UOJRJH, HXEKVK, XTIACQ, None, HIUSOO, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            TIACQF: GeckoBoolStructAccessor(
-                self.struct, TIACQF, UOJRJH, IACQFF, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, UOJRJH, FTTIDU, FFTTID, None, HIUSOO, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            TTIDUB: GeckoBoolStructAccessor(
-                self.struct, TTIDUB, UOJRJH, TIDUBS, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IDUBSS: GeckoBoolStructAccessor(
-                self.struct, IDUBSS, UOJRJH, DUBSSU, QBMJVH
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, BSSUHB, JHIUSO, QBMJVH
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoBoolStructAccessor(
-                self.struct, WVUBYG, VUBYGD, JHIUSO, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 44, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 45, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-58.py
+++ b/src/geckolib/driver/packs/inyj-cfg-58.py
@@ -12,805 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 30
-AIIDNI = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-AJVDQL = 73
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AMJMAO = "".join(chr(c) for c in [70, 51])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AONPYY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BDJQRJ = "".join(chr(c) for c in [66, 76, 85, 69])
-BFEGZU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-BIAMJM = "".join(chr(c) for c in [70, 49])
-BJEUTO = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-BLKXSJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-BQNRXC = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-BQSNQL = 10
-BSIRYX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-BSKSOK = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BSSUHB = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-BVWVUB = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-BWJYKL = 77
-BXTIAC = 64
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-CBFEGZ = 27
-CCPQIP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-CPQIPO = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-CRTFMN = 44
-CTHBSK = 79
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-DJQRJJ = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-DNIBXT = "".join(chr(c) for c in [50, 52, 104])
-DNQGVU = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DSBDJQ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-DUBSSU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-EFXQGL = 37
-EJNIBX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-EKCWAO = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-EKVKZI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-EOCTHB = 39
-EUTOPH = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-EXLSXU = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FCRTFM = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-FEGZUQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FFTTID = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FJBIAM = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FJTACC = 29
-FMNHTB = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-FTTIDU = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-FWRKIN = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-GDSBDJ = "".join(chr(c) for c in [82, 69, 68])
-GLRAHE = 40
-GQPLSP = "".join(chr(c) for c in [67, 69])
-GSELHB = 45
-GTYIYW = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-GVUNXN = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-GYOUSP = 68
-GZUQEX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-HBVWVU = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HTBJEU = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-HUGTYI = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-HUOJRJ = 56
-HXEKVK = 72
-IACQFF = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 50])
-IBXTIA = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-IBXYBQ = 23
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [65, 109, 80, 109])
-IDUBSS = 5
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IIDNIB = 34
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-ILXWAJ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 63
-IRYXBQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IUSOOQ = 2
-IUXFEF = 28
-IVDNQG = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(chr(c) for c in [76, 65])
-JBIAMJ = 83
-JEUTOP = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-JIGYOU = 66
-JJJVYF = 8
-JJVYFC = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-JNIBXY = 6
-JQRJJJ = "".join(chr(c) for c in [67, 89, 65, 78])
-JRJHIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JUIKFW = 104
-JUTYEK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JWMNZM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JYKLGQ = 26
-KCWAON = 60
-KFWRKI = 105
-KINEJN = 3
-KLGQPL = 51
-KMLOIJ = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-KPHUOJ = 55
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KVKZIL = 1
-KWIVDN = "".join(chr(c) for c in [80, 68, 67])
-KZILXW = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-LAIIDN = 75
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [85, 76])
-LHBQNR = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-LIUXFE = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LJUIKF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-LKXSJW = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-LNMHXE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-LOIJUG = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-LRAHEO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-LSPFTS = 52
-LSXUJU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LXWAJV = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-MCBFEG = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-MNHTBJ = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-MNZMJI = 3
-MOUNBL = 31
-NBLKXS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = 4
-NHTBJE = "".join(chr(c) for c in [65, 108, 112, 115])
-NIBXYB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NKMLOI = "".join(chr(c) for c in [73, 100, 111, 108])
-NMHXEK = 82
-NPYYLI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NQGVUN = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-NQJYMO = "".join(chr(c) for c in [70])
-NQLNMH = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-NRXCHW = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-NXNKML = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-NZMJIG = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OAWBSI = 84
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OIJUGS = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-OJRJHI = 81
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 62
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-OPHUGT = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-OQNRSJ = 32
-OUNBLK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-OUSPBW = 70
-OUYNQJ = 1
-PBWJYK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-PFTSIF = 53
-PHUGTY = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-POUYNQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PYYLIU = 78
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QFFTTI = 4
-QFYLJU = 99
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-QGVUNX = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-QIEFXQ = 36
-QIPOUY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QJYMOU = "".join(chr(c) for c in [67])
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-QNRSJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QNRXCH = 46
-QRJJJV = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 15
-RJHIUS = "".join(chr(c) for c in [79, 119, 110])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-RSJMCB = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-RTFMNH = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-RXCHWD = 47
-RYXBQF = 87
-SBDJQR = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-SELHBQ = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-SIFJBI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SIRYXB = 86
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SKSOKP = 80
-SKWIVD = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-SNQLNM = 71
-SOKPHU = 54
-SOOQNR = 48
-SPFTSI = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = 7
-SUHBVW = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-SXUJUT = "".join(chr(c) for c in [76, 111])
-TACCPQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-TBJEUT = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-TFMNHT = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-THBSKS = "".join(chr(c) for c in [76, 73])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TOPHUG = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-TSIFJB = 74
-TTIDUB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-TYEKCW = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TYIYWS = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-UBSSUH = 6
-UBYGDS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-UGSELH = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-UGTYIY = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-UHBVWV = 43
-UNBLKX = 25
-UNXNKM = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-UOJRJH = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-UQEXLS = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-USOOQN = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-USPBWJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UTOPHU = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-UTYEKC = 58
-UXFEFJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UYNQJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-VDNQGV = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-VDQLAI = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUNXNK = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-VWVUBY = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-VYFCRT = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-WAONPY = 61
-WBSIRY = 85
-WDAFIK = 58
-WIVDNQ = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-WRKINE = 106
-WSKWIV = "".join(chr(c) for c in [77, 65, 65, 88])
-WVUBYG = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-XBQFYL = 98
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XFEFJT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XNKMLO = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-XPICXQ = 14
-XQGLRA = 38
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XSJWMN = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XUJUTY = "".join(chr(c) for c in [72, 105])
-XYBQSN = 8
-YBQSNQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YEKCWA = 59
-YGDSBD = "".join(chr(c) for c in [79, 70, 70])
-YIYWSK = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-YKLGQP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-YLJUIK = 100
-YMOUNB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YNQJYM = 33
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-YXBQFY = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 76
-ZMJIGY = 35
-ZUQEXL = 57
-ACQFFT = [TIACQF, IACQFF]
-AHEOCT = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-CHWDAF = [THBSKS]
-CXQIEF = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-DQLAII = [VLASSA, JVDQLA, VDQLAI]
-EGZUQE = [BFEGZU, FEGZUQ]
-FEFJTA = [UXFEFJ, XFEFJT]
-HBQNRX = [ELHBQN, LHBQNR, VLASSA, VLASSA]
-HBSKSO = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    THBSKS,
-]
-HWDAFI = []
-IFJBIA = [CCPQIP, SIFJBI]
-JHIUSO = [JRJHIU, RJHIUS]
-JMCBFE = [QNRSJM, NRSJMC, RSJMCB, SJMCBF]
-JTACCP = [PIPIVL, YYLIUX]
-JUGSEL = [
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-]
-JYMOUN = [NQJYMO, QJYMOU]
-KXSJWM = [NBLKXS, BLKXSJ, LKXSJW]
-MAOAWB = [BIAMJM, IAMJMA, AMJMAO, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-NIBXTI = [JVHFTH, IDNIBX, DNIBXT]
-PQIPOU = [CCPQIP, CPQIPO]
-QLNMHX = [JVHFTH, BFEGZU, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-RJJJVY = [YGDSBD, GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ, DJQRJJ, JQRJJJ, QRJJJV]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-SPBWJY = [CCPQIP, USPBWJ]
-TIDUBS = [FTTIDU, TTIDUB]
-UIKFWR = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-UJUTYE = [SXUJUT, XUJUTY]
-VUBYGD = [VWVUBY, WVUBYG]
-WMNZMJ = [SJWMNZ, JWMNZM]
-XCHWDA = [BMJVHF, AKQXPI, QXPICX, PICXQI, LRAHEO, OCTHBS]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-XWAJVD = [ILXWAJ, LXWAJV]
-YFCRTF = [JVYFCR, VYFCRT]
-YLIUXF = [JVHFTH, YYLIUX, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -818,209 +19,577 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return WDAFIK
+        return 58
 
     @property
     def output_keys(self):
-        return XCHWDA
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, CXQIEF, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, RAHEOC, None, AHEOCT, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, HBSKSO, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, None),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, HIUSOO, JHIUSO, None, IUSOOQ, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, JMCBFE, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, EGZUQE, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, OJRJHI, IUSOOQ, UJUTYE, None, IUSOOQ, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YLIUXF, None, None, QBMJVH
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FEFJTA, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, JTACCP, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, PQIPOU, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoTempStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JTACCP, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, KXSJWM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, OJRJHI, MNZMJI, WMNZMJ, None, IUSOOQ, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, SPBWJY, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IFJBIA, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MAOAWB, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, MAOAWB, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, MAOAWB, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, None, MAOAWB, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, MAOAWB, None, None, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
             ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoByteStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, UIKFWR, None, None, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, UIKFWR, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, UIKFWR, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTimeStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoTimeStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, QLNMHX, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, NMHXEK, HIUSOO, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, HXEKVK, IUSOOQ, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, HXEKVK, HIUSOO, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, HXEKVK, KVKZIL, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, HXEKVK, MNZMJI, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, XWAJVD, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, DQLAII, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            QLAIID: GeckoByteStructAccessor(self.struct, QLAIID, LAIIDN, QBMJVH),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, IIDNIB, None, NIBXTI, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXTIA: GeckoWordStructAccessor(self.struct, IBXTIA, BXTIAC, QBMJVH),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, OJRJHI, KVKZIL, ACQFFT, None, IUSOOQ, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            CQFFTT: GeckoBoolStructAccessor(
-                self.struct, CQFFTT, OJRJHI, QFFTTI, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            FFTTID: GeckoEnumStructAccessor(
-                self.struct, FFTTID, OJRJHI, IDUBSS, TIDUBS, None, IUSOOQ, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            DUBSSU: GeckoBoolStructAccessor(
-                self.struct, DUBSSU, OJRJHI, UBSSUH, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            BSSUHB: GeckoBoolStructAccessor(
-                self.struct, BSSUHB, OJRJHI, SSUHBV, QBMJVH
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, UHBVWV, HIUSOO, QBMJVH
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            HBVWVU: GeckoBoolStructAccessor(
-                self.struct, HBVWVU, UHBVWV, KVKZIL, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
             ),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, UHBVWV, IUSOOQ, VUBYGD, None, IUSOOQ, QBMJVH
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, UHBVWV, MNZMJI, VUBYGD, None, IUSOOQ, QBMJVH
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, UHBVWV, QFFTTI, RJJJVY, None, JJJVYF, QBMJVH
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
             ),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, UHBVWV, SSUHBV, YFCRTF, None, IUSOOQ, QBMJVH
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
             ),
-            UGSELH: GeckoBoolStructAccessor(
-                self.struct, UGSELH, GSELHB, HIUSOO, QBMJVH
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
             ),
-            SELHBQ: GeckoEnumStructAccessor(
-                self.struct, SELHBQ, GSELHB, IUSOOQ, HBQNRX, None, QFFTTI, QBMJVH
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
             ),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, QBMJVH),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, RXCHWD, HIUSOO, QBMJVH
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-60.py
+++ b/src/geckolib/driver/packs/inyj-cfg-60.py
@@ -12,939 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 30
-ACQFFT = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-AFIKJP = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-AIIDNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-AMJMAO = "".join(chr(c) for c in [70, 51])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AONPYY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-ATDZXN = 125
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BDJQRJ = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-BFEGZU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-BIAMJM = "".join(chr(c) for c in [70, 49])
-BJEUTO = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-BLKXSJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-BQNRXC = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-BQSNQL = 10
-BSIRYX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-BSKSOK = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BSSUHB = 6
-BVWVUB = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-BWJYKL = 77
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BYGDSB = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-CBFEGZ = 27
-CCPQIP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-CHWDAF = 47
-CPQIPO = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-CRTFMN = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-CTHBSK = 79
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-DAFIKJ = 121
-DJQRJJ = "".join(chr(c) for c in [66, 76, 85, 69])
-DNIBXT = 34
-DNQGVU = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-DQLAII = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DSBDJQ = "".join(chr(c) for c in [82, 69, 68])
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-EAKSTS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-EFXQGL = 37
-EJNIBX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-EKCWAO = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-EKVKZI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-EMCGET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-EOCTHB = 39
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-EUTOPH = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-EXLSXU = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FEGZUQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FFTTID = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-FIKJPU = 123
-FJBIAM = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FJTACC = 29
-FMNHTB = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-FTTIDU = 4
-FWRKIN = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-FZDGKE = "".join(chr(c) for c in [51])
-GDSBDJ = "".join(chr(c) for c in [79, 70, 70])
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-GKEAKS = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-GLRAHE = 40
-GQPLSP = "".join(chr(c) for c in [67, 69])
-GSELHB = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GTYIYW = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-GVUNXN = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-GYOUSP = 68
-GZUQEX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-HBQNRX = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HBVWVU = 43
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HTBJEU = "".join(chr(c) for c in [65, 108, 112, 115])
-HUGTYI = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-HUOJRJ = 56
-HWDAFI = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-HXEKVK = 72
-IACQFF = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-IAMJMA = "".join(chr(c) for c in [70, 50])
-IBXTIA = "".join(chr(c) for c in [50, 52, 104])
-IBXYBQ = 23
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-IDUBSS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IHBXIB = 60
-IIDNIB = 75
-IJUGSE = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-IKJPUN = "".join(chr(c) for c in [82, 71, 66])
-ILXWAJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 63
-IRYXBQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IUSOOQ = 2
-IUXFEF = 28
-IVDNQG = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-IYWSKW = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-JBIAMJ = 83
-JEUTOP = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-JIGYOU = 66
-JJVYFC = 8
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-JNIBXY = 6
-JPUNRJ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-JQRJJJ = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-JRJHIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JUGSEL = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-JUIKFW = 104
-JUTYEK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-JWMNZM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JYKLGQ = 26
-JZTATD = 124
-KCWAON = 60
-KEAKST = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-KFWRKI = 105
-KINEJN = 3
-KLGQPL = 51
-KMLOIJ = "".join(chr(c) for c in [73, 100, 111, 108])
-KPHUOJ = 55
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KSTSEM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-KVKZIL = 1
-KWIVDN = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [85, 76])
-LHBQNR = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-LIUXFE = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LJUIKF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-LKXSJW = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-LNMHXE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-LOIJUG = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-LRAHEO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-LSPFTS = 52
-LSXUJU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LXWAJV = 76
-MCBFEG = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-MFZDGK = "".join(chr(c) for c in [50])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MNHTBJ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-MNZMJI = 3
-MOUNBL = 31
-NBLKXS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = 4
-NHTBJE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-NIBXTI = "".join(chr(c) for c in [65, 109, 80, 109])
-NIBXYB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NKMLOI = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-NMHXEK = 82
-NPYYLI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NQGVUN = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-NQJYMO = "".join(chr(c) for c in [70])
-NQLNMH = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-NQTMFZ = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-NRXCHW = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-NXNKML = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-NZMJIG = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OAWBSI = 84
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OIJUGS = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-OJRJHI = 81
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 62
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-OPHUGT = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-OQNRSJ = 32
-OUNBLK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-OUSPBW = 70
-OUYNQJ = 1
-PBWJYK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-PFTSIF = 53
-PHUGTY = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-POUYNQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PUNRJZ = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-PYYLIU = 78
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QFYLJU = 99
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-QGVUNX = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-QIEFXQ = 36
-QIPOUY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QJYMOU = "".join(chr(c) for c in [67])
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QNRSJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QRJJJV = "".join(chr(c) for c in [67, 89, 65, 78])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QTMFZD = 127
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 15
-RJHIUS = "".join(chr(c) for c in [79, 119, 110])
-RJJJVY = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-RJZTAT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-RSJMCB = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-RTFMNH = 44
-RXCHWD = 46
-RYXBQF = 87
-SBDJQR = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-SELHBQ = 45
-SEMCGE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-SIFJBI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SIRYXB = 86
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SKSOKP = 80
-SKWIVD = "".join(chr(c) for c in [77, 65, 65, 88])
-SNQLNM = 71
-SOKPHU = 54
-SOOQNR = 48
-SPFTSI = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-STSEMC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-SUHBVW = 7
-SXUJUT = "".join(chr(c) for c in [76, 111])
-TACCPQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-TATDZX = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-TBJEUT = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-TDZXNQ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-TFMNHT = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-THBSKS = "".join(chr(c) for c in [76, 73])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 64
-TIDUBS = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-TMFZDG = "".join(chr(c) for c in [49])
-TOPHUG = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-TSEMCG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-TSIFJB = 74
-TTIDUB = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-TYEKCW = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TYIYWS = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-UBSSUH = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-UGTYIY = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-UHBVWV = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UNBLKX = 25
-UNRJZT = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-UNXNKM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-UOJRJH = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-UQEXLS = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-USOOQN = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-USPBWJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UTOPHU = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-UTYEKC = 58
-UXFEFJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UYNQJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-VDNQGV = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-VDQLAI = 73
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-VUNXNK = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-VWVUBY = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-VYFCRT = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WAONPY = 61
-WBSIRY = 85
-WDAFIK = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-WIVDNQ = "".join(chr(c) for c in [80, 68, 67])
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-WRKINE = 106
-WSKWIV = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-WVUBYG = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-XBQFYL = 98
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XFEFJT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XNKMLO = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-XPICXQ = 14
-XQGLRA = 38
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-XSJWMN = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-XUJUTY = "".join(chr(c) for c in [72, 105])
-XWAJVD = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-XYBQSN = 8
-YBQSNQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YEKCWA = 59
-YFCRTF = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-YGDSBD = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-YIYWSK = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-YKLGQP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-YLJUIK = 100
-YMOUNB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YNQJYM = 33
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [76, 65])
-YXBQFY = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [52])
-ZILXWA = 5
-ZMJIGY = 35
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-ZUQEXL = 57
-ZXNQTM = 126
-AHEOCT = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-AJVDQL = [XWAJVD, WAJVDQ]
-BXTIAC = [JVHFTH, NIBXTI, IBXTIA]
-CXQIEF = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-DGKEAK = [VLASSA, TMFZDG, MFZDGK, FZDGKE, ZDGKEA]
-DUBSSU = [TIDUBS, IDUBSS]
-EGZUQE = [BFEGZU, FEGZUQ]
-FCRTFM = [VYFCRT, YFCRTF]
-FEFJTA = [UXFEFJ, XFEFJT]
-HBSKSO = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    THBSKS,
-]
-IFJBIA = [CCPQIP, SIFJBI]
-JHIUSO = [JRJHIU, RJHIUS]
-JJJVYF = [GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ, DJQRJJ, JQRJJJ, QRJJJV, RJJJVY]
-JMCBFE = [QNRSJM, NRSJMC, RSJMCB, SJMCBF]
-JTACCP = [PIPIVL, YYLIUX]
-JYMOUN = [NQJYMO, QJYMOU]
-KJPUNR = [IKJPUN, RJJJVY]
-KXSJWM = [NBLKXS, BLKXSJ, LKXSJW]
-LAIIDN = [VLASSA, DQLAII, QLAIID]
-MAOAWB = [BIAMJM, IAMJMA, AMJMAO, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-NRJZTA = [PUNRJZ, UNRJZT]
-OIHBXI = []
-PQIPOU = [CCPQIP, CPQIPO]
-QFFTTI = [ACQFFT, CQFFTT]
-QLNMHX = [JVHFTH, BFEGZU, NQLNMH]
-QNRXCH = [HBQNRX, BQNRXC, VLASSA, VLASSA]
-QPLSPF = [LGQPLS, GQPLSP]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-SPBWJY = [CCPQIP, USPBWJ]
-UBYGDS = [WVUBYG, VUBYGD]
-UGSELH = [
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-]
-UIKFWR = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-UJUTYE = [SXUJUT, XUJUTY]
-VXOIHB = [BMJVHF, AKQXPI, QXPICX, PICXQI, LRAHEO, OCTHBS]
-WMNZMJ = [SJWMNZ, JWMNZM]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-XOIHBX = [THBSKS]
-YLIUXF = [JVHFTH, YYLIUX, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -952,263 +19,674 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return IHBXIB
+        return 60
 
     @property
     def output_keys(self):
-        return VXOIHB
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "SilentMode": GeckoBoolStructAccessor(
+                self.struct, "SilentMode", 47, 3, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, CXQIEF, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, RAHEOC, None, AHEOCT, None, None, QBMJVH
-            ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, HBSKSO, None, None, None
-            ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, None),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, HIUSOO, JHIUSO, None, IUSOOQ, QBMJVH
-            ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, JMCBFE, None, None, QBMJVH
-            ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, EGZUQE, None, None, QBMJVH
-            ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, OJRJHI, IUSOOQ, UJUTYE, None, IUSOOQ, QBMJVH
-            ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YLIUXF, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FEFJTA, None, None, QBMJVH
-            ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, JTACCP, None, None, QBMJVH
-            ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, PQIPOU, None, None, QBMJVH
-            ),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoTempStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
-            ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JTACCP, None, None, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, KXSJWM, None, None, QBMJVH
-            ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, OJRJHI, MNZMJI, WMNZMJ, None, IUSOOQ, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, SPBWJY, None, None, QBMJVH
-            ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, MAOAWB, None, None, QBMJVH
-            ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, MAOAWB, None, None, QBMJVH
-            ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, None, MAOAWB, None, None, QBMJVH
-            ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, MAOAWB, None, None, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoByteStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, UIKFWR, None, None, QBMJVH
-            ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, UIKFWR, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, UIKFWR, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTimeStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoTimeStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, NMHXEK, HIUSOO, QBMJVH
-            ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, HXEKVK, IUSOOQ, QBMJVH
-            ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, HXEKVK, HIUSOO, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, HXEKVK, KVKZIL, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, HXEKVK, MNZMJI, QBMJVH
-            ),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, HXEKVK, ZILXWA, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, LAIIDN, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoWordStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, OJRJHI, KVKZIL, QFFTTI, None, IUSOOQ, QBMJVH
-            ),
-            FFTTID: GeckoBoolStructAccessor(
-                self.struct, FFTTID, OJRJHI, FTTIDU, QBMJVH
-            ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, OJRJHI, ZILXWA, DUBSSU, None, IUSOOQ, QBMJVH
-            ),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, OJRJHI, BSSUHB, QBMJVH
-            ),
-            SSUHBV: GeckoBoolStructAccessor(
-                self.struct, SSUHBV, OJRJHI, SUHBVW, QBMJVH
-            ),
-            UHBVWV: GeckoBoolStructAccessor(
-                self.struct, UHBVWV, HBVWVU, HIUSOO, QBMJVH
-            ),
-            BVWVUB: GeckoBoolStructAccessor(
-                self.struct, BVWVUB, HBVWVU, KVKZIL, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, HBVWVU, IUSOOQ, UBYGDS, None, IUSOOQ, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, HBVWVU, MNZMJI, UBYGDS, None, IUSOOQ, QBMJVH
-            ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, HBVWVU, FTTIDU, JJJVYF, None, JJVYFC, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, HBVWVU, SUHBVW, FCRTFM, None, IUSOOQ, QBMJVH
-            ),
-            GSELHB: GeckoBoolStructAccessor(
-                self.struct, GSELHB, SELHBQ, HIUSOO, QBMJVH
-            ),
-            ELHBQN: GeckoBoolStructAccessor(
-                self.struct, ELHBQN, SELHBQ, KVKZIL, QBMJVH
-            ),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, SELHBQ, IUSOOQ, QNRXCH, None, FTTIDU, QBMJVH
-            ),
-            NRXCHW: GeckoByteStructAccessor(self.struct, NRXCHW, RXCHWD, QBMJVH),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, HIUSOO, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, CHWDAF, MNZMJI, QBMJVH
-            ),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, QBMJVH),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, FIKJPU, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, JZTATD, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, ATDZXN, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, ATDZXN, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, ZXNQTM, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, HIUSOO, DGKEAK, None, JJVYFC, None
-            ),
-            GKEAKS: GeckoBoolStructAccessor(self.struct, GKEAKS, QTMFZD, SUHBVW, None),
-            KEAKST: GeckoBoolStructAccessor(self.struct, KEAKST, FIKJPU, FTTIDU, None),
-            EAKSTS: GeckoBoolStructAccessor(self.struct, EAKSTS, FIKJPU, ZILXWA, None),
-            AKSTSE: GeckoBoolStructAccessor(self.struct, AKSTSE, FIKJPU, BSSUHB, None),
-            KSTSEM: GeckoBoolStructAccessor(self.struct, KSTSEM, FIKJPU, SUHBVW, None),
-            STSEMC: GeckoBoolStructAccessor(self.struct, STSEMC, JZTATD, FTTIDU, None),
-            TSEMCG: GeckoBoolStructAccessor(self.struct, TSEMCG, JZTATD, ZILXWA, None),
-            SEMCGE: GeckoBoolStructAccessor(self.struct, SEMCGE, JZTATD, BSSUHB, None),
-            EMCGET: GeckoBoolStructAccessor(self.struct, EMCGET, JZTATD, SUHBVW, None),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, ATDZXN, FTTIDU, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, ATDZXN, ZILXWA, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, ATDZXN, BSSUHB, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, ATDZXN, SUHBVW, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, ZXNQTM, FTTIDU, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, ZXNQTM, ZILXWA, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, ZXNQTM, BSSUHB, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, ZXNQTM, SUHBVW, None),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-61.py
+++ b/src/geckolib/driver/packs/inyj-cfg-61.py
@@ -12,926 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 30
-ACQFFT = 108
-AFIKJP = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-AIIDNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(chr(c) for c in [51])
-AMJMAO = "".join(chr(c) for c in [70, 51])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AONPYY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-ATDZXN = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BDJQRJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-BFEGZU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-BIAMJM = "".join(chr(c) for c in [70, 49])
-BJEUTO = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BLKXSJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-BQNRXC = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-BQSNQL = 10
-BSIRYX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-BSKSOK = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BSSUHB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-BVWVUB = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-BWJYKL = 77
-BXIBHZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-BXTIAC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BYGDSB = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-CBFEGZ = 27
-CCPQIP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-CHWDAF = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-CPQIPO = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CRTFMN = "".join(chr(c) for c in [67, 89, 65, 78])
-CTHBSK = 79
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-DGKEAK = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-DJQRJJ = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DNIBXT = 107
-DNQGVU = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DQLAII = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DSBDJQ = 43
-DUBSSU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-EAKSTS = "".join(chr(c) for c in [50])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-EFXQGL = 37
-EJNIBX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-EKCWAO = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-EKVKZI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-EMCGET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-EOCTHB = 39
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-EUTOPH = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-EXLSXU = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FCRTFM = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-FEGZUQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FFTTID = "".join(chr(c) for c in [65, 109, 80, 109])
-FIKJPU = 46
-FJBIAM = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FJTACC = 29
-FMNHTB = 8
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-FTTIDU = "".join(chr(c) for c in [50, 52, 104])
-FWRKIN = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-FZDGKE = 126
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-GKEAKS = 127
-GLRAHE = 40
-GQPLSP = "".join(chr(c) for c in [67, 69])
-GSELHB = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-GTYIYW = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GVUNXN = "".join(chr(c) for c in [77, 65, 65, 88])
-GYOUSP = 68
-GZUQEX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-HBQNRX = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-HBVWVU = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HBXIBH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HTBJEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-HUGTYI = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-HUOJRJ = 56
-HWDAFI = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HXEKVK = 72
-HZVOAC = 61
-IACQFF = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-IAMJMA = "".join(chr(c) for c in [70, 50])
-IBXTIA = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-IBXYBQ = 23
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IDUBSS = 64
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IHBXIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-IIDNIB = 75
-IJUGSE = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-IKJPUN = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-ILXWAJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 63
-IRYXBQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IUSOOQ = 2
-IUXFEF = 28
-IVDNQG = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-IYWSKW = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-JBIAMJ = 83
-JEUTOP = 44
-JIGYOU = 66
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-JJVYFC = "".join(chr(c) for c in [82, 69, 68])
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-JNIBXY = 6
-JPUNRJ = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JRJHIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JUGSEL = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-JUIKFW = 104
-JUTYEK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JWMNZM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JYKLGQ = 26
-KCWAON = 60
-KEAKST = "".join(chr(c) for c in [49])
-KFWRKI = 105
-KINEJN = 3
-KJPUNR = 47
-KLGQPL = 51
-KMLOIJ = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-KPHUOJ = 55
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KSTSEM = "".join(chr(c) for c in [52])
-KVKZIL = 1
-KWIVDN = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [85, 76])
-LHBQNR = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-LIUXFE = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LJUIKF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-LKXSJW = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-LNMHXE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-LOIJUG = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-LRAHEO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-LSPFTS = 52
-LSXUJU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LXWAJV = 76
-MCBFEG = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-MFZDGK = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-MNZMJI = 3
-MOUNBL = 31
-NBLKXS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = 4
-NHTBJE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NIBXTI = "".join(chr(c) for c in [79, 70, 70])
-NIBXYB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NKMLOI = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NMHXEK = 82
-NPYYLI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NQGVUN = "".join(chr(c) for c in [76, 65])
-NQJYMO = "".join(chr(c) for c in [70])
-NQLNMH = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-NQTMFZ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-NRJZTA = 123
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-NXNKML = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-NZMJIG = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OAWBSI = 84
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OIHBXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-OIJUGS = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-OJRJHI = 81
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 62
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-OPHUGT = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-OQNRSJ = 32
-OUNBLK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-OUSPBW = 70
-OUYNQJ = 1
-PBWJYK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-PFTSIF = 53
-PHUGTY = "".join(chr(c) for c in [65, 108, 112, 115])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-POUYNQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PUNRJZ = 121
-PYYLIU = 78
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QFFTTI = 34
-QFYLJU = 99
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-QIEFXQ = 36
-QIPOUY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QJYMOU = "".join(chr(c) for c in [67])
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QNRSJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QNRXCH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QTMFZD = 125
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 15
-RJHIUS = "".join(chr(c) for c in [79, 119, 110])
-RJJJVY = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RJZTAT = "".join(chr(c) for c in [82, 71, 66])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-RSJMCB = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-RTFMNH = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-RYXBQF = 87
-SBDJQR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SELHBQ = "".join(chr(c) for c in [73, 100, 111, 108])
-SEMCGE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-SIFJBI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SIRYXB = 86
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SKSOKP = 80
-SKWIVD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SNQLNM = 71
-SOKPHU = 54
-SOOQNR = 48
-SPFTSI = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SUHBVW = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-SXUJUT = "".join(chr(c) for c in [76, 111])
-TACCPQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-TATDZX = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-THBSKS = "".join(chr(c) for c in [76, 73])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIDUBS = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-TMFZDG = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-TOPHUG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-TSEMCG = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-TSIFJB = 74
-TYEKCW = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TYIYWS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-UBSSUH = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBYGDS = 6
-UGSELH = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-UGTYIY = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-UHBVWV = 4
-UNBLKX = 25
-UNRJZT = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-UNXNKM = "".join(chr(c) for c in [80, 68, 67])
-UOJRJH = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-UQEXLS = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-USOOQN = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-USPBWJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UTOPHU = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UTYEKC = 58
-UXFEFJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UYNQJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-VDNQGV = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VDQLAI = 73
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-VUNXNK = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-VWVUBY = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-VXOIHB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-VYFCRT = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WAONPY = 61
-WBSIRY = 85
-WDAFIK = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-WIVDNQ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-WRKINE = 106
-WSKWIV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-XBQFYL = 98
-XCHWDA = 45
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XFEFJT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XNKMLO = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-XOIHBX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-XPICXQ = 14
-XQGLRA = 38
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XSJWMN = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XTIACQ = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-XUJUTY = "".join(chr(c) for c in [72, 105])
-XWAJVD = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-XYBQSN = 8
-YBQSNQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YEKCWA = 59
-YFCRTF = "".join(chr(c) for c in [66, 76, 85, 69])
-YGDSBD = 7
-YIYWSK = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-YKLGQP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-YLJUIK = 100
-YMOUNB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YNQJYM = 33
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-YXBQFY = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ZILXWA = 5
-ZMJIGY = 35
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-ZUQEXL = 57
-ZXNQTM = 124
-AHEOCT = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-AJVDQL = [XWAJVD, WAJVDQ]
-BHZVOA = []
-CXQIEF = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-DAFIKJ = [HWDAFI, WDAFIK, VLASSA, VLASSA]
-EGZUQE = [BFEGZU, FEGZUQ]
-FEFJTA = [UXFEFJ, XFEFJT]
-HBSKSO = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    THBSKS,
-]
-IBHZVO = [THBSKS]
-IFJBIA = [CCPQIP, SIFJBI]
-JHIUSO = [JRJHIU, RJHIUS]
-JMCBFE = [QNRSJM, NRSJMC, RSJMCB, SJMCBF]
-JTACCP = [PIPIVL, YYLIUX]
-JYMOUN = [NQJYMO, QJYMOU]
-JZTATD = [RJZTAT, RTFMNH]
-KXSJWM = [NBLKXS, BLKXSJ, LKXSJW]
-LAIIDN = [VLASSA, DQLAII, QLAIID]
-MAOAWB = [BIAMJM, IAMJMA, AMJMAO, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-NRXCHW = [
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-]
-PQIPOU = [CCPQIP, CPQIPO]
-QLNMHX = [JVHFTH, BFEGZU, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QRJJJV = [DJQRJJ, JQRJJJ]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-SPBWJY = [CCPQIP, USPBWJ]
-SSUHBV = [UBSSUH, BSSUHB]
-STSEMC = [VLASSA, KEAKST, EAKSTS, AKSTSE, KSTSEM]
-TBJEUT = [NHTBJE, HTBJEU]
-TDZXNQ = [TATDZX, ATDZXN]
-TFMNHT = [NIBXTI, JJVYFC, JVYFCR, VYFCRT, YFCRTF, FCRTFM, CRTFMN, RTFMNH]
-TIACQF = [JVHFTH, NIBXTI, IBXTIA, BXTIAC, XTIACQ]
-TTIDUB = [JVHFTH, FFTTID, FTTIDU]
-UIKFWR = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-UJUTYE = [SXUJUT, XUJUTY]
-WMNZMJ = [SJWMNZ, JWMNZM]
-WVUBYG = [BVWVUB, VWVUBY]
-XIBHZV = [BMJVHF, AKQXPI, QXPICX, PICXQI, LRAHEO, OCTHBS]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-YLIUXF = [JVHFTH, YYLIUX, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -939,261 +19,681 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return HZVOAC
+        return 61
 
     @property
     def output_keys(self):
-        return XIBHZV
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                107,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 108, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, CXQIEF, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, RAHEOC, None, AHEOCT, None, None, QBMJVH
-            ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, HBSKSO, None, None, None
-            ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, None),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, HIUSOO, JHIUSO, None, IUSOOQ, QBMJVH
-            ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, JMCBFE, None, None, QBMJVH
-            ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, EGZUQE, None, None, QBMJVH
-            ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, OJRJHI, IUSOOQ, UJUTYE, None, IUSOOQ, QBMJVH
-            ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YLIUXF, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FEFJTA, None, None, QBMJVH
-            ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, JTACCP, None, None, QBMJVH
-            ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, PQIPOU, None, None, QBMJVH
-            ),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoTempStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
-            ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JTACCP, None, None, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, KXSJWM, None, None, QBMJVH
-            ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, OJRJHI, MNZMJI, WMNZMJ, None, IUSOOQ, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, SPBWJY, None, None, QBMJVH
-            ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, MAOAWB, None, None, QBMJVH
-            ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, MAOAWB, None, None, QBMJVH
-            ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, None, MAOAWB, None, None, QBMJVH
-            ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, MAOAWB, None, None, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoByteStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, UIKFWR, None, None, QBMJVH
-            ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, UIKFWR, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, UIKFWR, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTimeStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoTimeStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, NMHXEK, HIUSOO, QBMJVH
-            ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, HXEKVK, IUSOOQ, QBMJVH
-            ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, HXEKVK, HIUSOO, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, HXEKVK, KVKZIL, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, HXEKVK, MNZMJI, QBMJVH
-            ),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, HXEKVK, ZILXWA, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, LAIIDN, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, TIACQF, None, None, QBMJVH
-            ),
-            IACQFF: GeckoTimeStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, OJRJHI, KVKZIL, SSUHBV, None, IUSOOQ, QBMJVH
-            ),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, OJRJHI, UHBVWV, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, OJRJHI, ZILXWA, WVUBYG, None, IUSOOQ, QBMJVH
-            ),
-            VUBYGD: GeckoBoolStructAccessor(
-                self.struct, VUBYGD, OJRJHI, UBYGDS, QBMJVH
-            ),
-            BYGDSB: GeckoBoolStructAccessor(
-                self.struct, BYGDSB, OJRJHI, YGDSBD, QBMJVH
-            ),
-            GDSBDJ: GeckoBoolStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, HIUSOO, QBMJVH
-            ),
-            SBDJQR: GeckoBoolStructAccessor(
-                self.struct, SBDJQR, DSBDJQ, KVKZIL, QBMJVH
-            ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DSBDJQ, IUSOOQ, QRJJJV, None, IUSOOQ, QBMJVH
-            ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, DSBDJQ, MNZMJI, QRJJJV, None, IUSOOQ, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, DSBDJQ, UHBVWV, TFMNHT, None, FMNHTB, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, DSBDJQ, YGDSBD, TBJEUT, None, IUSOOQ, QBMJVH
-            ),
-            RXCHWD: GeckoBoolStructAccessor(
-                self.struct, RXCHWD, XCHWDA, KVKZIL, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, XCHWDA, IUSOOQ, DAFIKJ, None, UHBVWV, QBMJVH
-            ),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, QBMJVH),
-            IKJPUN: GeckoBoolStructAccessor(
-                self.struct, IKJPUN, KJPUNR, HIUSOO, QBMJVH
-            ),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, QBMJVH),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, NRJZTA, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, NRJZTA, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, ZXNQTM, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, QTMFZD, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, FZDGKE, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, FZDGKE, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, GKEAKS, HIUSOO, STSEMC, None, FMNHTB, None
-            ),
-            TSEMCG: GeckoBoolStructAccessor(self.struct, TSEMCG, GKEAKS, YGDSBD, None),
-            SEMCGE: GeckoBoolStructAccessor(self.struct, SEMCGE, NRJZTA, UHBVWV, None),
-            EMCGET: GeckoBoolStructAccessor(self.struct, EMCGET, NRJZTA, ZILXWA, None),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, NRJZTA, UBYGDS, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, NRJZTA, YGDSBD, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, ZXNQTM, UHBVWV, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, ZXNQTM, ZILXWA, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, ZXNQTM, UBYGDS, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, ZXNQTM, YGDSBD, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, QTMFZD, UHBVWV, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, QTMFZD, ZILXWA, None),
-            VXOIHB: GeckoBoolStructAccessor(self.struct, VXOIHB, QTMFZD, UBYGDS, None),
-            XOIHBX: GeckoBoolStructAccessor(self.struct, XOIHBX, QTMFZD, YGDSBD, None),
-            OIHBXI: GeckoBoolStructAccessor(self.struct, OIHBXI, FZDGKE, UHBVWV, None),
-            IHBXIB: GeckoBoolStructAccessor(self.struct, IHBXIB, FZDGKE, ZILXWA, None),
-            HBXIBH: GeckoBoolStructAccessor(self.struct, HBXIBH, FZDGKE, UBYGDS, None),
-            BXIBHZ: GeckoBoolStructAccessor(self.struct, BXIBHZ, FZDGKE, YGDSBD, None),
         }

--- a/src/geckolib/driver/packs/inyj-cfg-62.py
+++ b/src/geckolib/driver/packs/inyj-cfg-62.py
@@ -12,953 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-ACQFFT = 108
-AFIKJP = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-AHEOCT = 15
-AIIDNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKSTSE = "".join(chr(c) for c in [50])
-AMJMAO = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-AOAWBS = "".join(chr(c) for c in [70, 50])
-AONPYY = 58
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-ATDZXN = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-AWBSIR = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-BDJQRJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-BFEGZU = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-BIAMJM = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BJEUTO = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BLKXSJ = "".join(chr(c) for c in [67])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 86
-BQNRXC = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-BQSNQL = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-BSSUHB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-BVWVUB = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-BWJYKL = 68
-BXIBHZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-BXTIAC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-BXYBQS = 23
-BYGDSB = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-CCPQIP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-CHWDAF = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CRTFMN = "".join(chr(c) for c in [67, 89, 65, 78])
-CTHBSK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 1
-CXQIEF = 16
-DGKEAK = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-DJQRJJ = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DNIBXT = 107
-DNQGVU = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DQLAII = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DSBDJQ = 43
-DUBSSU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-EAKSTS = "".join(chr(c) for c in [49])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [80, 49])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-EJNIBX = 4
-EKVKZI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-EMCGET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-EOCTHB = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-EUTOPH = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-FCRTFM = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-FEFJTA = 78
-FEGZUQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-FFTTID = "".join(chr(c) for c in [65, 109, 80, 109])
-FIKJPU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FJBIAM = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-FMNHTB = 8
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 69])
-FTTIDU = "".join(chr(c) for c in [50, 52, 104])
-FXQGLR = 37
-FYLJUI = 87
-FZDGKE = 126
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-GKEAKS = 127
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-GQPLSP = 77
-GSELHB = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-GTYIYW = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GVUNXN = "".join(chr(c) for c in [77, 65, 65, 88])
-GYOUSP = 3
-GZUQEX = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-HBQNRX = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-HBSKSO = 2
-HBVWVU = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HBXIBH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 81
-HTBJEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-HUGTYI = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-HUOJRJ = 54
-HWDAFI = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-IACQFF = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-IAMJMA = 74
-IBXTIA = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-IBXYBQ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IDNIBX = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IDUBSS = 64
-IEFXQG = 36
-IFJBIA = 52
-IHBXIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-IIDNIB = 75
-IJUGSE = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-IKJPUN = 46
-ILXWAJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-INEJNI = 3
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IRYXBQ = 84
-IUSOOQ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-IUXFEF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-IVDNQG = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-IYWSKW = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-JBIAMJ = 53
-JEUTOP = 44
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-JIGYOU = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-JJVYFC = "".join(chr(c) for c in [82, 69, 68])
-JMAOAW = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JMCBFE = 32
-JNIBXY = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JPUNRJ = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JRJHIU = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JTACCP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-JUGSEL = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-JUIKFW = "".join(chr(c) for c in [70, 52, 67, 117, 114, 114, 101, 110, 116])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JWMNZM = 25
-JYKLGQ = 70
-JYMOUN = 63
-KCWAON = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-KEAKST = "".join(chr(c) for c in [78, 111, 110, 101])
-KFWRKI = 104
-KINEJN = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-KJPUNR = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-KMLOIJ = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-KPHUOJ = 80
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 50])
-KSOKPH = "".join(chr(c) for c in [76, 73])
-KSTSEM = "".join(chr(c) for c in [51])
-KVKZIL = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-KWIVDN = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-KXSJWM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-LHBQNR = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-LIUXFE = 61
-LJUIKF = 98
-LOIJUG = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-LRAHEO = 40
-LSPFTS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-LSXUJU = 57
-LXWAJV = 76
-MAOAWB = 83
-MCBFEG = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-MFZDGK = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-MHXEKV = 82
-MJIGYO = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-MNZMJI = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-MOUNBL = 1
-NBLKXS = "".join(chr(c) for c in [70])
-NEJNIB = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-NHTBJE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NIBXTI = "".join(chr(c) for c in [79, 70, 70])
-NIBXYB = 6
-NKMLOI = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NMHXEK = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NPYYLI = 59
-NQGVUN = "".join(chr(c) for c in [76, 65])
-NQLNMH = 71
-NQTMFZ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-NRJZTA = 123
-NRSJMC = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-NXNKML = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-OAWBSI = "".join(chr(c) for c in [70, 52])
-OCTHBS = 39
-OIHBXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-OIJUGS = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-OJRJHI = 55
-OKPHUO = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-ONPYYL = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OOQNRS = 0
-OPHUGT = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-OQNRSJ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-OUNBLK = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-OUSPBW = 35
-OUYNQJ = 30
-PBWJYK = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PFTSIF = "".join(chr(c) for c in [85, 76])
-PHUGTY = "".join(chr(c) for c in [65, 108, 112, 115])
-PHUOJR = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = 14
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 26
-POUYNQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PUNRJZ = 121
-PYYLIU = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-QFFTTI = 34
-QFYLJU = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-QGLRAH = 38
-QGVUNX = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-QIPOUY = 29
-QJYMOU = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QLNMHX = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-QNRSJM = 48
-QNRXCH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-QSNQLN = 10
-QTMFZD = 125
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-QXPICX = 13
-RAHEOC = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJHIUS = 56
-RJJJVY = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RJZTAT = "".join(chr(c) for c in [82, 71, 66])
-RKINEJ = 105
-RSJMCB = 118
-RTFMNH = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-RYXBQF = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-SAKQXP = "".join(chr(c) for c in [65, 85, 88])
-SBDJQR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SELHBQ = "".join(chr(c) for c in [73, 100, 111, 108])
-SEMCGE = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-SIFJBI = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-SIRYXB = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-SJWMNZ = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-SKSOKP = 79
-SKWIVD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SPBWJY = 66
-SPFTSI = 51
-SSAKQX = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-STSEMC = "".join(chr(c) for c in [52])
-SUHBVW = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-SXUJUT = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TACCPQ = 28
-TATDZX = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-THBSKS = 47
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIDUBS = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-TMFZDG = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-TOPHUG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-TYEKCW = "".join(chr(c) for c in [76, 111])
-TYIYWS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-UBSSUH = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBYGDS = 6
-UGSELH = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-UGTYIY = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-UHBVWV = 4
-UIKFWR = 99
-UJUTYE = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-UNBLKX = 33
-UNRJZT = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-UNXNKM = "".join(chr(c) for c in [80, 68, 67])
-UOJRJH = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-UQEXLS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-USOOQN = "".join(chr(c) for c in [79, 119, 110])
-USPBWJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-UTOPHU = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UTYEKC = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-UXFEFJ = 62
-UYNQJY = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-VDNQGV = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VDQLAI = 73
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-VUNXNK = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-VWVUBY = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-VXOIHB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-VYFCRT = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WAONPY = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-WBSIRY = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-WDAFIK = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-WIVDNQ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-WJYKLG = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-WMNZMJ = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-WRKINE = "".join(chr(c) for c in [70, 52, 76, 105, 110, 101])
-WSKWIV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-XBQFYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-XCHWDA = 45
-XEKVKZ = 72
-XFEFJT = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-XIBHZV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-XNKMLO = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-XOIHBX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 51])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-XSJWMN = 31
-XTIACQ = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-XUJUTY = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-XWAJVD = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-XYBQSN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-YBQSNQ = 8
-YEKCWA = "".join(chr(c) for c in [72, 105])
-YFCRTF = "".join(chr(c) for c in [66, 76, 85, 69])
-YGDSBD = 7
-YIYWSK = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-YKLGQP = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YLJUIK = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-YMOUNB = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-YNQJYM = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-YOUSPB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-YXBQFY = 85
-YYLIUX = 60
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ZILXWA = 5
-ZMJIGY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-ZUQEXL = 27
-ZVOACM = 62
-ZXNQTM = 124
-AJVDQL = [XWAJVD, WAJVDQ]
-AKQXPI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-]
-BHZVOA = [KSOKPH]
-BSIRYX = [AOAWBS, OAWBSI, VLASSA, VLASSA, VLASSA, VLASSA, AWBSIR, WBSIRY]
-CPQIPO = [ACCPQI, CCPQIP]
-DAFIKJ = [HWDAFI, WDAFIK, VLASSA, VLASSA]
-EGZUQE = [MCBFEG, CBFEGZ, BFEGZU, FEGZUQ]
-EKCWAO = [TYEKCW, YEKCWA]
-EXLSXU = [UQEXLS, QEXLSX]
-FJTACC = [JVHFTH, EFJTAC, PIPIVL]
-FWRKIN = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, AWBSIR, WBSIRY]
-HEOCTH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-HZVOAC = []
-IBHZVO = [BMJVHF, KQXPIC, XPICXQ, ICXQIE, RAHEOC, BSKSOK]
-IGYOUS = [MJIGYO, JIGYOU]
-IPOUYN = [PIPIVL, EFJTAC]
-JUTYEK = [SXUJUT, XUJUTY, UJUTYE]
-JZTATD = [RJZTAT, RTFMNH]
-KLGQPL = [UYNQJY, YKLGQP]
-LAIIDN = [VLASSA, DQLAII, QLAIID]
-LKXSJW = [NBLKXS, BLKXSJ]
-LNMHXE = [JVHFTH, UQEXLS, QLNMHX]
-MJMAOA = [UYNQJY, AMJMAO]
-NQJYMO = [UYNQJY, YNQJYM]
-NRXCHW = [
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-]
-NZMJIG = [WMNZMJ, MNZMJI]
-QRJJJV = [DJQRJJ, JQRJJJ]
-SOKPHU = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KSOKPH,
-]
-SOOQNR = [IUSOOQ, USOOQN]
-SSUHBV = [UBSSUH, BSSUHB]
-TBJEUT = [NHTBJE, HTBJEU]
-TDZXNQ = [TATDZX, ATDZXN]
-TFMNHT = [NIBXTI, JJVYFC, JVYFCR, VYFCRT, YFCRTF, FCRTFM, CRTFMN, RTFMNH]
-TIACQF = [JVHFTH, NIBXTI, IBXTIA, BXTIAC, XTIACQ]
-TSEMCG = [KEAKST, EAKSTS, AKSTSE, KSTSEM, STSEMC]
-TSIFJB = [PFTSIF, FTSIFJ]
-TTIDUB = [JVHFTH, FFTTID, FTTIDU]
-WVUBYG = [BVWVUB, VWVUBY]
-XQIEFX = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -966,267 +19,682 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return ZVOACM
+        return 62
 
     @property
     def output_keys(self):
-        return IBHZVO
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, AKQXPI, None, None, QBMJVH
-            ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, AKQXPI, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, AKQXPI, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, XQIEFX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 47, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 47, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 98, "ALL"),
+            "F4Current": GeckoByteStructAccessor(self.struct, "F4Current", 99, "ALL"),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F4Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F4Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                107,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 108, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 45, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["None", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QIEFXQ: GeckoByteStructAccessor(self.struct, QIEFXQ, IEFXQG, QBMJVH),
-            EFXQGL: GeckoByteStructAccessor(self.struct, EFXQGL, FXQGLR, QBMJVH),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, HEOCTH, None, None, QBMJVH
-            ),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoBoolStructAccessor(
-                self.struct, CTHBSK, THBSKS, HBSKSO, QBMJVH
-            ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, SOKPHU, None, None, None
-            ),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, None),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, OOQNRS, SOOQNR, None, HBSKSO, QBMJVH
-            ),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, EGZUQE, None, None, QBMJVH
-            ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, JUTYEK, None, None, QBMJVH
-            ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, HIUSOO, HBSKSO, EKCWAO, None, HBSKSO, QBMJVH
-            ),
-            KCWAON: GeckoBoolStructAccessor(
-                self.struct, KCWAON, THBSKS, CWAONP, QBMJVH
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoEnumStructAccessor(
-                self.struct, XFEFJT, FEFJTA, None, FJTACC, None, None, QBMJVH
-            ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, IPOUYN, None, None, QBMJVH
-            ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, OUYNQJ, None, NQJYMO, None, None, QBMJVH
-            ),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, QBMJVH),
-            YMOUNB: GeckoTempStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, XSJWMN, None, IPOUYN, None, None, QBMJVH
-            ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, NZMJIG, None, None, QBMJVH
-            ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, HIUSOO, GYOUSP, IGYOUS, None, HBSKSO, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoTempStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoEnumStructAccessor(
-                self.struct, WJYKLG, JYKLGQ, None, KLGQPL, None, None, QBMJVH
-            ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, TSIFJB, None, None, QBMJVH
-            ),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, IAMJMA, None, MJMAOA, None, None, QBMJVH
-            ),
-            JMAOAW: GeckoEnumStructAccessor(
-                self.struct, JMAOAW, MAOAWB, None, BSIRYX, None, None, QBMJVH
-            ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, BSIRYX, None, None, QBMJVH
-            ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BSIRYX, None, None, QBMJVH
-            ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, BSIRYX, None, None, QBMJVH
-            ),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, None, BSIRYX, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoByteStructAccessor(self.struct, JUIKFW, UIKFWR, QBMJVH),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, FWRKIN, None, None, QBMJVH
-            ),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, FWRKIN, None, None, QBMJVH
-            ),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoTimeStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoTimeStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoTimeStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoTimeStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, None, LNMHXE, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, MHXEKV, OOQNRS, QBMJVH
-            ),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, HBSKSO, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, XEKVKZ, OOQNRS, QBMJVH
-            ),
-            KVKZIL: GeckoBoolStructAccessor(
-                self.struct, KVKZIL, XEKVKZ, CWAONP, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, XEKVKZ, GYOUSP, QBMJVH
-            ),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, XEKVKZ, ZILXWA, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, LAIIDN, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, TIACQF, None, None, QBMJVH
-            ),
-            IACQFF: GeckoTimeStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, HIUSOO, CWAONP, SSUHBV, None, HBSKSO, QBMJVH
-            ),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, HIUSOO, UHBVWV, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, HIUSOO, ZILXWA, WVUBYG, None, HBSKSO, QBMJVH
-            ),
-            VUBYGD: GeckoBoolStructAccessor(
-                self.struct, VUBYGD, HIUSOO, UBYGDS, QBMJVH
-            ),
-            BYGDSB: GeckoBoolStructAccessor(
-                self.struct, BYGDSB, HIUSOO, YGDSBD, QBMJVH
-            ),
-            GDSBDJ: GeckoBoolStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, OOQNRS, QBMJVH
-            ),
-            SBDJQR: GeckoBoolStructAccessor(
-                self.struct, SBDJQR, DSBDJQ, CWAONP, QBMJVH
-            ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DSBDJQ, HBSKSO, QRJJJV, None, HBSKSO, QBMJVH
-            ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, DSBDJQ, GYOUSP, QRJJJV, None, HBSKSO, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, DSBDJQ, UHBVWV, TFMNHT, None, FMNHTB, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, DSBDJQ, YGDSBD, TBJEUT, None, HBSKSO, QBMJVH
-            ),
-            RXCHWD: GeckoBoolStructAccessor(
-                self.struct, RXCHWD, XCHWDA, CWAONP, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, XCHWDA, HBSKSO, DAFIKJ, None, UHBVWV, QBMJVH
-            ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, XCHWDA, UHBVWV, QBMJVH
-            ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoBoolStructAccessor(
-                self.struct, KJPUNR, THBSKS, OOQNRS, QBMJVH
-            ),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, QBMJVH),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, NRJZTA, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, NRJZTA, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, ZXNQTM, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, QTMFZD, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, FZDGKE, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, FZDGKE, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, GKEAKS, OOQNRS, TSEMCG, None, FMNHTB, None
-            ),
-            SEMCGE: GeckoBoolStructAccessor(self.struct, SEMCGE, GKEAKS, YGDSBD, None),
-            EMCGET: GeckoBoolStructAccessor(self.struct, EMCGET, NRJZTA, UHBVWV, None),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, NRJZTA, ZILXWA, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, NRJZTA, UBYGDS, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, NRJZTA, YGDSBD, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, ZXNQTM, UHBVWV, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, ZXNQTM, ZILXWA, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, ZXNQTM, UBYGDS, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, ZXNQTM, YGDSBD, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, QTMFZD, UHBVWV, None),
-            VXOIHB: GeckoBoolStructAccessor(self.struct, VXOIHB, QTMFZD, ZILXWA, None),
-            XOIHBX: GeckoBoolStructAccessor(self.struct, XOIHBX, QTMFZD, UBYGDS, None),
-            OIHBXI: GeckoBoolStructAccessor(self.struct, OIHBXI, QTMFZD, YGDSBD, None),
-            IHBXIB: GeckoBoolStructAccessor(self.struct, IHBXIB, FZDGKE, UHBVWV, None),
-            HBXIBH: GeckoBoolStructAccessor(self.struct, HBXIBH, FZDGKE, ZILXWA, None),
-            BXIBHZ: GeckoBoolStructAccessor(self.struct, BXIBHZ, FZDGKE, UBYGDS, None),
-            XIBHZV: GeckoBoolStructAccessor(self.struct, XIBHZV, FZDGKE, YGDSBD, None),
         }

--- a/src/geckolib/driver/packs/inyj-log-53.py
+++ b/src/geckolib/driver/packs/inyj-log-53.py
@@ -12,881 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-AFIKJP = 454
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = 460
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BDJQRJ = "".join(chr(c) for c in [75, 52])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [80, 50, 76])
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = "".join(chr(c) for c in [67, 70, 71, 50])
-BQSNQL = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-BVWVUB = 316
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = 477
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BXYBQS = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BYGDSB = 357
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = 471
-CHWDAF = 452
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = 294
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-CTHBSK = 303
-CVDSSR = 256
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 54])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-DJQRJJ = "".join(chr(c) for c in [75, 53])
-DNIBXT = "".join(chr(c) for c in [51, 48, 65])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-DQLAII = "".join(chr(c) for c in [51, 79, 80])
-DSBDJQ = "".join(chr(c) for c in [75, 56, 53])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DZXNQT = 461
-EAKSTS = 467
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [105, 110, 88, 69])
-EKCWAO = 264
-EKVKZI = "".join(chr(c) for c in [52, 56, 75])
-ELHBQN = 448
-EMCGET = 470
-EOCTHB = 307
-ETIXQV = 472
-EUTOPH = "".join(chr(c) for c in [80, 51, 76])
-FCRTFM = 360
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 295
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 55])
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = 320
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-FWRKIN = 287
-FYLJUI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-GDSBDJ = "".join(chr(c) for c in [75, 52, 48, 48])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-GKEAKS = 466
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = 332
-GTYIYW = 321
-GVUNXN = 328
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = 449
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = "".join(chr(c) for c in [67, 70, 71, 53])
-HXEKVK = "".join(chr(c) for c in [49, 54, 75])
-HZVOAC = 479
-IACQFF = 293
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = 478
-IBXTIA = 7
-IBXYBQ = "".join(chr(c) for c in [68, 74, 83, 52])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [50, 53, 65])
-IDUBSS = 297
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = 476
-IIDNIB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-IJUGSE = 325
-IKFWRK = 285
-IKJPUN = 455
-ILXWAJ = "".join(chr(c) for c in [67, 69])
-INEJNI = 289
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IUXFEF = 271
-IVDNQG = "".join(chr(c) for c in [72, 84, 82])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = 473
-IYWSKW = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [80, 51, 72])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JPUNRJ = 456
-JQRJJJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUIKFW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 56])
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 331
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = 468
-KVKZIL = "".join(chr(c) for c in [54, 52, 75])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = "".join(chr(c) for c in [67, 70, 71, 49])
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LOIJUG = 333
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-MCVDSS = 53
-MFZDGK = 464
-MHXEKV = 290
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [78, 65])
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NHTBJE = "".join(chr(c) for c in [80, 49, 72])
-NIBXYB = "".join(chr(c) for c in [77, 73, 65])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = 327
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = "".join(chr(c) for c in [75, 56, 48, 48])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = "".join(chr(c) for c in [67, 70, 71, 51])
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-NZMJIG = 279
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-OIJUGS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [66, 76, 79])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 57])
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-QFYLJU = 315
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLNMHX = "".join(chr(c) for c in [105, 110, 89, 74])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = 450
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [75, 49, 48, 48])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QTMFZD = 463
-QVXOIH = 474
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-RJZTAT = 458
-RKINEJ = 288
-RSJMCB = 5
-RTFMNH = 361
-RXCHWD = 451
-RYXBQF = 311
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [75, 56])
-SELHBQ = "".join(chr(c) for c in [67, 70, 71, 48])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = 324
-SNQLNM = "".join(chr(c) for c in [105, 110, 89, 84])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SSAKQX = 259
-SSUHBV = 300
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-SUHBVW = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TBJEUT = "".join(chr(c) for c in [80, 50, 72])
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-TFMNHT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-TOPHUG = "".join(chr(c) for c in [80, 52, 76])
-TSEMCG = 469
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 296
-TYIYWS = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-UBSSUH = 299
-UBYGDS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-UGSELH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-UGTYIY = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-UHBVWV = 301
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = 457
-UNXNKM = 329
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = "".join(chr(c) for c in [80, 52, 72])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDQLAI = "".join(chr(c) for c in [53, 79, 80])
-VDSSRU = 479
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VOACMC = "".join(chr(c) for c in [76, 73])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-VWVUBY = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-VYFCRT = 358
-WAJVDQ = "".join(chr(c) for c in [80, 50, 50])
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = 453
-WIVDNQ = 326
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-WVUBYG = "".join(chr(c) for c in [70, 117, 108, 108])
-XBQFYL = 314
-XCHWDA = "".join(chr(c) for c in [67, 70, 71, 52])
-XEKVKZ = "".join(chr(c) for c in [51, 50, 75])
-XFEFJT = 272
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 330
-XNQTMF = 462
-XOIHBX = 475
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = 291
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-XYBQSN = "".join(chr(c) for c in [105, 110, 88, 77])
-YBQSNQ = "".join(chr(c) for c in [75, 54, 48, 48])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-YGDSBD = "".join(chr(c) for c in [75, 50, 48, 48])
-YIYWSK = 322
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = 323
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 465
-ZILXWA = "".join(chr(c) for c in [85, 76])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZTATDZ = 459
-ZUQEXL = 262
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ACMCVD = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-AJVDQL = [USOOQN, WAJVDQ]
-CMCVDS = [
-    YLJUIK,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    FYLJUI,
-    LJUIKF,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    BQFYLJ,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HUGTYI = [
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    JHIUSO,
-    OPHUGT,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    PHUGTY,
-]
-IUSOOQ = [IVLASS, PHUOJR]
-JJVYFC = [
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    NQLNMH,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    RJJJVY,
-    JJJVYF,
-]
-JUGSEL = [
-    MNHTBJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-LNMHXE = [
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-]
-LXWAJV = [ZILXWA, ILXWAJ]
-NIBXTI = [IDNIBX, DNIBXT]
-OACMCV = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    VOACMC,
-]
-QLAIID = [VDQLAI, DQLAII]
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VDNQGV = [
-    MNHTBJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    IVDNQG,
-]
-VKZILX = [HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VUBYGD = [VWVUBY, WVUBYG]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-ZVOACM = []
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -894,251 +19,745 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return MCVDSS
+        return 53
 
     @property
     def begin(self):
-        return CVDSSR
+        return 256
 
     @property
     def end(self):
-        return VDSSRU
+        return 479
 
     @property
     def all_device_keys(self):
-        return OACMCV
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ACMCVD
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return CMCVDS
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoWordStructAccessor(self.struct, IRYXBQ, RYXBQF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, IFJBIA, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, XPICXQ, None),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, LNMHXE, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, QXPICX, VKZILX, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, MHXEKV, ICXQIE, LXWAJV, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, MHXEKV, OQNRSJ, AJVDQL, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, MHXEKV, XPICXQ, QLAIID, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, MHXEKV, RSJMCB, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, MHXEKV, QIEFXQ, None),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, MHXEKV, IBXTIA, NIBXTI, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            BXTIAC: GeckoWordStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoWordStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, VUBYGD, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, JJVYFC, None, None, None
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JVYFCR: GeckoWordStructAccessor(self.struct, JVYFCR, VYFCRT, None),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, None),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, HUGTYI, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, HUGTYI, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, HUGTYI, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, HUGTYI, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, HUGTYI, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, VDNQGV, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, LASSAK),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, LASSAK),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, LASSAK),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, LASSAK),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, JUGSEL, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, LASSAK),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-log-54.py
+++ b/src/geckolib/driver/packs/inyj-log-54.py
@@ -12,886 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 53])
-AHEOCT = 308
-AJVDQL = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 466
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AONPYY = 266
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BDJQRJ = "".join(chr(c) for c in [75, 56, 53])
-BFEGZU = 310
-BHZVOA = 477
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BJEUTO = "".join(chr(c) for c in [80, 49, 72])
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BQNRXC = 448
-BQSNQL = "".join(chr(c) for c in [105, 110, 88, 77])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-BVWVUB = 301
-BWJYKL = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-BXYBQS = "".join(chr(c) for c in [77, 73, 65])
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 51])
-CMCVDS = "".join(chr(c) for c in [76, 73])
-CPQIPO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-CQBMJV = 317
-CQFFTT = 293
-CRTFMN = 358
-CTHBSK = 303
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 264
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 452
-DGKEAK = 464
-DJQRJJ = "".join(chr(c) for c in [75, 56])
-DNIBXT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-DNQGVU = 326
-DQLAII = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-DSBDJQ = "".join(chr(c) for c in [75, 50, 48, 48])
-DSSRUR = 54
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 272
-EFXQGL = 258
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = 289
-EKVKZI = "".join(chr(c) for c in [49, 54, 75])
-ELHBQN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-EUTOPH = "".join(chr(c) for c in [80, 50, 72])
-EXLSXU = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-FCRTFM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = 294
-FIKJPU = 453
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FJTACC = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FMNHTB = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = 350
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FWRKIN = 285
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = 463
-GDSBDJ = 357
-GETIXQ = 470
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-GQPLSP = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-GSELHB = 325
-GTYIYW = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-GYOUSP = 280
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 48])
-HBSKSO = 362
-HBVWVU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-HBXIBH = 475
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = 320
-HUGTYI = "".join(chr(c) for c in [80, 52, 76])
-HUOJRJ = 261
-HWDAFI = 451
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-IACQFF = 291
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-IBXTIA = "".join(chr(c) for c in [51, 48, 65])
-IBXYBQ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-IDUBSS = 296
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IGYOUS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-IIDNIB = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-IKFWRK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 54])
-ILXWAJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-INEJNI = 288
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = 270
-IVDNQG = 324
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-IYWSKW = 321
-JBIAMJ = 351
-JEUTOP = "".join(chr(c) for c in [80, 49, 76])
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JJJVYF = "".join(chr(c) for c in [75, 49, 48, 48])
-JJVYFC = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JMAOAW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-JMCBFE = 5
-JNIBXY = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 55])
-JQRJJJ = "".join(chr(c) for c in [75, 52])
-JTACCP = 273
-JUGSEL = 333
-JUIKFW = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-JUTYEK = "".join(chr(c) for c in [83, 84, 79, 80])
-JVDQLA = "".join(chr(c) for c in [80, 50, 50])
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [75, 51, 48, 48])
-JWMNZM = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JYKLGQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JYMOUN = "".join(chr(c) for c in [77, 69, 68])
-JZTATD = 457
-KCWAON = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-KEAKST = 465
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-KJPUNR = 454
-KLGQPL = 283
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-KPHUOJ = 306
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-KVKZIL = "".join(chr(c) for c in [51, 50, 75])
-KWIVDN = 323
-KXSJWM = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-KZILXW = "".join(chr(c) for c in [54, 52, 75])
-LAIIDN = "".join(chr(c) for c in [51, 79, 80])
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-LHBQNR = 332
-LIUXFE = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LJUIKF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-LKXSJW = 355
-LNMHXE = "".join(chr(c) for c in [75, 56, 48, 48])
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-LRAHEO = 1
-LSPFTS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LXWAJV = "".join(chr(c) for c in [85, 76])
-MAOAWB = 354
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = 469
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MJIGYO = 279
-MJMAOA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = 330
-MNHTBJ = 361
-MNZMJI = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-NBLKXS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-NEJNIB = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-NHTBJE = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-NIBXTI = "".join(chr(c) for c in [50, 53, 65])
-NIBXYB = "".join(chr(c) for c in [105, 110, 88, 69])
-NKMLOI = 329
-NMHXEK = "".join(chr(c) for c in [105, 110, 89, 74])
-NPYYLI = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-NQGVUN = "".join(chr(c) for c in [72, 84, 82])
-NQJYMO = 313
-NQLNMH = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-NQTMFZ = 461
-NRJZTA = 456
-NRSJMC = 3
-NRXCHW = 449
-NXNKML = 328
-OACMCV = 479
-OAWBSI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 474
-OIJUGS = 331
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 51, 76])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-OUSPBW = 281
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-PBWJYK = 352
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [80, 52, 72])
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-POUYNQ = 282
-PQIPOU = "".join(chr(c) for c in [67, 80, 79, 84])
-PUNRJZ = 455
-PYYLIU = 267
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 262
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-QFYLJU = 314
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QIEFXQ = 6
-QIPOUY = 274
-QJYMOU = "".join(chr(c) for c in [78, 79])
-QLAIID = "".join(chr(c) for c in [53, 79, 80])
-QLNMHX = "".join(chr(c) for c in [105, 110, 89, 84])
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 49])
-QPLSPF = 284
-QRJJJV = "".join(chr(c) for c in [75, 53])
-QSNQLN = "".join(chr(c) for c in [75, 54, 48, 48])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 57])
-RKINEJ = 287
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 50])
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [75, 52, 48, 48])
-SEMCGE = 468
-SIFJBI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SIRYXB = 309
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 275
-SKSOKP = 304
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-SNQLNM = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-SOKPHU = 305
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SPFTSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-SRURAZ = 479
-SSAKQX = 259
-SSRURA = 256
-SSUHBV = 299
-STSEMC = 467
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SXUJUT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-TACCPQ = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-TATDZX = 458
-TBJEUT = "".join(chr(c) for c in [78, 65])
-TDZXNQ = 459
-TFMNHT = 360
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 49, 76, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-TIXQVX = 471
-TMFZDG = 462
-TOPHUG = "".join(chr(c) for c in [80, 51, 72])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-TTIDUB = 295
-TYEKCW = "".join(chr(c) for c in [78, 69, 87])
-UBSSUH = 297
-UBYGDS = "".join(chr(c) for c in [70, 117, 108, 108])
-UGSELH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-UGTYIY = "".join(chr(c) for c in [66, 76, 79])
-UHBVWV = 300
-UIKFWR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-UJUTYE = "".join(chr(c) for c in [73, 68, 76, 69])
-UNBLKX = 353
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 56])
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-USOOQN = 260
-USPBWJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-UTOPHU = "".join(chr(c) for c in [80, 50, 76])
-UTYEKC = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-UYNQJY = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [52, 56, 75])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-VUBYGD = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VUNXNK = 327
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VXOIHB = 473
-VYFCRT = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-WBSIRY = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 52])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-WJYKLG = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-WMNZMJ = 277
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-WSKWIV = 322
-WVUBYG = 316
-XBQFYL = 311
-XCHWDA = 450
-XEKVKZ = 290
-XFEFJT = 271
-XIBHZV = 476
-XLSXUJ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 472
-XSJWMN = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-XTIACQ = 7
-XUJUTY = 263
-XWAJVD = "".join(chr(c) for c in [67, 69])
-XYBQSN = "".join(chr(c) for c in [68, 74, 83, 52])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-YEKCWA = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YGDSBD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-YKLGQP = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-YLIUXF = 268
-YLJUIK = 315
-YMOUNB = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-YNQJYM = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YOUSPB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = 257
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-YXBQFY = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YYLIUX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-ZMJIGY = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-ZVOACM = 478
-ZXNQTM = 460
-ACMCVD = []
-AIIDNI = [QLAIID, LAIIDN]
-BXTIAC = [NIBXTI, IBXTIA]
-BYGDSB = [VUBYGD, UBYGDS]
-CVDSSR = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-EKCWAO = [UJUTYE, JUTYEK, UTYEKC, TYEKCW, YEKCWA]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-JRJHIU = [IVLASS, UOJRJH, OJRJHI]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-LSXUJU = [EXLSXU, XLSXUJ]
-MCVDSS = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    CMCVDS,
-]
-MHXEKV = [
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-]
-MOUNBL = [QJYMOU, SAKQXP, JYMOUN, AKQXPI, YMOUNB]
-NZMJIG = [HFTHEC, MNZMJI, MNZMJI, MNZMJI]
-QGVUNX = [
-    TBJEUT,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    NQGVUN,
-]
-RYXBQF = [HFTHEC, IRYXBQ, IRYXBQ, IRYXBQ]
-SELHBQ = [
-    TBJEUT,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    OQNRSJ,
-]
-SOOQNR = [IVLASS, UOJRJH]
-TYIYWS = [
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    IUSOOQ,
-    UGTYIY,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    GTYIYW,
-]
-VDQLAI = [OOQNRS, JVDQLA]
-VDSSRU = [
-    JUIKFW,
-    BIAMJM,
-    MJMAOA,
-    PLSPFT,
-    KXSJWM,
-    LJUIKF,
-    UIKFWR,
-    ZMJIGY,
-    CPQIPO,
-    IFJBIA,
-    PFTSIF,
-    BWJYKL,
-    SPBWJY,
-    FYLJUI,
-    SPFTSI,
-    FJBIAM,
-    SIFJBI,
-    LGQPLS,
-    JMAOAW,
-    YKLGQP,
-    WJYKLG,
-    IAMJMA,
-    AWBSIR,
-    AMJMAO,
-    JYKLGQ,
-    TSIFJB,
-    LSPFTS,
-    GQPLSP,
-]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WAJVDQ = [LXWAJV, XWAJVD]
-YFCRTF = [
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    LNMHXE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-]
-ZILXWA = [EKVKZI, KVKZIL, VKZILX, KZILXW]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -899,252 +19,748 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return DSSRUR
+        return 54
 
     @property
     def begin(self):
-        return SSRURA
+        return 256
 
     @property
     def end(self):
-        return SRURAZ
+        return 479
 
     @property
     def all_device_keys(self):
-        return MCVDSS
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return CVDSSR
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdP1LTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return VDSSRU
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, LASSAK),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, QXPICX, JRJHIU, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, ICXQIE, JRJHIU, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, XPICXQ, JRJHIU, None, XPICXQ, None
+            "UdP1LTime": GeckoByteStructAccessor(self.struct, "UdP1LTime", 362, "ALL"),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, QIEFXQ, JRJHIU, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QXPICX, SOOQNR, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, QXPICX, LSXUJU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, EKCWAO, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            KCWAON: GeckoTimeStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, LASSAK),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, QEXLSX, ICXQIE, LSXUJU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, EKCWAO, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            YYLIUX: GeckoTimeStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, LASSAK),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, JTACCP, QXPICX, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, JTACCP, ICXQIE, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, JTACCP, NRSJMC, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, JTACCP, XPICXQ, None),
-            CPQIPO: GeckoBoolStructAccessor(self.struct, CPQIPO, JTACCP, JMCBFE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, ICXQIE, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, POUYNQ, NRSJMC, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, POUYNQ, JMCBFE, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, POUYNQ, QIEFXQ, None),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, MOUNBL, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, UNBLKX, JMCBFE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, UNBLKX, QIEFXQ, None),
-            BLKXSJ: GeckoWordStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, QIPOUY, LRAHEO, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoTempStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, USOOQN, JMCBFE, NZMJIG, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, MJIGYO, ICXQIE, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, MJIGYO, QIEFXQ, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, ICXQIE, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, LRAHEO, None),
-            USPBWJ: GeckoBoolStructAccessor(
-                self.struct, USPBWJ, OUSPBW, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, LRAHEO, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, NRSJMC, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, POUYNQ, QXPICX, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, POUYNQ, LRAHEO, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, ICXQIE, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, KLGQPL, NRSJMC, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, NRSJMC, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, QPLSPF, XPICXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, QPLSPF, JMCBFE, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, QPLSPF, QIEFXQ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, NRSJMC, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, XPICXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, FTSIFJ, JMCBFE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FTSIFJ, QIEFXQ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, ICXQIE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JBIAMJ, NRSJMC, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, PBWJYK, NRSJMC, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, UNBLKX, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, UNBLKX, LRAHEO, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, GYOUSP, QXPICX, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, KLGQPL, QXPICX, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, KLGQPL, LRAHEO, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, KLGQPL, XPICXQ, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, QXPICX, None),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, SIRYXB, LRAHEO, RYXBQF, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            YXBQFY: GeckoWordStructAccessor(self.struct, YXBQFY, XBQFYL, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YLJUIK, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, YLJUIK, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, JBIAMJ, QXPICX, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JBIAMJ, LRAHEO, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JBIAMJ, XPICXQ, None),
-            KFWRKI: GeckoWordStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, None),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, MHXEKV, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, QXPICX, ZILXWA, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, XEKVKZ, ICXQIE, WAJVDQ, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            AJVDQL: GeckoEnumStructAccessor(
-                self.struct, AJVDQL, XEKVKZ, NRSJMC, VDQLAI, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, XEKVKZ, XPICXQ, AIIDNI, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, XEKVKZ, JMCBFE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, XEKVKZ, QIEFXQ, None),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, XEKVKZ, XTIACQ, BXTIAC, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoWordStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, BYGDSB, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, YFCRTF, None, None, None
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            FCRTFM: GeckoWordStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, TYIYWS, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, TYIYWS, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, TYIYWS, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, TYIYWS, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, TYIYWS, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, QGVUNX, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, LASSAK),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, LASSAK),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, LASSAK),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, LASSAK),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, LASSAK),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, LASSAK),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, GSELHB, None, SELHBQ, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, LASSAK),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-log-55.py
+++ b/src/geckolib/driver/packs/inyj-log-55.py
@@ -12,883 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 54])
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 467
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BDJQRJ = "".join(chr(c) for c in [75, 52])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = 478
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [80, 50, 72])
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 449
-BQSNQL = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-BVWVUB = 316
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BXYBQS = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BYGDSB = 357
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 52])
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = 294
-CRTFMN = 360
-CTHBSK = 303
-CVDSSR = 55
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 453
-DGKEAK = 465
-DJQRJJ = "".join(chr(c) for c in [75, 53])
-DNIBXT = "".join(chr(c) for c in [51, 48, 65])
-DQLAII = "".join(chr(c) for c in [51, 79, 80])
-DSBDJQ = "".join(chr(c) for c in [75, 56, 53])
-DSSRUR = 479
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [105, 110, 88, 69])
-EKCWAO = 264
-EKVKZI = "".join(chr(c) for c in [52, 56, 75])
-ELHBQN = "".join(chr(c) for c in [67, 70, 71, 48])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-EUTOPH = "".join(chr(c) for c in [80, 51, 72])
-FCRTFM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = 295
-FIKJPU = 454
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-FWRKIN = 287
-FYLJUI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FZDGKE = 464
-GDSBDJ = "".join(chr(c) for c in [75, 52, 48, 48])
-GETIXQ = 471
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 49])
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-HBXIBH = 476
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = "".join(chr(c) for c in [80, 49, 72])
-HUGTYI = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 452
-HXEKVK = "".join(chr(c) for c in [49, 54, 75])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-IACQFF = 293
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-IBXTIA = 7
-IBXYBQ = "".join(chr(c) for c in [68, 74, 83, 52])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [50, 53, 65])
-IDUBSS = 297
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-IIDNIB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-IJUGSE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-IKFWRK = 285
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 55])
-ILXWAJ = "".join(chr(c) for c in [67, 69])
-INEJNI = 289
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IUXFEF = 271
-IVDNQG = 326
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-IYWSKW = 322
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [80, 50, 76])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = "".join(chr(c) for c in [75, 51, 48, 48])
-JJVYFC = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 56])
-JQRJJJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = 325
-JUIKFW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-JVHFTH = 319
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = 458
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 466
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-KINEJN = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KJPUNR = 455
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-KVKZIL = "".join(chr(c) for c in [54, 52, 75])
-KWIVDN = 324
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = 448
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = 470
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-MHXEKV = 290
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = 331
-MNHTBJ = 320
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NHTBJE = "".join(chr(c) for c in [78, 65])
-NIBXYB = "".join(chr(c) for c in [77, 73, 65])
-NKMLOI = 330
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = "".join(chr(c) for c in [75, 56, 48, 48])
-NQTMFZ = 462
-NRJZTA = 457
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 450
-NXNKML = 329
-NZMJIG = 279
-OACMCV = "".join(chr(c) for c in [76, 73])
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 475
-OIJUGS = 333
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [80, 52, 76])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [66, 76, 79])
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 456
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-QFYLJU = 315
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 327
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLNMHX = "".join(chr(c) for c in [105, 110, 89, 74])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 50])
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [75, 49, 48, 48])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-RKINEJ = 288
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 51])
-RYXBQF = 311
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [75, 56])
-SELHBQ = 332
-SEMCGE = 469
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-SNQLNM = "".join(chr(c) for c in [105, 110, 89, 84])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SSAKQX = 259
-SSUHBV = 300
-STSEMC = 468
-SUHBVW = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 459
-TBJEUT = "".join(chr(c) for c in [80, 49, 76])
-TDZXNQ = 460
-TFMNHT = 361
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TIXQVX = 472
-TMFZDG = 463
-TOPHUG = "".join(chr(c) for c in [80, 52, 72])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 296
-TYIYWS = 321
-UBSSUH = 299
-UBYGDS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-UHBVWV = 301
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 57])
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = "".join(chr(c) for c in [80, 51, 76])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = "".join(chr(c) for c in [72, 84, 82])
-VDQLAI = "".join(chr(c) for c in [53, 79, 80])
-VDSSRU = 256
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VUNXNK = 328
-VWVUBY = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VXOIHB = 474
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-WAJVDQ = "".join(chr(c) for c in [80, 50, 50])
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 53])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-WSKWIV = 323
-WVUBYG = "".join(chr(c) for c in [70, 117, 108, 108])
-XBQFYL = 314
-XCHWDA = 451
-XEKVKZ = "".join(chr(c) for c in [51, 50, 75])
-XFEFJT = 272
-XIBHZV = 477
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 473
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = 291
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-XYBQSN = "".join(chr(c) for c in [105, 110, 88, 77])
-YBQSNQ = "".join(chr(c) for c in [75, 54, 48, 48])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 358
-YGDSBD = "".join(chr(c) for c in [75, 50, 48, 48])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-ZILXWA = "".join(chr(c) for c in [85, 76])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-ZUQEXL = 262
-ZVOACM = 479
-ZXNQTM = 461
-ACMCVD = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    OACMCV,
-]
-AJVDQL = [USOOQN, WAJVDQ]
-CMCVDS = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-DNQGVU = [
-    NHTBJE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    VDNQGV,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-IUSOOQ = [IVLASS, PHUOJR]
-JVYFCR = [
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    NQLNMH,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-LNMHXE = [
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-]
-LXWAJV = [ZILXWA, ILXWAJ]
-MCVDSS = [
-    YLJUIK,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    FYLJUI,
-    LJUIKF,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    BQFYLJ,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-NIBXTI = [IDNIBX, DNIBXT]
-QLAIID = [VDQLAI, DQLAII]
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UGSELH = [
-    NHTBJE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-UGTYIY = [
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    JHIUSO,
-    PHUGTY,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HUGTYI,
-]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VKZILX = [HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VOACMC = []
-VUBYGD = [VWVUBY, WVUBYG]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -896,251 +19,746 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return CVDSSR
+        return 55
 
     @property
     def begin(self):
-        return VDSSRU
+        return 256
 
     @property
     def end(self):
-        return DSSRUR
+        return 479
 
     @property
     def all_device_keys(self):
-        return ACMCVD
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return CMCVDS
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return MCVDSS
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoWordStructAccessor(self.struct, IRYXBQ, RYXBQF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, IFJBIA, QXPICX, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, LRAHEO, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, XPICXQ, None),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, LNMHXE, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, QXPICX, VKZILX, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, MHXEKV, ICXQIE, LXWAJV, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, MHXEKV, OQNRSJ, AJVDQL, None, ICXQIE, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, MHXEKV, XPICXQ, QLAIID, None, ICXQIE, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, MHXEKV, RSJMCB, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, MHXEKV, QIEFXQ, None),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, MHXEKV, IBXTIA, NIBXTI, None, ICXQIE, None
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            BXTIAC: GeckoWordStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoWordStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, VUBYGD, None, ICXQIE, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, JVYFCR, None, None, None
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            VYFCRT: GeckoWordStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, UGTYIY, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, UGTYIY, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, UGTYIY, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, UGTYIY, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, UGTYIY, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, DNQGVU, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, LASSAK),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, LASSAK),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, LASSAK),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, LASSAK),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, LASSAK),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, LASSAK),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, UGSELH, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, LASSAK),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-log-56.py
+++ b/src/geckolib/driver/packs/inyj-log-56.py
@@ -12,902 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 271
-ACMCVD = 477
-ACQFFT = "".join(chr(c) for c in [51, 48, 65])
-AFIKJP = 450
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [80, 50, 50])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AONPYY = "".join(chr(c) for c in [78, 69, 87])
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 456
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-AZMKQT = 256
-BFEGZU = 310
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BJEUTO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-BLKXSJ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-BMJVHF = 256
-BQFYLJ = 309
-BQNRXC = 325
-BQSNQL = "".join(chr(c) for c in [105, 110, 88, 69])
-BSIRYX = 354
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = 295
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-BWJYKL = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 473
-BXTIAC = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-BXYBQS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BYGDSB = 301
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = 467
-CHWDAF = 448
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-CPQIPO = 272
-CQBMJV = 317
-CRTFMN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(chr(c) for c in [83, 84, 79, 80])
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 50])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-DJQRJJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-DNIBXT = "".join(chr(c) for c in [53, 79, 80])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-DQLAII = "".join(chr(c) for c in [67, 69])
-DSBDJQ = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-DUBSSU = 294
-DZXNQT = 457
-EAKSTS = 463
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = 268
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-EKCWAO = 263
-EKVKZI = "".join(chr(c) for c in [75, 56, 48, 48])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-EMCGET = 466
-EOCTHB = 308
-ETIXQV = 468
-EUTOPH = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-EXLSXU = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-FCRTFM = "".join(chr(c) for c in [75, 49, 48, 48])
-FEFJTA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 51])
-FJBIAM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-FJTACC = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FTHECV = 319
-FTSIFJ = 284
-FTTIDU = 291
-FWRKIN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-GDSBDJ = 316
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-GKEAKS = 462
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 51, 72])
-GVUNXN = 324
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-HBSKSO = 303
-HBVWVU = 297
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-HUGTYI = "".join(chr(c) for c in [80, 50, 72])
-HUOJRJ = 261
-HWDAFI = "".join(chr(c) for c in [67, 70, 71, 49])
-HXEKVK = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-HZVOAC = 475
-IACQFF = "".join(chr(c) for c in [50, 53, 65])
-IAMJMA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-IBHZVO = 474
-IBXYBQ = 288
-ICXQIE = 0
-IDNIBX = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-IDUBSS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-IGYOUS = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IHBXIB = 472
-IJUGSE = 329
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IKJPUN = 451
-ILXWAJ = "".join(chr(c) for c in [49, 54, 75])
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 469
-IYWSKW = "".join(chr(c) for c in [80, 52, 76])
-JBIAMJ = 350
-JEUTOP = 361
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = 277
-JJJVYF = "".join(chr(c) for c in [75, 56, 53])
-JJVYFC = "".join(chr(c) for c in [75, 56])
-JMAOAW = 351
-JMCBFE = 5
-JNIBXY = 287
-JPUNRJ = 452
-JQRJJJ = 357
-JTACCP = 270
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JVDQLA = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 52])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-JYKLGQ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JYMOUN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 55])
-KCWAON = "".join(chr(c) for c in [73, 68, 76, 69])
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-KFWRKI = 315
-KINEJN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 52])
-KLGQPL = 352
-KMLOIJ = 327
-KPHUOJ = 306
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = 464
-KVKZIL = "".join(chr(c) for c in [105, 110, 89, 74])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KXSJWM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-LAIIDN = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-LHBQNR = 333
-LIUXFE = 266
-LJUIKF = 311
-LNMHXE = "".join(chr(c) for c in [105, 110, 88, 77])
-LOIJUG = 328
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 283
-LSXUJU = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-LXWAJV = "".join(chr(c) for c in [51, 50, 75])
-MAOAWB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-MCVDSS = 478
-MFZDGK = 460
-MHXEKV = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-MJIGYO = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-MJMAOA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-MNZMJI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-MOUNBL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-NBLKXS = "".join(chr(c) for c in [77, 69, 68])
-NEJNIB = 285
-NHTBJE = 358
-NIBXTI = "".join(chr(c) for c in [51, 79, 80])
-NIBXYB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [75, 54, 48, 48])
-NQGVUN = 323
-NQJYMO = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NQLNMH = "".join(chr(c) for c in [68, 74, 83, 52])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 54])
-NRSJMC = 3
-NRXCHW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NXNKML = "".join(chr(c) for c in [72, 84, 82])
-NZMJIG = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-OAWBSI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [80, 49, 72])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = 313
-OUSPBW = 279
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-PBWJYK = 280
-PFTSIF = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-PHUGTY = "".join(chr(c) for c in [80, 49, 76])
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-POUYNQ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-PQIPOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 53])
-PYYLIU = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 364
-QFFTTI = 7
-QFYLJU = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-QIEFXQ = 2
-QIPOUY = 273
-QJYMOU = 282
-QLNMHX = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QPLSPF = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-QRJJJV = "".join(chr(c) for c in [75, 50, 48, 48])
-QSNQLN = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-QTMFZD = 459
-QVXOIH = 470
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 56
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [75, 52, 48, 48])
-RJZTAT = 454
-RKINEJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = "".join(chr(c) for c in [75, 51, 48, 48])
-RXCHWD = 332
-RYXBQF = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [70, 117, 108, 108])
-SELHBQ = 331
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-SIFJBI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SIRYXB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-SKSOKP = 304
-SNQLNM = "".join(chr(c) for c in [77, 73, 65])
-SOKPHU = 305
-SPBWJY = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-SPFTSI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-SSRURA = "".join(chr(c) for c in [76, 73])
-SSUHBV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-SUHBVW = 296
-SXUJUT = 367
-TACCPQ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 56])
-TBJEUT = 360
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 57])
-TFMNHT = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-TIDUBS = 293
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TOPHUG = "".join(chr(c) for c in [78, 65])
-TSEMCG = 465
-TSIFJB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TYIYWS = "".join(chr(c) for c in [80, 51, 76])
-UBSSUH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-UBYGDS = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-UGSELH = 330
-UGTYIY = "".join(chr(c) for c in [80, 50, 76])
-UHBVWV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-UIKFWR = 314
-UJUTYE = 262
-UNBLKX = "".join(chr(c) for c in [78, 79])
-UNRJZT = 453
-UNXNKM = 326
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-USOOQN = 260
-USPBWJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-UTOPHU = 320
-UTYEKC = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-VDNQGV = 322
-VDQLAI = "".join(chr(c) for c in [85, 76])
-VDSSRU = 479
-VHFTHE = 6
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 476
-VUBYGD = 300
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-VWVUBY = 299
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-VYFCRT = "".join(chr(c) for c in [75, 53])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [54, 52, 75])
-WAONPY = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-WBSIRY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-WDAFIK = 449
-WIVDNQ = 321
-WJYKLG = 281
-WMNZMJ = 355
-WRKINE = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-WSKWIV = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WVUBYG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-XBQFYL = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-XCHWDA = "".join(chr(c) for c in [67, 70, 71, 48])
-XEKVKZ = "".join(chr(c) for c in [105, 110, 89, 84])
-XFEFJT = 267
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-XLSXUJ = 365
-XNQTMF = 458
-XOIHBX = 471
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-XSJWMN = 353
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-XUJUTY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XWAJVD = "".join(chr(c) for c in [52, 56, 75])
-XYBQSN = 289
-YBQSNQ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YFCRTF = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-YGDSBD = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-YIYWSK = "".join(chr(c) for c in [80, 52, 72])
-YKLGQP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-YLJUIK = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YMOUNB = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YNQJYM = "".join(chr(c) for c in [67, 80, 79, 84])
-YOUSPB = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-YYLIUX = 264
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 461
-ZILXWA = 290
-ZMJIGY = 275
-ZMKQTD = 479
-ZTATDZ = 455
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-AJVDQL = [ILXWAJ, LXWAJV, XWAJVD, WAJVDQ]
-BDJQRJ = [DSBDJQ, SBDJQR]
-CQFFTT = [IACQFF, ACQFFT]
-DSSRUR = []
-FMNHTB = [
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    EKVKZI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-]
-FYLJUI = [HECVYY, QFYLJU, QFYLJU, QFYLJU]
-GYOUSP = [HECVYY, IGYOUS, IGYOUS, IGYOUS]
-IBXTIA = [DNIBXT, NIBXTI]
-IIDNIB = [OOQNRS, AIIDNI]
-JRJHIU = [ASSAKQ, UOJRJH, OJRJHI]
-LKXSJW = [UNBLKX, QXPICX, NBLKXS, XPICXQ, BLKXSJ]
-NPYYLI = [KCWAON, CWAONP, WAONPY, AONPYY, ONPYYL]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QLAIID = [VDQLAI, DQLAII]
-QNRXCH = [
-    TOPHUG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    OQNRSJ,
-]
-RAHEOC = [ASSAKQ, LRAHEO]
-RURAZM = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-SKWIVD = [
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    IUSOOQ,
-    YWSKWI,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WSKWIV,
-]
-SOOQNR = [ASSAKQ, UOJRJH]
-SRURAZ = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    UQEXLS,
-    EXLSXU,
-    LSXUJU,
-    SSRURA,
-]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TYEKCW = [JUTYEK, UTYEKC]
-URAZMK = [
-    WRKINE,
-    MAOAWB,
-    AWBSIR,
-    TSIFJB,
-    MNZMJI,
-    FWRKIN,
-    RKINEJ,
-    YOUSPB,
-    UYNQJY,
-    AMJMAO,
-    FJBIAM,
-    LGQPLS,
-    YKLGQP,
-    IKFWRK,
-    IFJBIA,
-    MJMAOA,
-    IAMJMA,
-    SPFTSI,
-    WBSIRY,
-    PLSPFT,
-    GQPLSP,
-    AOAWBS,
-    RYXBQF,
-    OAWBSI,
-    QPLSPF,
-    BIAMJM,
-    SIFJBI,
-    PFTSIF,
-]
-VKZILX = [
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-]
-XNKMLO = [
-    TOPHUG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NXNKML,
-]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -915,257 +19,768 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return RAZMKQ
+        return 56
 
     @property
     def begin(self):
-        return AZMKQT
+        return 256
 
     @property
     def end(self):
-        return ZMKQTD
+        return 479
 
     @property
     def all_device_keys(self):
-        return SRURAZ
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return RURAZM
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return URAZMK
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, SAKQXP),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, ICXQIE, JRJHIU, None, CXQIEF, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, QIEFXQ, JRJHIU, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, CXQIEF, JRJHIU, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, VHFTHE, JRJHIU, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, SOOQNR, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, ZUQEXL, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EXLSXU: GeckoWordStructAccessor(self.struct, EXLSXU, XLSXUJ, None),
-            LSXUJU: GeckoWordStructAccessor(self.struct, LSXUJU, SXUJUT, SAKQXP),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, ICXQIE, TYEKCW, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, NPYYLI, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            PYYLIU: GeckoTimeStructAccessor(self.struct, PYYLIU, YYLIUX, SAKQXP),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, SAKQXP),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UJUTYE, QIEFXQ, TYEKCW, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, NPYYLI, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            FEFJTA: GeckoTimeStructAccessor(self.struct, FEFJTA, EFJTAC, SAKQXP),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, SAKQXP),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, ICXQIE, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, QIEFXQ, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, NRSJMC, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, QIPOUY, CXQIEF, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, QIPOUY, JMCBFE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, JVHFTH, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, QJYMOU, NRSJMC, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, QJYMOU, JMCBFE, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, QJYMOU, VHFTHE, None),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, JMCBFE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, VHFTHE, None),
-            JWMNZM: GeckoWordStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, JVHFTH, AHEOCT, None),
-            NZMJIG: GeckoTempStructAccessor(self.struct, NZMJIG, ZMJIGY, None),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, None),
-            IGYOUS: GeckoEnumStructAccessor(
-                self.struct, IGYOUS, USOOQN, JMCBFE, GYOUSP, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, QIEFXQ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, OUSPBW, VHFTHE, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, QIEFXQ, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, WJYKLG, AHEOCT, None),
-            JYKLGQ: GeckoBoolStructAccessor(
-                self.struct, JYKLGQ, WJYKLG, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, JVHFTH, NRSJMC, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QJYMOU, ICXQIE, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, QJYMOU, AHEOCT, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, LSPFTS, NRSJMC, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, NRSJMC, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, CXQIEF, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, FTSIFJ, JMCBFE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FTSIFJ, VHFTHE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, NRSJMC, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JBIAMJ, CXQIEF, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, JBIAMJ, JMCBFE, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, JBIAMJ, VHFTHE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, QIEFXQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, NRSJMC, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, KLGQPL, NRSJMC, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, XSJWMN, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, XSJWMN, AHEOCT, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, ICXQIE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, PBWJYK, ICXQIE, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, LSPFTS, ICXQIE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, LSPFTS, AHEOCT, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, LSPFTS, CXQIEF, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, ICXQIE, None),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, BQFYLJ, AHEOCT, FYLJUI, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            YLJUIK: GeckoWordStructAccessor(self.struct, YLJUIK, LJUIKF, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, KFWRKI, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, KFWRKI, AHEOCT, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, JMAOAW, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, JMAOAW, AHEOCT, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, JMAOAW, CXQIEF, None),
-            INEJNI: GeckoWordStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, None),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, VKZILX, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, ICXQIE, AJVDQL, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, ZILXWA, QIEFXQ, QLAIID, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, ZILXWA, NRSJMC, IIDNIB, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, ZILXWA, CXQIEF, IBXTIA, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, ZILXWA, JMCBFE, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, ZILXWA, VHFTHE, None),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, ZILXWA, QFFTTI, CQFFTT, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            FFTTID: GeckoWordStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, None),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, None),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, None),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, None),
-            UHBVWV: GeckoWordStructAccessor(self.struct, UHBVWV, HBVWVU, None),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoWordStructAccessor(self.struct, UBYGDS, BYGDSB, None),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, BDJQRJ, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, FMNHTB, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            MNHTBJ: GeckoWordStructAccessor(self.struct, MNHTBJ, NHTBJE, None),
-            HTBJEU: GeckoByteStructAccessor(self.struct, HTBJEU, TBJEUT, None),
-            BJEUTO: GeckoByteStructAccessor(self.struct, BJEUTO, JEUTOP, None),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, SKWIVD, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, SKWIVD, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, SKWIVD, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, SKWIVD, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, SKWIVD, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, XNKMLO, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, SAKQXP),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, SAKQXP),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, QNRXCH, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            NRXCHW: GeckoByteStructAccessor(self.struct, NRXCHW, RXCHWD, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-log-57.py
+++ b/src/geckolib/driver/packs/inyj-log-57.py
@@ -12,913 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 268
-ACMCVD = 475
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-AFIKJP = 448
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [67, 69])
-AJVDQL = "".join(chr(c) for c in [51, 50, 75])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-AMJMAO = 350
-AOAWBS = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-AONPYY = 263
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 454
-AWBSIR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BDJQRJ = 316
-BFEGZU = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BIAMJM = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-BJEUTO = 358
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BQNRXC = 331
-BQSNQL = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BSIRYX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-BVWVUB = 296
-BWJYKL = 279
-BXIBHZ = 471
-BXTIAC = "".join(chr(c) for c in [53, 79, 80])
-BXYBQS = 287
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-CBFEGZ = "".join(chr(c) for c in [76, 49, 50, 48])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = 465
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-CPQIPO = 270
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-CRTFMN = "".join(chr(c) for c in [75, 53])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 48])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-DJQRJJ = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-DNIBXT = "".join(chr(c) for c in [80, 50, 50])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-DSBDJQ = 301
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-DZXNQT = 455
-EAKSTS = 461
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EJNIBX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-EKCWAO = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-EKVKZI = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-EMCGET = 464
-EOCTHB = 308
-ETIXQV = 466
-EUTOPH = 360
-EXLSXU = "".join(chr(c) for c in [70, 85, 76, 76])
-FCRTFM = "".join(chr(c) for c in [75, 52])
-FEFJTA = 266
-FEGZUQ = 5
-FFTTID = "".join(chr(c) for c in [51, 48, 65])
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 49])
-FJBIAM = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-FJTACC = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-FMNHTB = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-FTHECV = 319
-FTSIFJ = 283
-FWRKIN = 314
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-GKEAKS = 460
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 49, 76])
-GVUNXN = 322
-GYOUSP = 275
-GZUQEX = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HBSKSO = 370
-HBVWVU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [76, 79, 87])
-HUGTYI = "".join(chr(c) for c in [78, 65])
-HUOJRJ = 306
-HWDAFI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-HXEKVK = "".join(chr(c) for c in [105, 110, 88, 77])
-HZVOAC = 473
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-IAMJMA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IBHZVO = 472
-IBXTIA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-IBXYBQ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-IDUBSS = 291
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = 284
-IGYOUS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IHBXIB = 470
-IJUGSE = 327
-IKFWRK = 311
-IKJPUN = 449
-INEJNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-IUXFEF = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IVDNQG = "".join(chr(c) for c in [65, 85, 88])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 467
-IYWSKW = "".join(chr(c) for c in [80, 51, 72])
-JBIAMJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-JEUTOP = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-JHIUSO = "".join(chr(c) for c in [72, 73, 71, 72])
-JIGYOU = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-JJJVYF = 357
-JJVYFC = "".join(chr(c) for c in [75, 50, 48, 48])
-JMAOAW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-JMCBFE = "".join(chr(c) for c in [79, 51])
-JNIBXY = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JPUNRJ = 450
-JQRJJJ = "".join(chr(c) for c in [70, 117, 108, 108])
-JRJHIU = "".join(chr(c) for c in [80, 49])
-JTACCP = 267
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-JUTYEK = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-JVDQLA = "".join(chr(c) for c in [52, 56, 75])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 52, 48, 48])
-JYKLGQ = 280
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 53])
-KCWAON = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-KFWRKI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KINEJN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 50])
-KLGQPL = 281
-KMLOIJ = 326
-KPHUOJ = 305
-KQTDKH = 57
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-KSTSEM = 462
-KVKZIL = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-KWIVDN = "".join(chr(c) for c in [66, 76, 79])
-KXSJWM = "".join(chr(c) for c in [78, 79])
-KZILXW = "".join(chr(c) for c in [75, 56, 48, 48])
-LAIIDN = "".join(chr(c) for c in [85, 76])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-LHBQNR = 330
-LJUIKF = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-LKXSJW = 313
-LNMHXE = "".join(chr(c) for c in [77, 73, 65])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LSXUJU = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-LXWAJV = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-MAOAWB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-MCBFEG = 3
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-MCVDSS = 476
-MFZDGK = 458
-MHXEKV = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-MJIGYO = 355
-MJMAOA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = "".join(chr(c) for c in [72, 84, 82])
-MNHTBJ = "".join(chr(c) for c in [75, 51, 48, 48])
-MNZMJI = 353
-MOUNBL = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NBLKXS = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-NHTBJE = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-NIBXYB = 285
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NMHXEK = "".join(chr(c) for c in [68, 74, 83, 52])
-NPYYLI = "".join(chr(c) for c in [83, 84, 79, 80])
-NQGVUN = 321
-NQJYMO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-NQLNMH = "".join(chr(c) for c in [105, 110, 88, 69])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 57])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 52])
-NRXCHW = 333
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NZMJIG = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-OAWBSI = 351
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-OJRJHI = 369
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [73, 68, 76, 69])
-OOQNRS = "".join(chr(c) for c in [80, 52])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-OQNRSJ = "".join(chr(c) for c in [80, 53])
-OUNBLK = 282
-OUSPBW = 277
-OUYNQJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PBWJYK = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-PFTSIF = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PHUGTY = 320
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-POUYNQ = 272
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 51])
-PYYLIU = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-QFFTTI = "".join(chr(c) for c in [50, 53, 65])
-QFYLJU = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-QIEFXQ = 2
-QIPOUY = 271
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-QLNMHX = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-QNRSJM = 260
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-QPLSPF = 352
-QSNQLN = 289
-QTDKHT = 256
-QTMFZD = 457
-QVXOIH = 468
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [76, 73])
-RJHIUS = 261
-RJJJVY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-RJZTAT = 452
-RKINEJ = 315
-RSJMCB = "".join(chr(c) for c in [66, 76])
-RTFMNH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-RURAZM = 479
-RXCHWD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-RYXBQF = 354
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SELHBQ = 329
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-SIFJBI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-SJMCBF = "".join(chr(c) for c in [67, 80])
-SJWMNZ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-SKSOKP = 303
-SKWIVD = "".join(chr(c) for c in [80, 52, 76])
-SNQLNM = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-SOKPHU = 304
-SOOQNR = "".join(chr(c) for c in [80, 51])
-SPFTSI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-SSRURA = 478
-SSUHBV = 294
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-SUHBVW = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-SXUJUT = 364
-TACCPQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 54])
-TBJEUT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-TDKHTZ = 479
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 55])
-TFMNHT = "".join(chr(c) for c in [75, 49, 48, 48])
-THBSKS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-TOPHUG = 361
-TSEMCG = 463
-TSIFJB = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-TTIDUB = 7
-TYEKCW = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 50, 72])
-UBSSUH = 293
-UBYGDS = 299
-UGSELH = 328
-UGTYIY = "".join(chr(c) for c in [80, 49, 72])
-UHBVWV = 295
-UIKFWR = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-UJUTYE = 365
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-UNRJZT = 451
-UNXNKM = 323
-UOJRJH = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-UQEXLS = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-USOOQN = "".join(chr(c) for c in [80, 50])
-USPBWJ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-UTOPHU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-UTYEKC = 367
-UXFEFJ = 264
-UYNQJY = 273
-VDQLAI = "".join(chr(c) for c in [54, 52, 75])
-VDSSRU = 477
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [105, 110, 89, 84])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 474
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-VYFCRT = "".join(chr(c) for c in [75, 56, 53])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [49, 54, 75])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-WDAFIK = 332
-WIVDNQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WJYKLG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-WMNZMJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-WRKINE = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-WSKWIV = "".join(chr(c) for c in [80, 52, 72])
-WVUBYG = 297
-XBQFYL = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-XCHWDA = 325
-XEKVKZ = "".join(chr(c) for c in [75, 54, 48, 48])
-XFEFJT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XNKMLO = 324
-XNQTMF = 456
-XOIHBX = 469
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-XSJWMN = "".join(chr(c) for c in [77, 69, 68])
-XTIACQ = "".join(chr(c) for c in [51, 79, 80])
-XUJUTY = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-XWAJVD = 290
-XYBQSN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-YBQSNQ = 288
-YEKCWA = 262
-YFCRTF = "".join(chr(c) for c in [75, 56])
-YGDSBD = 300
-YIYWSK = "".join(chr(c) for c in [80, 50, 76])
-YKLGQP = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YLIUXF = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YLJUIK = 309
-YMOUNB = "".join(chr(c) for c in [67, 80, 79, 84])
-YNQJYM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YOUSPB = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 51, 76])
-YXBQFY = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(chr(c) for c in [78, 69, 87])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 459
-ZILXWA = "".join(chr(c) for c in [105, 110, 89, 74])
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-ZTATDZ = 453
-ZUQEXL = 310
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 56])
-AZMKQT = [
-    JRJHIU,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    RSJMCB,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    BFEGZU,
-    EGZUQE,
-    GZUQEX,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    RAZMKQ,
-]
-CHWDAF = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SJMCBF,
-]
-CWAONP = [EKCWAO, KCWAON]
-DQLAII = [WAJVDQ, AJVDQL, JVDQLA, VDQLAI]
-FTTIDU = [QFFTTI, FFTTID]
-HTBJEU = [
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    KZILXW,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-]
-IIDNIB = [LAIIDN, AIIDNI]
-ILXWAJ = [
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-]
-IUSOOQ = [ASSAKQ, JHIUSO, HIUSOO]
-JUIKFW = [HECVYY, LJUIKF, LJUIKF, LJUIKF]
-JWMNZM = [KXSJWM, QXPICX, XSJWMN, XPICXQ, SJWMNZ]
-LIUXFE = [ONPYYL, NPYYLI, PYYLIU, YYLIUX, YLIUXF]
-LOIJUG = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    MLOIJU,
-]
-MKQTDK = [
-    INEJNI,
-    AWBSIR,
-    SIRYXB,
-    FJBIAM,
-    JIGYOU,
-    KINEJN,
-    NEJNIB,
-    PBWJYK,
-    JYMOUN,
-    MAOAWB,
-    IAMJMA,
-    PLSPFT,
-    GQPLSP,
-    WRKINE,
-    BIAMJM,
-    AOAWBS,
-    JMAOAW,
-    TSIFJB,
-    IRYXBQ,
-    PFTSIF,
-    LSPFTS,
-    WBSIRY,
-    BQFYLJ,
-    BSIRYX,
-    SPFTSI,
-    MJMAOA,
-    JBIAMJ,
-    SIFJBI,
-]
-NIBXTI = [RSJMCB, DNIBXT]
-NRSJMC = [ASSAKQ, JHIUSO]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QRJJJV = [DJQRJJ, JQRJJJ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SPBWJY = [HECVYY, USPBWJ, USPBWJ, USPBWJ]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TIACQF = [BXTIAC, XTIACQ]
-URAZMK = []
-VDNQGV = [
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    OQNRSJ,
-    KWIVDN,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IVDNQG,
-]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-ZMKQTD = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -926,260 +19,811 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return KQTDKH
+        return 57
 
     @property
     def begin(self):
-        return QTDKHT
+        return 256
 
     @property
     def end(self):
-        return TDKHTZ
+        return 479
 
     @property
     def all_device_keys(self):
-        return AZMKQT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ZMKQTD
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return MKQTDK
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, ICXQIE, IUSOOQ, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, RJHIUS, QIEFXQ, IUSOOQ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, RJHIUS, CXQIEF, IUSOOQ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, RJHIUS, VHFTHE, IUSOOQ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, ICXQIE, NRSJMC, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, QNRSJM, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, QNRSJM, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, QNRSJM, MCBFEG, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, QNRSJM, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, QNRSJM, FEGZUQ, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, QNRSJM, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XLSXUJ, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            XUJUTY: GeckoWordStructAccessor(self.struct, XUJUTY, UJUTYE, None),
-            JUTYEK: GeckoWordStructAccessor(self.struct, JUTYEK, UTYEKC, SAKQXP),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, ICXQIE, CWAONP, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, LIUXFE, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            IUXFEF: GeckoTimeStructAccessor(self.struct, IUXFEF, UXFEFJ, SAKQXP),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, SAKQXP),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YEKCWA, QIEFXQ, CWAONP, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, LIUXFE, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            TACCPQ: GeckoTimeStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, SAKQXP),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, UYNQJY, ICXQIE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, UYNQJY, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, UYNQJY, MCBFEG, None),
-            QJYMOU: GeckoBoolStructAccessor(self.struct, QJYMOU, UYNQJY, CXQIEF, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, UYNQJY, FEGZUQ, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, JVHFTH, QIEFXQ, None),
-            MOUNBL: GeckoBoolStructAccessor(self.struct, MOUNBL, OUNBLK, MCBFEG, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, OUNBLK, FEGZUQ, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, OUNBLK, VHFTHE, None),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, JWMNZM, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, MNZMJI, FEGZUQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, MNZMJI, VHFTHE, None),
-            ZMJIGY: GeckoWordStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, JVHFTH, AHEOCT, None),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, None),
-            YOUSPB: GeckoTempStructAccessor(self.struct, YOUSPB, OUSPBW, None),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, QNRSJM, FEGZUQ, SPBWJY, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, QIEFXQ, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, QIEFXQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(
-                self.struct, LGQPLS, KLGQPL, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, AHEOCT, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, JVHFTH, MCBFEG, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, OUNBLK, ICXQIE, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, OUNBLK, AHEOCT, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, QIEFXQ, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, MCBFEG, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, MCBFEG, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, CXQIEF, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, IFJBIA, FEGZUQ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IFJBIA, VHFTHE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, AMJMAO, MCBFEG, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, AMJMAO, CXQIEF, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, AMJMAO, FEGZUQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AMJMAO, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QIEFXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, MCBFEG, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, QPLSPF, MCBFEG, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, MNZMJI, ICXQIE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, MNZMJI, AHEOCT, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, ICXQIE, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, JYKLGQ, ICXQIE, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, FTSIFJ, ICXQIE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, FTSIFJ, AHEOCT, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FTSIFJ, CXQIEF, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YLJUIK, ICXQIE, None),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, YLJUIK, AHEOCT, JUIKFW, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, ICXQIE, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, RKINEJ, AHEOCT, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, OAWBSI, ICXQIE, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, OAWBSI, AHEOCT, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, OAWBSI, CXQIEF, None),
-            JNIBXY: GeckoWordStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoByteStructAccessor(self.struct, IBXYBQ, BXYBQS, None),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, ILXWAJ, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, ICXQIE, DQLAII, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, XWAJVD, QIEFXQ, IIDNIB, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, XWAJVD, MCBFEG, NIBXTI, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, XWAJVD, CXQIEF, TIACQF, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, XWAJVD, FEGZUQ, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, XWAJVD, VHFTHE, None),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, XWAJVD, TTIDUB, FTTIDU, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoWordStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoWordStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, QRJJJV, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, JJJVYF, None, HTBJEU, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            TBJEUT: GeckoWordStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, VDNQGV, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, VDNQGV, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, VDNQGV, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, VDNQGV, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, VDNQGV, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, LOIJUG, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, CHWDAF, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-log-58.py
+++ b/src/geckolib/driver/packs/inyj-log-58.py
@@ -12,940 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 268
-ACMCVD = 473
-ACQFFT = "".join(chr(c) for c in [53, 79, 80])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [54, 52, 75])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-AMJMAO = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-AOAWBS = 350
-AONPYY = 263
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 452
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-BDJQRJ = 300
-BFEGZU = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-BIAMJM = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-BJEUTO = "".join(chr(c) for c in [75, 51, 48, 48])
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-BQNRXC = 329
-BQSNQL = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-BSIRYX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BVWVUB = 294
-BWJYKL = 279
-BXIBHZ = 469
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-BXYBQS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-CBFEGZ = "".join(chr(c) for c in [76, 49, 50, 48])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = 463
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-CPQIPO = 270
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [51, 79, 80])
-CRTFMN = "".join(chr(c) for c in [75, 52, 48, 48])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CXQIEF = 4
-DAFIKJ = 325
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-DNIBXT = "".join(chr(c) for c in [85, 76])
-DNQGVU = "".join(chr(c) for c in [66, 76, 79])
-DQLAII = "".join(chr(c) for c in [49, 54, 75])
-DSBDJQ = 299
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-DZXNQT = 453
-EAKSTS = 459
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EJNIBX = 315
-EKCWAO = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-EKVKZI = "".join(chr(c) for c in [68, 74, 83, 52])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-EMCGET = 462
-EOCTHB = 308
-ETIXQV = 464
-EXLSXU = "".join(chr(c) for c in [70, 85, 76, 76])
-FCRTFM = "".join(chr(c) for c in [75, 50, 48, 48])
-FEFJTA = 266
-FEGZUQ = 5
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-FIKJPU = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-FJBIAM = 283
-FJTACC = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-FMNHTB = "".join(chr(c) for c in [75, 52])
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 57])
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-GKEAKS = 458
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-GYOUSP = 275
-GZUQEX = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-HBSKSO = 370
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [76, 79, 87])
-HTBJEU = "".join(chr(c) for c in [75, 49, 48, 48])
-HTZBBE = 256
-HUGTYI = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-HUOJRJ = 306
-HWDAFI = 333
-HXEKVK = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-HZVOAC = 471
-IACQFF = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-IAMJMA = 284
-IBHZVO = 470
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-IDUBSS = "".join(chr(c) for c in [51, 48, 65])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-IGYOUS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IHBXIB = 468
-IJUGSE = 326
-IKFWRK = 309
-IKJPUN = 332
-ILXWAJ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-INEJNI = 314
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-IUXFEF = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IVDNQG = "".join(chr(c) for c in [80, 52, 72])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 465
-IYWSKW = "".join(chr(c) for c in [80, 49, 72])
-JBIAMJ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-JEUTOP = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JHIUSO = "".join(chr(c) for c in [72, 73, 71, 72])
-JIGYOU = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-JJJVYF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-JJVYFC = "".join(chr(c) for c in [70, 117, 108, 108])
-JMAOAW = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-JMCBFE = "".join(chr(c) for c in [79, 51])
-JNIBXY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JPUNRJ = 448
-JQRJJJ = 301
-JRJHIU = "".join(chr(c) for c in [80, 49])
-JTACCP = 267
-JUGSEL = "".join(chr(c) for c in [72, 84, 82])
-JUIKFW = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-JUTYEK = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-JVDQLA = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-JVHFTH = 274
-JYKLGQ = 280
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 51])
-KCWAON = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-KFWRKI = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-KHTZBB = 58
-KINEJN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 48])
-KLGQPL = 281
-KMLOIJ = 323
-KPHUOJ = 305
-KQTDKH = "".join(chr(c) for c in [76, 73])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-KSTSEM = 460
-KVKZIL = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-KWIVDN = "".join(chr(c) for c in [80, 51, 72])
-KXSJWM = "".join(chr(c) for c in [78, 79])
-KZILXW = "".join(chr(c) for c in [75, 54, 48, 48])
-LAIIDN = "".join(chr(c) for c in [52, 56, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-LHBQNR = 328
-LJUIKF = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = 313
-LNMHXE = 289
-LOIJUG = 324
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 377
-LSXUJU = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-LXWAJV = "".join(chr(c) for c in [105, 110, 89, 84])
-MAOAWB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-MCBFEG = 3
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MCVDSS = 474
-MFZDGK = 456
-MHXEKV = "".join(chr(c) for c in [105, 110, 88, 69])
-MJIGYO = 355
-MJMAOA = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-MNHTBJ = "".join(chr(c) for c in [75, 53])
-MNZMJI = 353
-MOUNBL = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NBLKXS = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NHTBJE = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-NIBXTI = "".join(chr(c) for c in [67, 69])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-NMHXEK = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NPYYLI = "".join(chr(c) for c in [83, 84, 79, 80])
-NQGVUN = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-NQJYMO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-NQLNMH = 288
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 55])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 50])
-NRXCHW = 330
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-NZMJIG = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-OAWBSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-OJRJHI = 369
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [73, 68, 76, 69])
-OOQNRS = "".join(chr(c) for c in [80, 52])
-OPHUGT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-OQNRSJ = "".join(chr(c) for c in [80, 53])
-OUNBLK = 282
-OUSPBW = 277
-OUYNQJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PBWJYK = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-PFTSIF = 383
-PHUGTY = 360
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-POUYNQ = 272
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 49])
-PYYLIU = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-QFYLJU = 354
-QGVUNX = "".join(chr(c) for c in [65, 85, 88])
-QIEFXQ = 2
-QIPOUY = 271
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [51, 50, 75])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-QNRSJM = 260
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-QPLSPF = 352
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-QSNQLN = 287
-QTMFZD = 455
-QVXOIH = 466
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 478
-RJHIUS = 261
-RJJJVY = 316
-RJZTAT = 450
-RKINEJ = 311
-RSJMCB = "".join(chr(c) for c in [66, 76])
-RTFMNH = "".join(chr(c) for c in [75, 56, 53])
-RURAZM = 477
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SELHBQ = 327
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-SIFJBI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SIRYXB = 351
-SJMCBF = "".join(chr(c) for c in [67, 80])
-SJWMNZ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-SKSOKP = 303
-SKWIVD = "".join(chr(c) for c in [80, 50, 76])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-SOKPHU = 304
-SOOQNR = "".join(chr(c) for c in [80, 51])
-SPFTSI = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-SSRURA = 476
-SSUHBV = 291
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-SXUJUT = 364
-TACCPQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 52])
-TBJEUT = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 53])
-TFMNHT = "".join(chr(c) for c in [75, 56])
-THBSKS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(chr(c) for c in [50, 53, 65])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 56])
-TOPHUG = 358
-TSEMCG = 461
-TSIFJB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-TTIDUB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-TYEKCW = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-TYIYWS = 320
-TZBBEK = 479
-UBSSUH = 7
-UBYGDS = 296
-UGTYIY = 361
-UHBVWV = 293
-UIKFWR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-UJUTYE = 365
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-UNRJZT = 449
-UNXNKM = 321
-UOJRJH = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-UQEXLS = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-USOOQN = "".join(chr(c) for c in [80, 50])
-USPBWJ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-UTOPHU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UTYEKC = 367
-UXFEFJ = 264
-UYNQJY = 273
-VDNQGV = "".join(chr(c) for c in [80, 52, 76])
-VDQLAI = 290
-VDSSRU = 475
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [105, 110, 88, 77])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 472
-VUBYGD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-VWVUBY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 89, 74])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-WBSIRY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-WDAFIK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-WIVDNQ = "".join(chr(c) for c in [80, 51, 76])
-WJYKLG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-WMNZMJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-WRKINE = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-WSKWIV = "".join(chr(c) for c in [80, 50, 72])
-WVUBYG = 295
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-XCHWDA = 331
-XEKVKZ = "".join(chr(c) for c in [77, 73, 65])
-XFEFJT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-XNKMLO = 322
-XNQTMF = 454
-XOIHBX = 467
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-XSJWMN = "".join(chr(c) for c in [77, 69, 68])
-XTIACQ = "".join(chr(c) for c in [80, 50, 50])
-XUJUTY = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-XWAJVD = "".join(chr(c) for c in [75, 56, 48, 48])
-XYBQSN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-YBQSNQ = 285
-YEKCWA = 262
-YFCRTF = 357
-YGDSBD = 297
-YIYWSK = "".join(chr(c) for c in [78, 65])
-YKLGQP = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YLIUXF = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YLJUIK = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-YMOUNB = "".join(chr(c) for c in [67, 80, 79, 84])
-YNQJYM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YOUSPB = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 49, 76])
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-YYLIUX = "".join(chr(c) for c in [78, 69, 87])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 457
-ZILXWA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-ZMKQTD = 479
-ZTATDZ = 451
-ZUQEXL = 310
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 54])
-AFIKJP = [
-    YIYWSK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SJMCBF,
-]
-AJVDQL = [
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-]
-CWAONP = [EKCWAO, KCWAON]
-DKHTZB = [
-    NIBXYB,
-    IRYXBQ,
-    XBQFYL,
-    AMJMAO,
-    JIGYOU,
-    JNIBXY,
-    IBXYBQ,
-    PBWJYK,
-    JYMOUN,
-    WBSIRY,
-    MAOAWB,
-    FTSIFJ,
-    GQPLSP,
-    NEJNIB,
-    JMAOAW,
-    BSIRYX,
-    AWBSIR,
-    JBIAMJ,
-    BQFYLJ,
-    IFJBIA,
-    TSIFJB,
-    RYXBQF,
-    LJUIKF,
-    YXBQFY,
-    SIFJBI,
-    OAWBSI,
-    MJMAOA,
-    BIAMJM,
-]
-DUBSSU = [TIDUBS, IDUBSS]
-EUTOPH = [
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    XWAJVD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-]
-FWRKIN = [HECVYY, KFWRKI, KFWRKI, KFWRKI]
-GVUNXN = [
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    OQNRSJ,
-    DNQGVU,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NQGVUN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    QGVUNX,
-]
-IBXTIA = [DNIBXT, NIBXTI]
-IIDNIB = [DQLAII, QLAIID, LAIIDN, AIIDNI]
-IUSOOQ = [ASSAKQ, JHIUSO, HIUSOO]
-JVYFCR = [JJJVYF, JJVYFC]
-JWMNZM = [KXSJWM, QXPICX, XSJWMN, XPICXQ, SJWMNZ]
-LIUXFE = [ONPYYL, NPYYLI, PYYLIU, YYLIUX, YLIUXF]
-MKQTDK = []
-NRSJMC = [ASSAKQ, JHIUSO]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QFFTTI = [ACQFFT, CQFFTT]
-QGLRAH = [ASSAKQ, XPICXQ]
-QTDKHT = [
-    JRJHIU,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    RSJMCB,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    BFEGZU,
-    EGZUQE,
-    GZUQEX,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    KQTDKH,
-]
-RAHEOC = [ASSAKQ, LRAHEO]
-SPBWJY = [HECVYY, USPBWJ, USPBWJ, USPBWJ]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TDKHTZ = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-]
-TIACQF = [RSJMCB, XTIACQ]
-UGSELH = [
-    YIYWSK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JUGSEL,
-]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -953,262 +19,817 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return KHTZBB
+        return 58
 
     @property
     def begin(self):
-        return HTZBBE
+        return 256
 
     @property
     def end(self):
-        return TZBBEK
+        return 479
 
     @property
     def all_device_keys(self):
-        return QTDKHT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return TDKHTZ
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return DKHTZB
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, ICXQIE, IUSOOQ, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, RJHIUS, QIEFXQ, IUSOOQ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, RJHIUS, CXQIEF, IUSOOQ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, RJHIUS, VHFTHE, IUSOOQ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, ICXQIE, NRSJMC, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, QNRSJM, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, QNRSJM, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, QNRSJM, MCBFEG, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, QNRSJM, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, QNRSJM, FEGZUQ, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, QNRSJM, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XLSXUJ, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            XUJUTY: GeckoWordStructAccessor(self.struct, XUJUTY, UJUTYE, None),
-            JUTYEK: GeckoWordStructAccessor(self.struct, JUTYEK, UTYEKC, SAKQXP),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, ICXQIE, CWAONP, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, LIUXFE, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            IUXFEF: GeckoTimeStructAccessor(self.struct, IUXFEF, UXFEFJ, SAKQXP),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, SAKQXP),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YEKCWA, QIEFXQ, CWAONP, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, LIUXFE, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            TACCPQ: GeckoTimeStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, SAKQXP),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, UYNQJY, ICXQIE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, UYNQJY, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, UYNQJY, MCBFEG, None),
-            QJYMOU: GeckoBoolStructAccessor(self.struct, QJYMOU, UYNQJY, CXQIEF, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, UYNQJY, FEGZUQ, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, JVHFTH, QIEFXQ, None),
-            MOUNBL: GeckoBoolStructAccessor(self.struct, MOUNBL, OUNBLK, MCBFEG, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, OUNBLK, FEGZUQ, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, OUNBLK, VHFTHE, None),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, JWMNZM, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, MNZMJI, FEGZUQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, MNZMJI, VHFTHE, None),
-            ZMJIGY: GeckoWordStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, JVHFTH, AHEOCT, None),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, None),
-            YOUSPB: GeckoTempStructAccessor(self.struct, YOUSPB, OUSPBW, None),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, QNRSJM, FEGZUQ, SPBWJY, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, QIEFXQ, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, QIEFXQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(
-                self.struct, LGQPLS, KLGQPL, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, AHEOCT, None),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, ICXQIE, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, JVHFTH, MCBFEG, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, OUNBLK, ICXQIE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, OUNBLK, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, QIEFXQ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, FJBIAM, MCBFEG, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, MCBFEG, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, CXQIEF, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, IAMJMA, FEGZUQ, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, IAMJMA, VHFTHE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, MCBFEG, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, AOAWBS, CXQIEF, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, AOAWBS, FEGZUQ, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, AOAWBS, VHFTHE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, QIEFXQ, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, SIRYXB, MCBFEG, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, QPLSPF, MCBFEG, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, MNZMJI, ICXQIE, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, MNZMJI, AHEOCT, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, JYKLGQ, ICXQIE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FJBIAM, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FJBIAM, AHEOCT, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FJBIAM, CXQIEF, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IKFWRK, ICXQIE, None),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, IKFWRK, AHEOCT, FWRKIN, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            WRKINE: GeckoWordStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, INEJNI, ICXQIE, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, EJNIBX, ICXQIE, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, EJNIBX, AHEOCT, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, SIRYXB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, SIRYXB, AHEOCT, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, SIRYXB, CXQIEF, None),
-            XYBQSN: GeckoWordStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, None),
-            SNQLNM: GeckoByteStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, AJVDQL, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, ICXQIE, IIDNIB, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, VDQLAI, QIEFXQ, IBXTIA, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, VDQLAI, MCBFEG, TIACQF, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, VDQLAI, CXQIEF, QFFTTI, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, VDQLAI, FEGZUQ, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, VDQLAI, VHFTHE, None),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, VDQLAI, UBSSUH, DUBSSU, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoWordStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoWordStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, JVYFCR, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, EUTOPH, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            UTOPHU: GeckoWordStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, None),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, GVUNXN, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, GVUNXN, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, GVUNXN, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, GVUNXN, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, LOIJUG, None, GVUNXN, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, UGSELH, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, SAKQXP),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, SAKQXP),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, AFIKJP, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-log-59.py
+++ b/src/geckolib/driver/packs/inyj-log-59.py
@@ -12,999 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ACQFFT = "".join(chr(c) for c in [67, 69])
-AFIKJP = 331
-AHEOCT = 1
-AJVDQL = "".join(chr(c) for c in [75, 54, 48, 48])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 457
-AMJMAO = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-AOAWBS = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 50])
-AWBSIR = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-AZMKQT = 476
-BBEKBD = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-BDFSRO = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-BDJQRJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-BEKBDF = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = 468
-BIAMJM = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-BJEUTO = "".join(chr(c) for c in [75, 52])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-BQNRXC = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-BQSNQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BSIRYX = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BWJYKL = 275
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-BXTIAC = "".join(chr(c) for c in [54, 52, 75])
-BXYBQS = 314
-BYGDSB = 294
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-CHWDAF = 329
-CMCVDS = 471
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CRTFMN = "".join(chr(c) for c in [70, 117, 108, 108])
-CTHBSK = 307
-CVDSSR = 472
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-DGKEAK = 455
-DJQRJJ = 297
-DKHTZB = 479
-DNIBXT = "".join(chr(c) for c in [49, 54, 75])
-DNQGVU = "".join(chr(c) for c in [80, 50, 76])
-DPMXFU = 59
-DQLAII = "".join(chr(c) for c in [105, 110, 89, 84])
-DSBDJQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-DSSRUR = 473
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 51])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 57])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EKBDFS = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-ELHBQN = 326
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FCRTFM = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FFTTID = "".join(chr(c) for c in [80, 50, 50])
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-FMNHTB = 357
-FSROGM = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-FWRKIN = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FZDGKE = 454
-GDSBDJ = 295
-GETIXQ = 461
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 56])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = 279
-GSELHB = 324
-GTYIYW = 358
-GVUNXN = "".join(chr(c) for c in [80, 52, 72])
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBSKSO = 363
-HBXIBH = 466
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [75, 56, 53])
-HTZBBE = 371
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IACQFF = "".join(chr(c) for c in [85, 76])
-IAMJMA = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IBXTIA = "".join(chr(c) for c in [52, 56, 75])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ICXQIE = 0
-IDNIBX = 290
-IDUBSS = "".join(chr(c) for c in [51, 79, 80])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = 377
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-IIDNIB = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-IKFWRK = 354
-IKJPUN = 333
-ILXWAJ = "".join(chr(c) for c in [77, 73, 65])
-INEJNI = 309
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = 350
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [80, 49, 76])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-IYWSKW = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-JBIAMJ = 383
-JEUTOP = "".join(chr(c) for c in [75, 53])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = 300
-JJVYFC = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JMAOAW = 283
-JMCBFE = 260
-JNIBXY = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-JPUNRJ = 325
-JQRJJJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = 323
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-JVHFTH = 274
-JVYFCR = 301
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 448
-KBDFSR = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-KCWAON = 365
-KEAKST = 456
-KFWRKI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KHTZBB = "".join(
-    chr(c)
-    for c in [105, 110, 70, 108, 111, 80, 117, 108, 115, 101, 87, 105, 100, 116, 104]
-)
-KINEJN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-KJPUNR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KPHUOJ = 304
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KVKZIL = 289
-KWIVDN = "".join(chr(c) for c in [78, 65])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 88, 69])
-LAIIDN = "".join(chr(c) for c in [105, 110, 89, 74])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = "".join(chr(c) for c in [72, 84, 82])
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 285
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [68, 74, 83, 52])
-MAOAWB = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-MCGETI = 460
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 54])
-MHXEKV = 287
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 477
-MLOIJU = 321
-MNHTBJ = "".join(chr(c) for c in [75, 50, 48, 48])
-MNZMJI = 313
-MOUNBL = 273
-MXFUBJ = 479
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-NHTBJE = "".join(chr(c) for c in [75, 52, 48, 48])
-NIBXTI = "".join(chr(c) for c in [51, 50, 75])
-NIBXYB = 311
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [80, 51, 72])
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-NQTMFZ = 452
-NRJZTA = 332
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-NXNKML = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = 470
-OAWBSI = 284
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [76, 73])
-OIHBXI = 465
-OIJUGS = 322
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [75, 51, 48, 48])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-PHUGTY = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = 280
-PMXFUB = 256
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-QFYLJU = 351
-QGVUNX = "".join(chr(c) for c in [80, 51, 76])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [75, 56, 48, 48])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = 327
-QPLSPF = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-QRJJJV = 299
-QSNQLN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QTDKHT = 478
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 53])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 48])
-RKINEJ = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-RXCHWD = 328
-RYXBQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = 296
-SELHBQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-SEMCGE = 459
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = 320
-SNQLNM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = 281
-SROGMD = 375
-SRURAZ = 474
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-SSUHBV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-STSEMC = 458
-SUHBVW = "".join(chr(c) for c in [50, 53, 65])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = 449
-TBJEUT = "".join(chr(c) for c in [75, 56])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-TDZXNQ = 450
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-TIDUBS = "".join(chr(c) for c in [53, 79, 80])
-TIXQVX = 462
-TMFZDG = 453
-TOPHUG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TSIFJB = 352
-TTIDUB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-TZBBEK = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-UGSELH = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UHBVWV = "".join(chr(c) for c in [51, 48, 65])
-UIKFWR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-UNXNKM = "".join(chr(c) for c in [66, 76, 79])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = 475
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [75, 49, 48, 48])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = "".join(chr(c) for c in [80, 50, 72])
-VDQLAI = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-VUBYGD = 293
-VUNXNK = "".join(chr(c) for c in [80, 52, 76])
-VWVUBY = 291
-VXOIHB = 464
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 88, 77])
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-WDAFIK = 330
-WIVDNQ = "".join(chr(c) for c in [80, 49, 72])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-WVUBYG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-XCHWDA = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-XEKVKZ = 288
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XIBHZV = 467
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [65, 85, 88])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 52])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 463
-XSJWMN = 282
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-XYBQSN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = 315
-YEKCWA = 364
-YFCRTF = 316
-YGDSBD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-YIYWSK = 360
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = 361
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 374
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 55])
-ZILXWA = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49])
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = 469
-ZXNQTM = 451
-AIIDNI = [
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-    DQLAII,
-    QLAIID,
-    LAIIDN,
-]
-CQFFTT = [IACQFF, ACQFFT]
-DDPMXF = [
-    QSNQLN,
-    FYLJUI,
-    JUIKFW,
-    AWBSIR,
-    SPBWJY,
-    BQSNQL,
-    SNQLNM,
-    LGQPLS,
-    BLKXSJ,
-    XBQFYL,
-    SIRYXB,
-    BIAMJM,
-    FTSIFJ,
-    XYBQSN,
-    BSIRYX,
-    BQFYLJ,
-    YXBQFY,
-    MAOAWB,
-    UIKFWR,
-    MJMAOA,
-    IAMJMA,
-    YLJUIK,
-    WRKINE,
-    LJUIKF,
-    AMJMAO,
-    RYXBQF,
-    WBSIRY,
-    AOAWBS,
-]
-DFSROG = [BBEKBD, BEKBDF, EKBDFS, KBDFSR, BDFSRO]
-DUBSSU = [TIDUBS, IDUBSS]
-EJNIBX = [HECVYY, NEJNIB, NEJNIB, NEJNIB]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FTTIDU = [CBFEGZ, FFTTID]
-GMDDPM = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    OGMDDP,
-]
-HBQNRX = [
-    KWIVDN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LHBQNR,
-]
-HBVWVU = [SUHBVW, UHBVWV]
-HUGTYI = [
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    QLAIID,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDDPMX = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-NKMLOI = [
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    SJMCBF,
-    UNXNKM,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NXNKML,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    XNKMLO,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PUNRJZ = [
-    KWIVDN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-ROGMDD = []
-RTFMNH = [FCRTFM, CRTFMN]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XTIACQ = [DNIBXT, NIBXTI, IBXTIA, BXTIAC]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1012,276 +19,851 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return DPMXFU
+        return 59
 
     @property
     def begin(self):
-        return PMXFUB
+        return 256
 
     @property
     def end(self):
-        return MXFUBJ
+        return 479
 
     @property
     def all_device_keys(self):
-        return GMDDPM
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return MDDPMX
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return DDPMXF
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, AHEOCT, None),
-            PFTSIF: GeckoBoolStructAccessor(
-                self.struct, PFTSIF, SPFTSI, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, AHEOCT, None),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, ICXQIE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JVHFTH, EGZUQE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, XSJWMN, ICXQIE, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, XSJWMN, AHEOCT, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, QIEFXQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, EGZUQE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, EGZUQE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, OAWBSI, UQEXLS, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, OAWBSI, VHFTHE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, EGZUQE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, IRYXBQ, CXQIEF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, IRYXBQ, UQEXLS, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, IRYXBQ, VHFTHE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QIEFXQ, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, EGZUQE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, TSIFJB, EGZUQE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, GYOUSP, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, GYOUSP, AHEOCT, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IKFWRK, ICXQIE, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, PLSPFT, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, JMAOAW, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, JMAOAW, AHEOCT, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, JMAOAW, CXQIEF, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, INEJNI, ICXQIE, None),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, INEJNI, AHEOCT, EJNIBX, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            JNIBXY: GeckoWordStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, YBQSNQ, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YBQSNQ, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, QFYLJU, ICXQIE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, QFYLJU, AHEOCT, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QFYLJU, CXQIEF, None),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoByteStructAccessor(self.struct, HXEKVK, XEKVKZ, None),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, AIIDNI, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, ICXQIE, XTIACQ, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IDNIBX, QIEFXQ, CQFFTT, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, IDNIBX, EGZUQE, FTTIDU, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, IDNIBX, CXQIEF, DUBSSU, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, IDNIBX, UQEXLS, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, IDNIBX, VHFTHE, None),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, IDNIBX, XLSXUJ, HBVWVU, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BVWVUB: GeckoWordStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, None),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, None),
-            BDJQRJ: GeckoWordStructAccessor(self.struct, BDJQRJ, DJQRJJ, None),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, None),
-            RJJJVY: GeckoByteStructAccessor(self.struct, RJJJVY, JJJVYF, None),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, RTFMNH, None, QIEFXQ, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, HUGTYI, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, NKMLOI, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, NKMLOI, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, NKMLOI, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, NKMLOI, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, GSELHB, None, NKMLOI, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            SELHBQ: GeckoEnumStructAccessor(
-                self.struct, SELHBQ, ELHBQN, None, HBQNRX, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, SAKQXP),
-            NRXCHW: GeckoByteStructAccessor(self.struct, NRXCHW, RXCHWD, SAKQXP),
-            XCHWDA: GeckoByteStructAccessor(self.struct, XCHWDA, CHWDAF, SAKQXP),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, SAKQXP),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, SAKQXP),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, SAKQXP),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, PUNRJZ, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            KHTZBB: GeckoByteStructAccessor(self.struct, KHTZBB, HTZBBE, None),
-            TZBBEK: GeckoEnumStructAccessor(
-                self.struct, TZBBEK, ZBBEKB, None, DFSROG, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FSROGM: GeckoBoolStructAccessor(
-                self.struct, FSROGM, SROGMD, ICXQIE, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
+            "inFloPulseWidth": GeckoByteStructAccessor(
+                self.struct, "inFloPulseWidth", 371, None
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyj-v2-cfg-58.py
+++ b/src/geckolib/driver/packs/inyj-v2-cfg-58.py
@@ -12,805 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 30
-AIIDNI = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-AJVDQL = 73
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AMJMAO = "".join(chr(c) for c in [70, 51])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AONPYY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BDJQRJ = "".join(chr(c) for c in [66, 76, 85, 69])
-BFEGZU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-BIAMJM = "".join(chr(c) for c in [70, 49])
-BJEUTO = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-BLKXSJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-BQNRXC = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-BQSNQL = 10
-BSIRYX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-BSKSOK = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BSSUHB = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-BVWVUB = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-BWJYKL = 77
-BXTIAC = 64
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-CBFEGZ = 27
-CCPQIP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-CPQIPO = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-CRTFMN = 44
-CTHBSK = 79
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-DJQRJJ = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-DNIBXT = "".join(chr(c) for c in [50, 52, 104])
-DNQGVU = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DSBDJQ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-DUBSSU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-EFXQGL = 37
-EJNIBX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-EKCWAO = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-EKVKZI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-EOCTHB = 39
-EUTOPH = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-EXLSXU = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FCRTFM = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-FEGZUQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FFTTID = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FJBIAM = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FJTACC = 29
-FMNHTB = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-FTTIDU = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-FWRKIN = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-GDSBDJ = "".join(chr(c) for c in [82, 69, 68])
-GLRAHE = 40
-GQPLSP = "".join(chr(c) for c in [67, 69])
-GSELHB = 45
-GTYIYW = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-GVUNXN = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-GYOUSP = 68
-GZUQEX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-HBVWVU = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HTBJEU = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-HUGTYI = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-HUOJRJ = 56
-HXEKVK = 72
-IACQFF = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IAMJMA = "".join(chr(c) for c in [70, 50])
-IBXTIA = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-IBXYBQ = 23
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [65, 109, 80, 109])
-IDUBSS = 5
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IIDNIB = 34
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-ILXWAJ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 63
-IRYXBQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IUSOOQ = 2
-IUXFEF = 28
-IVDNQG = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(chr(c) for c in [76, 65])
-JBIAMJ = 83
-JEUTOP = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-JIGYOU = 66
-JJJVYF = 8
-JJVYFC = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-JNIBXY = 6
-JQRJJJ = "".join(chr(c) for c in [67, 89, 65, 78])
-JRJHIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JUIKFW = 104
-JUTYEK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JWMNZM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JYKLGQ = 26
-KCWAON = 60
-KFWRKI = 105
-KINEJN = 3
-KLGQPL = 51
-KMLOIJ = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-KPHUOJ = 55
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KVKZIL = 1
-KWIVDN = "".join(chr(c) for c in [80, 68, 67])
-KZILXW = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-LAIIDN = 75
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [85, 76])
-LHBQNR = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-LIUXFE = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LJUIKF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-LKXSJW = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-LNMHXE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-LOIJUG = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-LRAHEO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-LSPFTS = 52
-LSXUJU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LXWAJV = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-MCBFEG = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-MNHTBJ = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-MNZMJI = 3
-MOUNBL = 31
-NBLKXS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = 4
-NHTBJE = "".join(chr(c) for c in [65, 108, 112, 115])
-NIBXYB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NKMLOI = "".join(chr(c) for c in [73, 100, 111, 108])
-NMHXEK = 82
-NPYYLI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NQGVUN = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-NQJYMO = "".join(chr(c) for c in [70])
-NQLNMH = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-NRXCHW = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-NXNKML = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-NZMJIG = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OAWBSI = 84
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OIJUGS = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-OJRJHI = 81
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 62
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-OPHUGT = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-OQNRSJ = 32
-OUNBLK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-OUSPBW = 70
-OUYNQJ = 1
-PBWJYK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-PFTSIF = 53
-PHUGTY = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-POUYNQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PYYLIU = 78
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QFFTTI = 4
-QFYLJU = 99
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-QGVUNX = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-QIEFXQ = 36
-QIPOUY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QJYMOU = "".join(chr(c) for c in [67])
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-QNRSJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QNRXCH = 46
-QRJJJV = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 15
-RJHIUS = "".join(chr(c) for c in [79, 119, 110])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-RSJMCB = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-RTFMNH = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-RXCHWD = 47
-RYXBQF = 87
-SBDJQR = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-SELHBQ = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-SIFJBI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SIRYXB = 86
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SKSOKP = 80
-SKWIVD = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-SNQLNM = 71
-SOKPHU = 54
-SOOQNR = 48
-SPFTSI = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = 7
-SUHBVW = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-SXUJUT = "".join(chr(c) for c in [76, 111])
-TACCPQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-TBJEUT = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-TFMNHT = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-THBSKS = "".join(chr(c) for c in [76, 73])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TOPHUG = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-TSIFJB = 74
-TTIDUB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-TYEKCW = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TYIYWS = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-UBSSUH = 6
-UBYGDS = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-UGSELH = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-UGTYIY = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-UHBVWV = 43
-UNBLKX = 25
-UNXNKM = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-UOJRJH = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-UQEXLS = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-USOOQN = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-USPBWJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UTOPHU = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-UTYEKC = 58
-UXFEFJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UYNQJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-VDNQGV = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-VDQLAI = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUNXNK = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-VWVUBY = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-VYFCRT = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-WAONPY = 61
-WBSIRY = 85
-WDAFIK = 58
-WIVDNQ = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-WRKINE = 106
-WSKWIV = "".join(chr(c) for c in [77, 65, 65, 88])
-WVUBYG = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-XBQFYL = 98
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XFEFJT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XNKMLO = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-XPICXQ = 14
-XQGLRA = 38
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XSJWMN = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XUJUTY = "".join(chr(c) for c in [72, 105])
-XYBQSN = 8
-YBQSNQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YEKCWA = 59
-YGDSBD = "".join(chr(c) for c in [79, 70, 70])
-YIYWSK = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-YKLGQP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-YLJUIK = 100
-YMOUNB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YNQJYM = 33
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-YXBQFY = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 76
-ZMJIGY = 35
-ZUQEXL = 57
-ACQFFT = [TIACQF, IACQFF]
-AHEOCT = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-CHWDAF = [THBSKS]
-CXQIEF = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-DQLAII = [VLASSA, JVDQLA, VDQLAI]
-EGZUQE = [BFEGZU, FEGZUQ]
-FEFJTA = [UXFEFJ, XFEFJT]
-HBQNRX = [ELHBQN, LHBQNR, VLASSA, VLASSA]
-HBSKSO = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    THBSKS,
-]
-HWDAFI = []
-IFJBIA = [CCPQIP, SIFJBI]
-JHIUSO = [JRJHIU, RJHIUS]
-JMCBFE = [QNRSJM, NRSJMC, RSJMCB, SJMCBF]
-JTACCP = [PIPIVL, YYLIUX]
-JUGSEL = [
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-]
-JYMOUN = [NQJYMO, QJYMOU]
-KXSJWM = [NBLKXS, BLKXSJ, LKXSJW]
-MAOAWB = [BIAMJM, IAMJMA, AMJMAO, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-NIBXTI = [JVHFTH, IDNIBX, DNIBXT]
-PQIPOU = [CCPQIP, CPQIPO]
-QLNMHX = [JVHFTH, BFEGZU, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-RJJJVY = [YGDSBD, GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ, DJQRJJ, JQRJJJ, QRJJJV]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-SPBWJY = [CCPQIP, USPBWJ]
-TIDUBS = [FTTIDU, TTIDUB]
-UIKFWR = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-UJUTYE = [SXUJUT, XUJUTY]
-VUBYGD = [VWVUBY, WVUBYG]
-WMNZMJ = [SJWMNZ, JWMNZM]
-XCHWDA = [BMJVHF, AKQXPI, QXPICX, PICXQI, LRAHEO, OCTHBS]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-XWAJVD = [ILXWAJ, LXWAJV]
-YFCRTF = [JVYFCR, VYFCRT]
-YLIUXF = [JVHFTH, YYLIUX, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -818,209 +19,577 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return WDAFIK
+        return 58
 
     @property
     def output_keys(self):
-        return XCHWDA
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, CXQIEF, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, RAHEOC, None, AHEOCT, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, HBSKSO, None, None, None
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, None),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, HIUSOO, JHIUSO, None, IUSOOQ, QBMJVH
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, JMCBFE, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, EGZUQE, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, OJRJHI, IUSOOQ, UJUTYE, None, IUSOOQ, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YLIUXF, None, None, QBMJVH
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FEFJTA, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, JTACCP, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, PQIPOU, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoTempStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JTACCP, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, KXSJWM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, OJRJHI, MNZMJI, WMNZMJ, None, IUSOOQ, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, SPBWJY, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IFJBIA, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MAOAWB, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, MAOAWB, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, MAOAWB, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, None, MAOAWB, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, MAOAWB, None, None, QBMJVH
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
             ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoByteStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, UIKFWR, None, None, QBMJVH
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
             ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, UIKFWR, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, UIKFWR, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTimeStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoTimeStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, QLNMHX, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, NMHXEK, HIUSOO, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, HXEKVK, IUSOOQ, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, HXEKVK, HIUSOO, QBMJVH
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
             ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, HXEKVK, KVKZIL, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, HXEKVK, MNZMJI, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, XWAJVD, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, DQLAII, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            QLAIID: GeckoByteStructAccessor(self.struct, QLAIID, LAIIDN, QBMJVH),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, IIDNIB, None, NIBXTI, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXTIA: GeckoWordStructAccessor(self.struct, IBXTIA, BXTIAC, QBMJVH),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, OJRJHI, KVKZIL, ACQFFT, None, IUSOOQ, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            CQFFTT: GeckoBoolStructAccessor(
-                self.struct, CQFFTT, OJRJHI, QFFTTI, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            FFTTID: GeckoEnumStructAccessor(
-                self.struct, FFTTID, OJRJHI, IDUBSS, TIDUBS, None, IUSOOQ, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            DUBSSU: GeckoBoolStructAccessor(
-                self.struct, DUBSSU, OJRJHI, UBSSUH, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            BSSUHB: GeckoBoolStructAccessor(
-                self.struct, BSSUHB, OJRJHI, SSUHBV, QBMJVH
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, UHBVWV, HIUSOO, QBMJVH
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
             ),
-            HBVWVU: GeckoBoolStructAccessor(
-                self.struct, HBVWVU, UHBVWV, KVKZIL, QBMJVH
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
             ),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, UHBVWV, IUSOOQ, VUBYGD, None, IUSOOQ, QBMJVH
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, UHBVWV, MNZMJI, VUBYGD, None, IUSOOQ, QBMJVH
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, UHBVWV, QFFTTI, RJJJVY, None, JJJVYF, QBMJVH
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
             ),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, UHBVWV, SSUHBV, YFCRTF, None, IUSOOQ, QBMJVH
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
             ),
-            UGSELH: GeckoBoolStructAccessor(
-                self.struct, UGSELH, GSELHB, HIUSOO, QBMJVH
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
             ),
-            SELHBQ: GeckoEnumStructAccessor(
-                self.struct, SELHBQ, GSELHB, IUSOOQ, HBQNRX, None, QFFTTI, QBMJVH
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
             ),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, QBMJVH),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, RXCHWD, HIUSOO, QBMJVH
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyj-v2-cfg-60.py
+++ b/src/geckolib/driver/packs/inyj-v2-cfg-60.py
@@ -12,939 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 30
-ACQFFT = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-AFIKJP = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-AIIDNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-AMJMAO = "".join(chr(c) for c in [70, 51])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AONPYY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-ATDZXN = 125
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BDJQRJ = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-BFEGZU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-BIAMJM = "".join(chr(c) for c in [70, 49])
-BJEUTO = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-BLKXSJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-BQNRXC = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-BQSNQL = 10
-BSIRYX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-BSKSOK = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BSSUHB = 6
-BVWVUB = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-BWJYKL = 77
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BYGDSB = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-CBFEGZ = 27
-CCPQIP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-CHWDAF = 47
-CPQIPO = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-CRTFMN = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-CTHBSK = 79
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-DAFIKJ = 121
-DJQRJJ = "".join(chr(c) for c in [66, 76, 85, 69])
-DNIBXT = 34
-DNQGVU = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-DQLAII = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DSBDJQ = "".join(chr(c) for c in [82, 69, 68])
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-EAKSTS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-EFXQGL = 37
-EJNIBX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-EKCWAO = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-EKVKZI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-EMCGET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-EOCTHB = 39
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-EUTOPH = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-EXLSXU = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FEGZUQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FFTTID = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-FIKJPU = 123
-FJBIAM = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FJTACC = 29
-FMNHTB = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-FTTIDU = 4
-FWRKIN = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-FZDGKE = "".join(chr(c) for c in [51])
-GDSBDJ = "".join(chr(c) for c in [79, 70, 70])
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-GKEAKS = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-GLRAHE = 40
-GQPLSP = "".join(chr(c) for c in [67, 69])
-GSELHB = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GTYIYW = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-GVUNXN = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-GYOUSP = 68
-GZUQEX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-HBQNRX = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HBVWVU = 43
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HTBJEU = "".join(chr(c) for c in [65, 108, 112, 115])
-HUGTYI = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-HUOJRJ = 56
-HWDAFI = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-HXEKVK = 72
-IACQFF = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-IAMJMA = "".join(chr(c) for c in [70, 50])
-IBXTIA = "".join(chr(c) for c in [50, 52, 104])
-IBXYBQ = 23
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-IDUBSS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IHBXIB = 60
-IIDNIB = 75
-IJUGSE = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-IKJPUN = "".join(chr(c) for c in [82, 71, 66])
-ILXWAJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 63
-IRYXBQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IUSOOQ = 2
-IUXFEF = 28
-IVDNQG = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-IYWSKW = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-JBIAMJ = 83
-JEUTOP = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-JIGYOU = 66
-JJVYFC = 8
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-JNIBXY = 6
-JPUNRJ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-JQRJJJ = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-JRJHIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JUGSEL = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-JUIKFW = 104
-JUTYEK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-JWMNZM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JYKLGQ = 26
-JZTATD = 124
-KCWAON = 60
-KEAKST = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-KFWRKI = 105
-KINEJN = 3
-KLGQPL = 51
-KMLOIJ = "".join(chr(c) for c in [73, 100, 111, 108])
-KPHUOJ = 55
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KSTSEM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-KVKZIL = 1
-KWIVDN = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [85, 76])
-LHBQNR = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-LIUXFE = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LJUIKF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-LKXSJW = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-LNMHXE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-LOIJUG = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-LRAHEO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-LSPFTS = 52
-LSXUJU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LXWAJV = 76
-MCBFEG = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-MFZDGK = "".join(chr(c) for c in [50])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MNHTBJ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-MNZMJI = 3
-MOUNBL = 31
-NBLKXS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = 4
-NHTBJE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-NIBXTI = "".join(chr(c) for c in [65, 109, 80, 109])
-NIBXYB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NKMLOI = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-NMHXEK = 82
-NPYYLI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NQGVUN = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-NQJYMO = "".join(chr(c) for c in [70])
-NQLNMH = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-NQTMFZ = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-NRXCHW = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-NXNKML = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-NZMJIG = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OAWBSI = 84
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OIJUGS = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-OJRJHI = 81
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 62
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-OPHUGT = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-OQNRSJ = 32
-OUNBLK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-OUSPBW = 70
-OUYNQJ = 1
-PBWJYK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-PFTSIF = 53
-PHUGTY = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-POUYNQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PUNRJZ = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-PYYLIU = 78
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QFYLJU = 99
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-QGVUNX = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-QIEFXQ = 36
-QIPOUY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QJYMOU = "".join(chr(c) for c in [67])
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QNRSJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QRJJJV = "".join(chr(c) for c in [67, 89, 65, 78])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QTMFZD = 127
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 15
-RJHIUS = "".join(chr(c) for c in [79, 119, 110])
-RJJJVY = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-RJZTAT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-RSJMCB = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-RTFMNH = 44
-RXCHWD = 46
-RYXBQF = 87
-SBDJQR = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-SELHBQ = 45
-SEMCGE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-SIFJBI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SIRYXB = 86
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SKSOKP = 80
-SKWIVD = "".join(chr(c) for c in [77, 65, 65, 88])
-SNQLNM = 71
-SOKPHU = 54
-SOOQNR = 48
-SPFTSI = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SSUHBV = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-STSEMC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-SUHBVW = 7
-SXUJUT = "".join(chr(c) for c in [76, 111])
-TACCPQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-TATDZX = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-TBJEUT = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-TDZXNQ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-TFMNHT = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-THBSKS = "".join(chr(c) for c in [76, 73])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 64
-TIDUBS = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-TMFZDG = "".join(chr(c) for c in [49])
-TOPHUG = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-TSEMCG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-TSIFJB = 74
-TTIDUB = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-TYEKCW = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TYIYWS = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-UBSSUH = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-UGTYIY = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-UHBVWV = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UNBLKX = 25
-UNRJZT = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-UNXNKM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-UOJRJH = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-UQEXLS = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-USOOQN = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-USPBWJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UTOPHU = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-UTYEKC = 58
-UXFEFJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UYNQJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-VDNQGV = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-VDQLAI = 73
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-VUNXNK = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-VWVUBY = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-VYFCRT = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WAONPY = 61
-WBSIRY = 85
-WDAFIK = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-WIVDNQ = "".join(chr(c) for c in [80, 68, 67])
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-WRKINE = 106
-WSKWIV = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-WVUBYG = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-XBQFYL = 98
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XFEFJT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XNKMLO = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-XPICXQ = 14
-XQGLRA = 38
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-XSJWMN = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-XUJUTY = "".join(chr(c) for c in [72, 105])
-XWAJVD = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-XYBQSN = 8
-YBQSNQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YEKCWA = 59
-YFCRTF = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-YGDSBD = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-YIYWSK = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-YKLGQP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-YLJUIK = 100
-YMOUNB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YNQJYM = 33
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [76, 65])
-YXBQFY = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [52])
-ZILXWA = 5
-ZMJIGY = 35
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-ZUQEXL = 57
-ZXNQTM = 126
-AHEOCT = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-AJVDQL = [XWAJVD, WAJVDQ]
-BXTIAC = [JVHFTH, NIBXTI, IBXTIA]
-CXQIEF = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-DGKEAK = [VLASSA, TMFZDG, MFZDGK, FZDGKE, ZDGKEA]
-DUBSSU = [TIDUBS, IDUBSS]
-EGZUQE = [BFEGZU, FEGZUQ]
-FCRTFM = [VYFCRT, YFCRTF]
-FEFJTA = [UXFEFJ, XFEFJT]
-HBSKSO = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    THBSKS,
-]
-IFJBIA = [CCPQIP, SIFJBI]
-JHIUSO = [JRJHIU, RJHIUS]
-JJJVYF = [GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ, DJQRJJ, JQRJJJ, QRJJJV, RJJJVY]
-JMCBFE = [QNRSJM, NRSJMC, RSJMCB, SJMCBF]
-JTACCP = [PIPIVL, YYLIUX]
-JYMOUN = [NQJYMO, QJYMOU]
-KJPUNR = [IKJPUN, RJJJVY]
-KXSJWM = [NBLKXS, BLKXSJ, LKXSJW]
-LAIIDN = [VLASSA, DQLAII, QLAIID]
-MAOAWB = [BIAMJM, IAMJMA, AMJMAO, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-NRJZTA = [PUNRJZ, UNRJZT]
-OIHBXI = []
-PQIPOU = [CCPQIP, CPQIPO]
-QFFTTI = [ACQFFT, CQFFTT]
-QLNMHX = [JVHFTH, BFEGZU, NQLNMH]
-QNRXCH = [HBQNRX, BQNRXC, VLASSA, VLASSA]
-QPLSPF = [LGQPLS, GQPLSP]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-SPBWJY = [CCPQIP, USPBWJ]
-UBYGDS = [WVUBYG, VUBYGD]
-UGSELH = [
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-]
-UIKFWR = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-UJUTYE = [SXUJUT, XUJUTY]
-VXOIHB = [BMJVHF, AKQXPI, QXPICX, PICXQI, LRAHEO, OCTHBS]
-WMNZMJ = [SJWMNZ, JWMNZM]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-XOIHBX = [THBSKS]
-YLIUXF = [JVHFTH, YYLIUX, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -952,263 +19,674 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return IHBXIB
+        return 60
 
     @property
     def output_keys(self):
-        return VXOIHB
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 45, 0, "ALL"
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "SilentMode": GeckoBoolStructAccessor(
+                self.struct, "SilentMode", 47, 3, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, CXQIEF, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, RAHEOC, None, AHEOCT, None, None, QBMJVH
-            ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, HBSKSO, None, None, None
-            ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, None),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, HIUSOO, JHIUSO, None, IUSOOQ, QBMJVH
-            ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, JMCBFE, None, None, QBMJVH
-            ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, EGZUQE, None, None, QBMJVH
-            ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, OJRJHI, IUSOOQ, UJUTYE, None, IUSOOQ, QBMJVH
-            ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YLIUXF, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FEFJTA, None, None, QBMJVH
-            ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, JTACCP, None, None, QBMJVH
-            ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, PQIPOU, None, None, QBMJVH
-            ),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoTempStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
-            ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JTACCP, None, None, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, KXSJWM, None, None, QBMJVH
-            ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, OJRJHI, MNZMJI, WMNZMJ, None, IUSOOQ, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, SPBWJY, None, None, QBMJVH
-            ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, MAOAWB, None, None, QBMJVH
-            ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, MAOAWB, None, None, QBMJVH
-            ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, None, MAOAWB, None, None, QBMJVH
-            ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, MAOAWB, None, None, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoByteStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, UIKFWR, None, None, QBMJVH
-            ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, UIKFWR, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, UIKFWR, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTimeStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoTimeStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, NMHXEK, HIUSOO, QBMJVH
-            ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, HXEKVK, IUSOOQ, QBMJVH
-            ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, HXEKVK, HIUSOO, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, HXEKVK, KVKZIL, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, HXEKVK, MNZMJI, QBMJVH
-            ),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, HXEKVK, ZILXWA, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, LAIIDN, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoWordStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, OJRJHI, KVKZIL, QFFTTI, None, IUSOOQ, QBMJVH
-            ),
-            FFTTID: GeckoBoolStructAccessor(
-                self.struct, FFTTID, OJRJHI, FTTIDU, QBMJVH
-            ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, OJRJHI, ZILXWA, DUBSSU, None, IUSOOQ, QBMJVH
-            ),
-            UBSSUH: GeckoBoolStructAccessor(
-                self.struct, UBSSUH, OJRJHI, BSSUHB, QBMJVH
-            ),
-            SSUHBV: GeckoBoolStructAccessor(
-                self.struct, SSUHBV, OJRJHI, SUHBVW, QBMJVH
-            ),
-            UHBVWV: GeckoBoolStructAccessor(
-                self.struct, UHBVWV, HBVWVU, HIUSOO, QBMJVH
-            ),
-            BVWVUB: GeckoBoolStructAccessor(
-                self.struct, BVWVUB, HBVWVU, KVKZIL, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, HBVWVU, IUSOOQ, UBYGDS, None, IUSOOQ, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, HBVWVU, MNZMJI, UBYGDS, None, IUSOOQ, QBMJVH
-            ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, HBVWVU, FTTIDU, JJJVYF, None, JJVYFC, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, HBVWVU, SUHBVW, FCRTFM, None, IUSOOQ, QBMJVH
-            ),
-            GSELHB: GeckoBoolStructAccessor(
-                self.struct, GSELHB, SELHBQ, HIUSOO, QBMJVH
-            ),
-            ELHBQN: GeckoBoolStructAccessor(
-                self.struct, ELHBQN, SELHBQ, KVKZIL, QBMJVH
-            ),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, SELHBQ, IUSOOQ, QNRXCH, None, FTTIDU, QBMJVH
-            ),
-            NRXCHW: GeckoByteStructAccessor(self.struct, NRXCHW, RXCHWD, QBMJVH),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, HIUSOO, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, CHWDAF, MNZMJI, QBMJVH
-            ),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, QBMJVH),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, FIKJPU, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, JZTATD, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, ATDZXN, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, ATDZXN, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, HIUSOO, KJPUNR, None, IUSOOQ, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, ZXNQTM, KVKZIL, NRJZTA, None, IUSOOQ, None
-            ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, HIUSOO, DGKEAK, None, JJVYFC, None
-            ),
-            GKEAKS: GeckoBoolStructAccessor(self.struct, GKEAKS, QTMFZD, SUHBVW, None),
-            KEAKST: GeckoBoolStructAccessor(self.struct, KEAKST, FIKJPU, FTTIDU, None),
-            EAKSTS: GeckoBoolStructAccessor(self.struct, EAKSTS, FIKJPU, ZILXWA, None),
-            AKSTSE: GeckoBoolStructAccessor(self.struct, AKSTSE, FIKJPU, BSSUHB, None),
-            KSTSEM: GeckoBoolStructAccessor(self.struct, KSTSEM, FIKJPU, SUHBVW, None),
-            STSEMC: GeckoBoolStructAccessor(self.struct, STSEMC, JZTATD, FTTIDU, None),
-            TSEMCG: GeckoBoolStructAccessor(self.struct, TSEMCG, JZTATD, ZILXWA, None),
-            SEMCGE: GeckoBoolStructAccessor(self.struct, SEMCGE, JZTATD, BSSUHB, None),
-            EMCGET: GeckoBoolStructAccessor(self.struct, EMCGET, JZTATD, SUHBVW, None),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, ATDZXN, FTTIDU, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, ATDZXN, ZILXWA, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, ATDZXN, BSSUHB, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, ATDZXN, SUHBVW, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, ZXNQTM, FTTIDU, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, ZXNQTM, ZILXWA, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, ZXNQTM, BSSUHB, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, ZXNQTM, SUHBVW, None),
         }

--- a/src/geckolib/driver/packs/inyj-v2-cfg-61.py
+++ b/src/geckolib/driver/packs/inyj-v2-cfg-61.py
@@ -12,926 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 30
-ACQFFT = 108
-AFIKJP = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-AIIDNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 50])
-AKSTSE = "".join(chr(c) for c in [51])
-AMJMAO = "".join(chr(c) for c in [70, 51])
-AOAWBS = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-AONPYY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-ATDZXN = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-AWBSIR = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BDJQRJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-BFEGZU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-BIAMJM = "".join(chr(c) for c in [70, 49])
-BJEUTO = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BLKXSJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-BQNRXC = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-BQSNQL = 10
-BSIRYX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-BSKSOK = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BSSUHB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-BVWVUB = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-BWJYKL = 77
-BXIBHZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-BXTIAC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-BXYBQS = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-BYGDSB = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-CBFEGZ = 27
-CCPQIP = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-CHWDAF = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-CPQIPO = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CRTFMN = "".join(chr(c) for c in [67, 89, 65, 78])
-CTHBSK = 79
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-DGKEAK = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-DJQRJJ = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DNIBXT = 107
-DNQGVU = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DQLAII = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DSBDJQ = 43
-DUBSSU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-EAKSTS = "".join(chr(c) for c in [50])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-EFXQGL = 37
-EJNIBX = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-EKCWAO = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-EKVKZI = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-EMCGET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-EOCTHB = 39
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-EUTOPH = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-EXLSXU = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FCRTFM = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-FEGZUQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-FFTTID = "".join(chr(c) for c in [65, 109, 80, 109])
-FIKJPU = 46
-FJBIAM = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-FJTACC = 29
-FMNHTB = 8
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-FTTIDU = "".join(chr(c) for c in [50, 52, 104])
-FWRKIN = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-FZDGKE = 126
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-GKEAKS = 127
-GLRAHE = 40
-GQPLSP = "".join(chr(c) for c in [67, 69])
-GSELHB = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-GTYIYW = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GVUNXN = "".join(chr(c) for c in [77, 65, 65, 88])
-GYOUSP = 68
-GZUQEX = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-HBQNRX = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-HBVWVU = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HBXIBH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 0
-HTBJEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-HUGTYI = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-HUOJRJ = 56
-HWDAFI = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HXEKVK = 72
-HZVOAC = 61
-IACQFF = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-IAMJMA = "".join(chr(c) for c in [70, 50])
-IBXTIA = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-IBXYBQ = 23
-ICXQIE = 16
-IDNIBX = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IDUBSS = 64
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-IGYOUS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IHBXIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-IIDNIB = 75
-IJUGSE = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-IKJPUN = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-ILXWAJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-INEJNI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 63
-IRYXBQ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IUSOOQ = 2
-IUXFEF = 28
-IVDNQG = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-IYWSKW = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-JBIAMJ = 83
-JEUTOP = 44
-JIGYOU = 66
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-JJVYFC = "".join(chr(c) for c in [82, 69, 68])
-JMAOAW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-JNIBXY = 6
-JPUNRJ = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JRJHIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JUGSEL = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-JUIKFW = 104
-JUTYEK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JWMNZM = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JYKLGQ = 26
-KCWAON = 60
-KEAKST = "".join(chr(c) for c in [49])
-KFWRKI = 105
-KINEJN = 3
-KJPUNR = 47
-KLGQPL = 51
-KMLOIJ = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-KPHUOJ = 55
-KQXPIC = 13
-KSOKPH = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KSTSEM = "".join(chr(c) for c in [52])
-KVKZIL = 1
-KWIVDN = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [85, 76])
-LHBQNR = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-LIUXFE = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LJUIKF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-LKXSJW = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-LNMHXE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-LOIJUG = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-LRAHEO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-LSPFTS = 52
-LSXUJU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LXWAJV = 76
-MCBFEG = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-MFZDGK = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJMAOA = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-MNZMJI = 3
-MOUNBL = 31
-NBLKXS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-NEJNIB = 4
-NHTBJE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NIBXTI = "".join(chr(c) for c in [79, 70, 70])
-NIBXYB = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NKMLOI = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NMHXEK = 82
-NPYYLI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NQGVUN = "".join(chr(c) for c in [76, 65])
-NQJYMO = "".join(chr(c) for c in [70])
-NQLNMH = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-NQTMFZ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-NRJZTA = 123
-NRSJMC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-NXNKML = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-NZMJIG = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OAWBSI = 84
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OIHBXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-OIJUGS = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-OJRJHI = 81
-OKPHUO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-ONPYYL = 62
-OOQNRS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-OPHUGT = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-OQNRSJ = 32
-OUNBLK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-OUSPBW = 70
-OUYNQJ = 1
-PBWJYK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-PFTSIF = 53
-PHUGTY = "".join(chr(c) for c in [65, 108, 112, 115])
-PHUOJR = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-POUYNQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-PUNRJZ = 121
-PYYLIU = 78
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QFFTTI = 34
-QFYLJU = 99
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-QIEFXQ = 36
-QIPOUY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QJYMOU = "".join(chr(c) for c in [67])
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QNRSJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QNRXCH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QTMFZD = 125
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 51])
-RAHEOC = 15
-RJHIUS = "".join(chr(c) for c in [79, 119, 110])
-RJJJVY = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RJZTAT = "".join(chr(c) for c in [82, 71, 66])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-RSJMCB = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-RTFMNH = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-RYXBQF = 87
-SBDJQR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SELHBQ = "".join(chr(c) for c in [73, 100, 111, 108])
-SEMCGE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-SIFJBI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SIRYXB = 86
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SJWMNZ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SKSOKP = 80
-SKWIVD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SNQLNM = 71
-SOKPHU = 54
-SOOQNR = 48
-SPFTSI = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-SSAKQX = "".join(chr(c) for c in [65, 85, 88])
-SUHBVW = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-SXUJUT = "".join(chr(c) for c in [76, 111])
-TACCPQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-TATDZX = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-THBSKS = "".join(chr(c) for c in [76, 73])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIDUBS = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-TMFZDG = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-TOPHUG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-TSEMCG = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-TSIFJB = 74
-TYEKCW = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-TYIYWS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-UBSSUH = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBYGDS = 6
-UGSELH = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-UGTYIY = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-UHBVWV = 4
-UNBLKX = 25
-UNRJZT = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-UNXNKM = "".join(chr(c) for c in [80, 68, 67])
-UOJRJH = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-UQEXLS = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-USOOQN = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-USPBWJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UTOPHU = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UTYEKC = 58
-UXFEFJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UYNQJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-VDNQGV = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VDQLAI = 73
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-VUNXNK = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-VWVUBY = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-VXOIHB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-VYFCRT = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WAONPY = 61
-WBSIRY = 85
-WDAFIK = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-WIVDNQ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-WRKINE = 106
-WSKWIV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-XBQFYL = 98
-XCHWDA = 45
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-XFEFJT = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XNKMLO = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-XOIHBX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-XPICXQ = 14
-XQGLRA = 38
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XSJWMN = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XTIACQ = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-XUJUTY = "".join(chr(c) for c in [72, 105])
-XWAJVD = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-XYBQSN = 8
-YBQSNQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YEKCWA = 59
-YFCRTF = "".join(chr(c) for c in [66, 76, 85, 69])
-YGDSBD = 7
-YIYWSK = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-YKLGQP = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-YLJUIK = 100
-YMOUNB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YNQJYM = 33
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-YXBQFY = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-YYLIUX = "".join(chr(c) for c in [80, 49])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ZILXWA = 5
-ZMJIGY = 35
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-ZUQEXL = 57
-ZXNQTM = 124
-AHEOCT = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-AJVDQL = [XWAJVD, WAJVDQ]
-BHZVOA = []
-CXQIEF = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-DAFIKJ = [HWDAFI, WDAFIK, VLASSA, VLASSA]
-EGZUQE = [BFEGZU, FEGZUQ]
-FEFJTA = [UXFEFJ, XFEFJT]
-HBSKSO = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    THBSKS,
-]
-IBHZVO = [THBSKS]
-IFJBIA = [CCPQIP, SIFJBI]
-JHIUSO = [JRJHIU, RJHIUS]
-JMCBFE = [QNRSJM, NRSJMC, RSJMCB, SJMCBF]
-JTACCP = [PIPIVL, YYLIUX]
-JYMOUN = [NQJYMO, QJYMOU]
-JZTATD = [RJZTAT, RTFMNH]
-KXSJWM = [NBLKXS, BLKXSJ, LKXSJW]
-LAIIDN = [VLASSA, DQLAII, QLAIID]
-MAOAWB = [BIAMJM, IAMJMA, AMJMAO, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-NRXCHW = [
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-]
-PQIPOU = [CCPQIP, CPQIPO]
-QLNMHX = [JVHFTH, BFEGZU, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QRJJJV = [DJQRJJ, JQRJJJ]
-SAKQXP = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-SPBWJY = [CCPQIP, USPBWJ]
-SSUHBV = [UBSSUH, BSSUHB]
-STSEMC = [VLASSA, KEAKST, EAKSTS, AKSTSE, KSTSEM]
-TBJEUT = [NHTBJE, HTBJEU]
-TDZXNQ = [TATDZX, ATDZXN]
-TFMNHT = [NIBXTI, JJVYFC, JVYFCR, VYFCRT, YFCRTF, FCRTFM, CRTFMN, RTFMNH]
-TIACQF = [JVHFTH, NIBXTI, IBXTIA, BXTIAC, XTIACQ]
-TTIDUB = [JVHFTH, FFTTID, FTTIDU]
-UIKFWR = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, MJMAOA, JMAOAW]
-UJUTYE = [SXUJUT, XUJUTY]
-WMNZMJ = [SJWMNZ, JWMNZM]
-WVUBYG = [BVWVUB, VWVUBY]
-XIBHZV = [BMJVHF, AKQXPI, QXPICX, PICXQI, LRAHEO, OCTHBS]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-YLIUXF = [JVHFTH, YYLIUX, PIPIVL]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -939,261 +19,681 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return HZVOAC
+        return 61
 
     @property
     def output_keys(self):
-        return XIBHZV
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, SAKQXP, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                107,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 108, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, SAKQXP, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, SAKQXP, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, CXQIEF, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoByteStructAccessor(self.struct, XQIEFX, QIEFXQ, QBMJVH),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, RAHEOC, None, AHEOCT, None, None, QBMJVH
-            ),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, HBSKSO, None, None, None
-            ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, None),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, QBMJVH),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, QBMJVH),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, HIUSOO, JHIUSO, None, IUSOOQ, QBMJVH
-            ),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, QBMJVH),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, JMCBFE, None, None, QBMJVH
-            ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, EGZUQE, None, None, QBMJVH
-            ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, OJRJHI, IUSOOQ, UJUTYE, None, IUSOOQ, QBMJVH
-            ),
-            JUTYEK: GeckoByteStructAccessor(self.struct, JUTYEK, UTYEKC, QBMJVH),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, QBMJVH),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YLIUXF, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FEFJTA, None, None, QBMJVH
-            ),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, JTACCP, None, None, QBMJVH
-            ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, PQIPOU, None, None, QBMJVH
-            ),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoTempStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
-            ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, JTACCP, None, None, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, KXSJWM, None, None, QBMJVH
-            ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, OJRJHI, MNZMJI, WMNZMJ, None, IUSOOQ, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoTempStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, SPBWJY, None, None, QBMJVH
-            ),
-            PBWJYK: GeckoByteStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoByteStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, MAOAWB, None, None, QBMJVH
-            ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, MAOAWB, None, None, QBMJVH
-            ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, SIRYXB, None, MAOAWB, None, None, QBMJVH
-            ),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, MAOAWB, None, None, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoByteStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, UIKFWR, None, None, QBMJVH
-            ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, UIKFWR, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, UIKFWR, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoTimeStructAccessor(self.struct, INEJNI, NEJNIB, QBMJVH),
-            EJNIBX: GeckoTimeStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoTimeStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTimeStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoTimeStructAccessor(self.struct, YBQSNQ, BQSNQL, QBMJVH),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoBoolStructAccessor(
-                self.struct, LNMHXE, NMHXEK, HIUSOO, QBMJVH
-            ),
-            MHXEKV: GeckoBoolStructAccessor(
-                self.struct, MHXEKV, HXEKVK, IUSOOQ, QBMJVH
-            ),
-            XEKVKZ: GeckoBoolStructAccessor(
-                self.struct, XEKVKZ, HXEKVK, HIUSOO, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, HXEKVK, KVKZIL, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, HXEKVK, MNZMJI, QBMJVH
-            ),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, HXEKVK, ZILXWA, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, LAIIDN, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, TIACQF, None, None, QBMJVH
-            ),
-            IACQFF: GeckoTimeStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, OJRJHI, KVKZIL, SSUHBV, None, IUSOOQ, QBMJVH
-            ),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, OJRJHI, UHBVWV, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, OJRJHI, ZILXWA, WVUBYG, None, IUSOOQ, QBMJVH
-            ),
-            VUBYGD: GeckoBoolStructAccessor(
-                self.struct, VUBYGD, OJRJHI, UBYGDS, QBMJVH
-            ),
-            BYGDSB: GeckoBoolStructAccessor(
-                self.struct, BYGDSB, OJRJHI, YGDSBD, QBMJVH
-            ),
-            GDSBDJ: GeckoBoolStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, HIUSOO, QBMJVH
-            ),
-            SBDJQR: GeckoBoolStructAccessor(
-                self.struct, SBDJQR, DSBDJQ, KVKZIL, QBMJVH
-            ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DSBDJQ, IUSOOQ, QRJJJV, None, IUSOOQ, QBMJVH
-            ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, DSBDJQ, MNZMJI, QRJJJV, None, IUSOOQ, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, DSBDJQ, UHBVWV, TFMNHT, None, FMNHTB, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, DSBDJQ, YGDSBD, TBJEUT, None, IUSOOQ, QBMJVH
-            ),
-            RXCHWD: GeckoBoolStructAccessor(
-                self.struct, RXCHWD, XCHWDA, KVKZIL, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, XCHWDA, IUSOOQ, DAFIKJ, None, UHBVWV, QBMJVH
-            ),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, QBMJVH),
-            IKJPUN: GeckoBoolStructAccessor(
-                self.struct, IKJPUN, KJPUNR, HIUSOO, QBMJVH
-            ),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, QBMJVH),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, NRJZTA, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, NRJZTA, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, ZXNQTM, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, QTMFZD, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, FZDGKE, HIUSOO, JZTATD, None, IUSOOQ, None
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, FZDGKE, KVKZIL, TDZXNQ, None, IUSOOQ, None
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, GKEAKS, HIUSOO, STSEMC, None, FMNHTB, None
-            ),
-            TSEMCG: GeckoBoolStructAccessor(self.struct, TSEMCG, GKEAKS, YGDSBD, None),
-            SEMCGE: GeckoBoolStructAccessor(self.struct, SEMCGE, NRJZTA, UHBVWV, None),
-            EMCGET: GeckoBoolStructAccessor(self.struct, EMCGET, NRJZTA, ZILXWA, None),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, NRJZTA, UBYGDS, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, NRJZTA, YGDSBD, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, ZXNQTM, UHBVWV, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, ZXNQTM, ZILXWA, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, ZXNQTM, UBYGDS, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, ZXNQTM, YGDSBD, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, QTMFZD, UHBVWV, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, QTMFZD, ZILXWA, None),
-            VXOIHB: GeckoBoolStructAccessor(self.struct, VXOIHB, QTMFZD, UBYGDS, None),
-            XOIHBX: GeckoBoolStructAccessor(self.struct, XOIHBX, QTMFZD, YGDSBD, None),
-            OIHBXI: GeckoBoolStructAccessor(self.struct, OIHBXI, FZDGKE, UHBVWV, None),
-            IHBXIB: GeckoBoolStructAccessor(self.struct, IHBXIB, FZDGKE, ZILXWA, None),
-            HBXIBH: GeckoBoolStructAccessor(self.struct, HBXIBH, FZDGKE, UBYGDS, None),
-            BXIBHZ: GeckoBoolStructAccessor(self.struct, BXIBHZ, FZDGKE, YGDSBD, None),
         }

--- a/src/geckolib/driver/packs/inyj-v2-log-57.py
+++ b/src/geckolib/driver/packs/inyj-v2-log-57.py
@@ -12,913 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 268
-ACMCVD = 475
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-AFIKJP = 448
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [67, 69])
-AJVDQL = "".join(chr(c) for c in [51, 50, 75])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-AMJMAO = 350
-AOAWBS = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-AONPYY = 263
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 454
-AWBSIR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BDJQRJ = 316
-BFEGZU = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BIAMJM = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-BJEUTO = 358
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BQNRXC = 331
-BQSNQL = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BSIRYX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-BVWVUB = 296
-BWJYKL = 279
-BXIBHZ = 471
-BXTIAC = "".join(chr(c) for c in [53, 79, 80])
-BXYBQS = 287
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-CBFEGZ = "".join(chr(c) for c in [76, 49, 50, 48])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = 465
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-CPQIPO = 270
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-CRTFMN = "".join(chr(c) for c in [75, 53])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 48])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-DJQRJJ = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-DNIBXT = "".join(chr(c) for c in [80, 50, 50])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-DSBDJQ = 301
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-DZXNQT = 455
-EAKSTS = 461
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EJNIBX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-EKCWAO = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-EKVKZI = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-EMCGET = 464
-EOCTHB = 308
-ETIXQV = 466
-EUTOPH = 360
-EXLSXU = "".join(chr(c) for c in [70, 85, 76, 76])
-FCRTFM = "".join(chr(c) for c in [75, 52])
-FEFJTA = 266
-FEGZUQ = 5
-FFTTID = "".join(chr(c) for c in [51, 48, 65])
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 49])
-FJBIAM = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-FJTACC = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-FMNHTB = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-FTHECV = 319
-FTSIFJ = 283
-FWRKIN = 314
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-GKEAKS = 460
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 49, 76])
-GVUNXN = 322
-GYOUSP = 275
-GZUQEX = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HBSKSO = 370
-HBVWVU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [76, 79, 87])
-HUGTYI = "".join(chr(c) for c in [78, 65])
-HUOJRJ = 306
-HWDAFI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-HXEKVK = "".join(chr(c) for c in [105, 110, 88, 77])
-HZVOAC = 473
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-IAMJMA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IBHZVO = 472
-IBXTIA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-IBXYBQ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-IDUBSS = 291
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = 284
-IGYOUS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IHBXIB = 470
-IJUGSE = 327
-IKFWRK = 311
-IKJPUN = 449
-INEJNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-IUXFEF = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IVDNQG = "".join(chr(c) for c in [65, 85, 88])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 467
-IYWSKW = "".join(chr(c) for c in [80, 51, 72])
-JBIAMJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-JEUTOP = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-JHIUSO = "".join(chr(c) for c in [72, 73, 71, 72])
-JIGYOU = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-JJJVYF = 357
-JJVYFC = "".join(chr(c) for c in [75, 50, 48, 48])
-JMAOAW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-JMCBFE = "".join(chr(c) for c in [79, 51])
-JNIBXY = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JPUNRJ = 450
-JQRJJJ = "".join(chr(c) for c in [70, 117, 108, 108])
-JRJHIU = "".join(chr(c) for c in [80, 49])
-JTACCP = 267
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-JUTYEK = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-JVDQLA = "".join(chr(c) for c in [52, 56, 75])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 52, 48, 48])
-JYKLGQ = 280
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 53])
-KCWAON = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-KFWRKI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KINEJN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 50])
-KLGQPL = 281
-KMLOIJ = 326
-KPHUOJ = 305
-KQTDKH = 57
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-KSTSEM = 462
-KVKZIL = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-KWIVDN = "".join(chr(c) for c in [66, 76, 79])
-KXSJWM = "".join(chr(c) for c in [78, 79])
-KZILXW = "".join(chr(c) for c in [75, 56, 48, 48])
-LAIIDN = "".join(chr(c) for c in [85, 76])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-LHBQNR = 330
-LJUIKF = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-LKXSJW = 313
-LNMHXE = "".join(chr(c) for c in [77, 73, 65])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LSXUJU = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-LXWAJV = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-MAOAWB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-MCBFEG = 3
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-MCVDSS = 476
-MFZDGK = 458
-MHXEKV = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-MJIGYO = 355
-MJMAOA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = "".join(chr(c) for c in [72, 84, 82])
-MNHTBJ = "".join(chr(c) for c in [75, 51, 48, 48])
-MNZMJI = 353
-MOUNBL = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NBLKXS = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-NHTBJE = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-NIBXYB = 285
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NMHXEK = "".join(chr(c) for c in [68, 74, 83, 52])
-NPYYLI = "".join(chr(c) for c in [83, 84, 79, 80])
-NQGVUN = 321
-NQJYMO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-NQLNMH = "".join(chr(c) for c in [105, 110, 88, 69])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 57])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 52])
-NRXCHW = 333
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NZMJIG = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-OAWBSI = 351
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-OJRJHI = 369
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [73, 68, 76, 69])
-OOQNRS = "".join(chr(c) for c in [80, 52])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-OQNRSJ = "".join(chr(c) for c in [80, 53])
-OUNBLK = 282
-OUSPBW = 277
-OUYNQJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PBWJYK = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-PFTSIF = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PHUGTY = 320
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-POUYNQ = 272
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 51])
-PYYLIU = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-QFFTTI = "".join(chr(c) for c in [50, 53, 65])
-QFYLJU = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-QIEFXQ = 2
-QIPOUY = 271
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-QLNMHX = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-QNRSJM = 260
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-QPLSPF = 352
-QSNQLN = 289
-QTDKHT = 256
-QTMFZD = 457
-QVXOIH = 468
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [76, 73])
-RJHIUS = 261
-RJJJVY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-RJZTAT = 452
-RKINEJ = 315
-RSJMCB = "".join(chr(c) for c in [66, 76])
-RTFMNH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-RURAZM = 479
-RXCHWD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-RYXBQF = 354
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SELHBQ = 329
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-SIFJBI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-SJMCBF = "".join(chr(c) for c in [67, 80])
-SJWMNZ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-SKSOKP = 303
-SKWIVD = "".join(chr(c) for c in [80, 52, 76])
-SNQLNM = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-SOKPHU = 304
-SOOQNR = "".join(chr(c) for c in [80, 51])
-SPFTSI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-SSRURA = 478
-SSUHBV = 294
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-SUHBVW = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-SXUJUT = 364
-TACCPQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 54])
-TBJEUT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-TDKHTZ = 479
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 55])
-TFMNHT = "".join(chr(c) for c in [75, 49, 48, 48])
-THBSKS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-TOPHUG = 361
-TSEMCG = 463
-TSIFJB = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-TTIDUB = 7
-TYEKCW = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 50, 72])
-UBSSUH = 293
-UBYGDS = 299
-UGSELH = 328
-UGTYIY = "".join(chr(c) for c in [80, 49, 72])
-UHBVWV = 295
-UIKFWR = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-UJUTYE = 365
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-UNRJZT = 451
-UNXNKM = 323
-UOJRJH = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-UQEXLS = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-USOOQN = "".join(chr(c) for c in [80, 50])
-USPBWJ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-UTOPHU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-UTYEKC = 367
-UXFEFJ = 264
-UYNQJY = 273
-VDQLAI = "".join(chr(c) for c in [54, 52, 75])
-VDSSRU = 477
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [105, 110, 89, 84])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 474
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-VYFCRT = "".join(chr(c) for c in [75, 56, 53])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [49, 54, 75])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-WDAFIK = 332
-WIVDNQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WJYKLG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-WMNZMJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-WRKINE = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-WSKWIV = "".join(chr(c) for c in [80, 52, 72])
-WVUBYG = 297
-XBQFYL = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-XCHWDA = 325
-XEKVKZ = "".join(chr(c) for c in [75, 54, 48, 48])
-XFEFJT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XNKMLO = 324
-XNQTMF = 456
-XOIHBX = 469
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-XSJWMN = "".join(chr(c) for c in [77, 69, 68])
-XTIACQ = "".join(chr(c) for c in [51, 79, 80])
-XUJUTY = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-XWAJVD = 290
-XYBQSN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-YBQSNQ = 288
-YEKCWA = 262
-YFCRTF = "".join(chr(c) for c in [75, 56])
-YGDSBD = 300
-YIYWSK = "".join(chr(c) for c in [80, 50, 76])
-YKLGQP = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YLIUXF = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YLJUIK = 309
-YMOUNB = "".join(chr(c) for c in [67, 80, 79, 84])
-YNQJYM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YOUSPB = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 51, 76])
-YXBQFY = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YYLIUX = "".join(chr(c) for c in [78, 69, 87])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 459
-ZILXWA = "".join(chr(c) for c in [105, 110, 89, 74])
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-ZTATDZ = 453
-ZUQEXL = 310
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 56])
-AZMKQT = [
-    JRJHIU,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    RSJMCB,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    BFEGZU,
-    EGZUQE,
-    GZUQEX,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    RAZMKQ,
-]
-CHWDAF = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SJMCBF,
-]
-CWAONP = [EKCWAO, KCWAON]
-DQLAII = [WAJVDQ, AJVDQL, JVDQLA, VDQLAI]
-FTTIDU = [QFFTTI, FFTTID]
-HTBJEU = [
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    KZILXW,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-]
-IIDNIB = [LAIIDN, AIIDNI]
-ILXWAJ = [
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-]
-IUSOOQ = [ASSAKQ, JHIUSO, HIUSOO]
-JUIKFW = [HECVYY, LJUIKF, LJUIKF, LJUIKF]
-JWMNZM = [KXSJWM, QXPICX, XSJWMN, XPICXQ, SJWMNZ]
-LIUXFE = [ONPYYL, NPYYLI, PYYLIU, YYLIUX, YLIUXF]
-LOIJUG = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    MLOIJU,
-]
-MKQTDK = [
-    INEJNI,
-    AWBSIR,
-    SIRYXB,
-    FJBIAM,
-    JIGYOU,
-    KINEJN,
-    NEJNIB,
-    PBWJYK,
-    JYMOUN,
-    MAOAWB,
-    IAMJMA,
-    PLSPFT,
-    GQPLSP,
-    WRKINE,
-    BIAMJM,
-    AOAWBS,
-    JMAOAW,
-    TSIFJB,
-    IRYXBQ,
-    PFTSIF,
-    LSPFTS,
-    WBSIRY,
-    BQFYLJ,
-    BSIRYX,
-    SPFTSI,
-    MJMAOA,
-    JBIAMJ,
-    SIFJBI,
-]
-NIBXTI = [RSJMCB, DNIBXT]
-NRSJMC = [ASSAKQ, JHIUSO]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QRJJJV = [DJQRJJ, JQRJJJ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SPBWJY = [HECVYY, USPBWJ, USPBWJ, USPBWJ]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TIACQF = [BXTIAC, XTIACQ]
-URAZMK = []
-VDNQGV = [
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    OQNRSJ,
-    KWIVDN,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IVDNQG,
-]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-ZMKQTD = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -926,260 +19,811 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return KQTDKH
+        return 57
 
     @property
     def begin(self):
-        return QTDKHT
+        return 256
 
     @property
     def end(self):
-        return TDKHTZ
+        return 479
 
     @property
     def all_device_keys(self):
-        return AZMKQT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ZMKQTD
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return MKQTDK
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, ICXQIE, IUSOOQ, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, RJHIUS, QIEFXQ, IUSOOQ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, RJHIUS, CXQIEF, IUSOOQ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, RJHIUS, VHFTHE, IUSOOQ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, ICXQIE, NRSJMC, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, QNRSJM, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, QNRSJM, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, QNRSJM, MCBFEG, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, QNRSJM, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, QNRSJM, FEGZUQ, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, QNRSJM, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XLSXUJ, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            XUJUTY: GeckoWordStructAccessor(self.struct, XUJUTY, UJUTYE, None),
-            JUTYEK: GeckoWordStructAccessor(self.struct, JUTYEK, UTYEKC, SAKQXP),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, ICXQIE, CWAONP, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, LIUXFE, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            IUXFEF: GeckoTimeStructAccessor(self.struct, IUXFEF, UXFEFJ, SAKQXP),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, SAKQXP),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YEKCWA, QIEFXQ, CWAONP, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, LIUXFE, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            TACCPQ: GeckoTimeStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, SAKQXP),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, UYNQJY, ICXQIE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, UYNQJY, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, UYNQJY, MCBFEG, None),
-            QJYMOU: GeckoBoolStructAccessor(self.struct, QJYMOU, UYNQJY, CXQIEF, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, UYNQJY, FEGZUQ, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, JVHFTH, QIEFXQ, None),
-            MOUNBL: GeckoBoolStructAccessor(self.struct, MOUNBL, OUNBLK, MCBFEG, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, OUNBLK, FEGZUQ, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, OUNBLK, VHFTHE, None),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, JWMNZM, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, MNZMJI, FEGZUQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, MNZMJI, VHFTHE, None),
-            ZMJIGY: GeckoWordStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, JVHFTH, AHEOCT, None),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, None),
-            YOUSPB: GeckoTempStructAccessor(self.struct, YOUSPB, OUSPBW, None),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, QNRSJM, FEGZUQ, SPBWJY, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, QIEFXQ, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, QIEFXQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(
-                self.struct, LGQPLS, KLGQPL, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, AHEOCT, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, JVHFTH, MCBFEG, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, OUNBLK, ICXQIE, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, OUNBLK, AHEOCT, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, QIEFXQ, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, MCBFEG, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, MCBFEG, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, CXQIEF, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, IFJBIA, FEGZUQ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IFJBIA, VHFTHE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, AMJMAO, MCBFEG, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, AMJMAO, CXQIEF, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, AMJMAO, FEGZUQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AMJMAO, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QIEFXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, MCBFEG, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, QPLSPF, MCBFEG, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, MNZMJI, ICXQIE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, MNZMJI, AHEOCT, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, ICXQIE, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, JYKLGQ, ICXQIE, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, FTSIFJ, ICXQIE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, FTSIFJ, AHEOCT, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FTSIFJ, CXQIEF, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YLJUIK, ICXQIE, None),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, YLJUIK, AHEOCT, JUIKFW, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            UIKFWR: GeckoWordStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, ICXQIE, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, RKINEJ, AHEOCT, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, OAWBSI, ICXQIE, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, OAWBSI, AHEOCT, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, OAWBSI, CXQIEF, None),
-            JNIBXY: GeckoWordStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoByteStructAccessor(self.struct, IBXYBQ, BXYBQS, None),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, ILXWAJ, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, ICXQIE, DQLAII, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, XWAJVD, QIEFXQ, IIDNIB, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, XWAJVD, MCBFEG, NIBXTI, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, XWAJVD, CXQIEF, TIACQF, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, XWAJVD, FEGZUQ, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, XWAJVD, VHFTHE, None),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, XWAJVD, TTIDUB, FTTIDU, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoWordStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoWordStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, QRJJJV, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, JJJVYF, None, HTBJEU, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            TBJEUT: GeckoWordStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, VDNQGV, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, VDNQGV, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, VDNQGV, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, VDNQGV, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, VDNQGV, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, LOIJUG, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, CHWDAF, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-v2-log-58.py
+++ b/src/geckolib/driver/packs/inyj-v2-log-58.py
@@ -12,940 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 268
-ACMCVD = 473
-ACQFFT = "".join(chr(c) for c in [53, 79, 80])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [54, 52, 75])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-AMJMAO = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-AOAWBS = 350
-AONPYY = 263
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 452
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-BDJQRJ = 300
-BFEGZU = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-BIAMJM = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-BJEUTO = "".join(chr(c) for c in [75, 51, 48, 48])
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-BQNRXC = 329
-BQSNQL = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-BSIRYX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BVWVUB = 294
-BWJYKL = 279
-BXIBHZ = 469
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-BXYBQS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-CBFEGZ = "".join(chr(c) for c in [76, 49, 50, 48])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-CGETIX = 463
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-CPQIPO = 270
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [51, 79, 80])
-CRTFMN = "".join(chr(c) for c in [75, 52, 48, 48])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CXQIEF = 4
-DAFIKJ = 325
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-DNIBXT = "".join(chr(c) for c in [85, 76])
-DNQGVU = "".join(chr(c) for c in [66, 76, 79])
-DQLAII = "".join(chr(c) for c in [49, 54, 75])
-DSBDJQ = 299
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-DZXNQT = 453
-EAKSTS = 459
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EJNIBX = 315
-EKCWAO = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-EKVKZI = "".join(chr(c) for c in [68, 74, 83, 52])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-EMCGET = 462
-EOCTHB = 308
-ETIXQV = 464
-EXLSXU = "".join(chr(c) for c in [70, 85, 76, 76])
-FCRTFM = "".join(chr(c) for c in [75, 50, 48, 48])
-FEFJTA = 266
-FEGZUQ = 5
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-FIKJPU = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-FJBIAM = 283
-FJTACC = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-FMNHTB = "".join(chr(c) for c in [75, 52])
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 57])
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-GKEAKS = 458
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-GYOUSP = 275
-GZUQEX = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-HBSKSO = 370
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [76, 79, 87])
-HTBJEU = "".join(chr(c) for c in [75, 49, 48, 48])
-HTZBBE = 256
-HUGTYI = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-HUOJRJ = 306
-HWDAFI = 333
-HXEKVK = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-HZVOAC = 471
-IACQFF = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-IAMJMA = 284
-IBHZVO = 470
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-IDUBSS = "".join(chr(c) for c in [51, 48, 65])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-IGYOUS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IHBXIB = 468
-IJUGSE = 326
-IKFWRK = 309
-IKJPUN = 332
-ILXWAJ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-INEJNI = 314
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-IUXFEF = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-IVDNQG = "".join(chr(c) for c in [80, 52, 72])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 465
-IYWSKW = "".join(chr(c) for c in [80, 49, 72])
-JBIAMJ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-JEUTOP = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JHIUSO = "".join(chr(c) for c in [72, 73, 71, 72])
-JIGYOU = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-JJJVYF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-JJVYFC = "".join(chr(c) for c in [70, 117, 108, 108])
-JMAOAW = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-JMCBFE = "".join(chr(c) for c in [79, 51])
-JNIBXY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JPUNRJ = 448
-JQRJJJ = 301
-JRJHIU = "".join(chr(c) for c in [80, 49])
-JTACCP = 267
-JUGSEL = "".join(chr(c) for c in [72, 84, 82])
-JUIKFW = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-JUTYEK = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-JVDQLA = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-JVHFTH = 274
-JYKLGQ = 280
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 51])
-KCWAON = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-KFWRKI = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-KHTZBB = 58
-KINEJN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 48])
-KLGQPL = 281
-KMLOIJ = 323
-KPHUOJ = 305
-KQTDKH = "".join(chr(c) for c in [76, 73])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-KSTSEM = 460
-KVKZIL = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-KWIVDN = "".join(chr(c) for c in [80, 51, 72])
-KXSJWM = "".join(chr(c) for c in [78, 79])
-KZILXW = "".join(chr(c) for c in [75, 54, 48, 48])
-LAIIDN = "".join(chr(c) for c in [52, 56, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-LHBQNR = 328
-LJUIKF = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-LKXSJW = 313
-LNMHXE = 289
-LOIJUG = 324
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 377
-LSXUJU = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-LXWAJV = "".join(chr(c) for c in [105, 110, 89, 84])
-MAOAWB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-MCBFEG = 3
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MCVDSS = 474
-MFZDGK = 456
-MHXEKV = "".join(chr(c) for c in [105, 110, 88, 69])
-MJIGYO = 355
-MJMAOA = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-MNHTBJ = "".join(chr(c) for c in [75, 53])
-MNZMJI = 353
-MOUNBL = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-NBLKXS = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NHTBJE = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-NIBXTI = "".join(chr(c) for c in [67, 69])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-NMHXEK = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NPYYLI = "".join(chr(c) for c in [83, 84, 79, 80])
-NQGVUN = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-NQJYMO = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-NQLNMH = 288
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 55])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 50])
-NRXCHW = 330
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-NZMJIG = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-OAWBSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-OJRJHI = 369
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-ONPYYL = "".join(chr(c) for c in [73, 68, 76, 69])
-OOQNRS = "".join(chr(c) for c in [80, 52])
-OPHUGT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-OQNRSJ = "".join(chr(c) for c in [80, 53])
-OUNBLK = 282
-OUSPBW = 277
-OUYNQJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-PBWJYK = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-PFTSIF = 383
-PHUGTY = 360
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-POUYNQ = 272
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 49])
-PYYLIU = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-QFYLJU = 354
-QGVUNX = "".join(chr(c) for c in [65, 85, 88])
-QIEFXQ = 2
-QIPOUY = 271
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [51, 50, 75])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-QNRSJM = 260
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-QPLSPF = 352
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-QSNQLN = 287
-QTMFZD = 455
-QVXOIH = 466
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 478
-RJHIUS = 261
-RJJJVY = 316
-RJZTAT = 450
-RKINEJ = 311
-RSJMCB = "".join(chr(c) for c in [66, 76])
-RTFMNH = "".join(chr(c) for c in [75, 56, 53])
-RURAZM = 477
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SELHBQ = 327
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-SIFJBI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SIRYXB = 351
-SJMCBF = "".join(chr(c) for c in [67, 80])
-SJWMNZ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-SKSOKP = 303
-SKWIVD = "".join(chr(c) for c in [80, 50, 76])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-SOKPHU = 304
-SOOQNR = "".join(chr(c) for c in [80, 51])
-SPFTSI = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-SSRURA = 476
-SSUHBV = 291
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-SXUJUT = 364
-TACCPQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 52])
-TBJEUT = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 53])
-TFMNHT = "".join(chr(c) for c in [75, 56])
-THBSKS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(chr(c) for c in [50, 53, 65])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 56])
-TOPHUG = 358
-TSEMCG = 461
-TSIFJB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-TTIDUB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-TYEKCW = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-TYIYWS = 320
-TZBBEK = 479
-UBSSUH = 7
-UBYGDS = 296
-UGTYIY = 361
-UHBVWV = 293
-UIKFWR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-UJUTYE = 365
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-UNRJZT = 449
-UNXNKM = 321
-UOJRJH = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-UQEXLS = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-USOOQN = "".join(chr(c) for c in [80, 50])
-USPBWJ = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-UTOPHU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UTYEKC = 367
-UXFEFJ = 264
-UYNQJY = 273
-VDNQGV = "".join(chr(c) for c in [80, 52, 76])
-VDQLAI = 290
-VDSSRU = 475
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [105, 110, 88, 77])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 472
-VUBYGD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-VWVUBY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-VYFCRT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 89, 74])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-WBSIRY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-WDAFIK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-WIVDNQ = "".join(chr(c) for c in [80, 51, 76])
-WJYKLG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-WMNZMJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-WRKINE = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-WSKWIV = "".join(chr(c) for c in [80, 50, 72])
-WVUBYG = 295
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-XCHWDA = 331
-XEKVKZ = "".join(chr(c) for c in [77, 73, 65])
-XFEFJT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-XNKMLO = 322
-XNQTMF = 454
-XOIHBX = 467
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-XSJWMN = "".join(chr(c) for c in [77, 69, 68])
-XTIACQ = "".join(chr(c) for c in [80, 50, 50])
-XUJUTY = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-XWAJVD = "".join(chr(c) for c in [75, 56, 48, 48])
-XYBQSN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-YBQSNQ = 285
-YEKCWA = 262
-YFCRTF = 357
-YGDSBD = 297
-YIYWSK = "".join(chr(c) for c in [78, 65])
-YKLGQP = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YLIUXF = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YLJUIK = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-YMOUNB = "".join(chr(c) for c in [67, 80, 79, 84])
-YNQJYM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YOUSPB = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 49, 76])
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-YYLIUX = "".join(chr(c) for c in [78, 69, 87])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 457
-ZILXWA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-ZMKQTD = 479
-ZTATDZ = 451
-ZUQEXL = 310
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 54])
-AFIKJP = [
-    YIYWSK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SJMCBF,
-]
-AJVDQL = [
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-]
-CWAONP = [EKCWAO, KCWAON]
-DKHTZB = [
-    NIBXYB,
-    IRYXBQ,
-    XBQFYL,
-    AMJMAO,
-    JIGYOU,
-    JNIBXY,
-    IBXYBQ,
-    PBWJYK,
-    JYMOUN,
-    WBSIRY,
-    MAOAWB,
-    FTSIFJ,
-    GQPLSP,
-    NEJNIB,
-    JMAOAW,
-    BSIRYX,
-    AWBSIR,
-    JBIAMJ,
-    BQFYLJ,
-    IFJBIA,
-    TSIFJB,
-    RYXBQF,
-    LJUIKF,
-    YXBQFY,
-    SIFJBI,
-    OAWBSI,
-    MJMAOA,
-    BIAMJM,
-]
-DUBSSU = [TIDUBS, IDUBSS]
-EUTOPH = [
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    XWAJVD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-]
-FWRKIN = [HECVYY, KFWRKI, KFWRKI, KFWRKI]
-GVUNXN = [
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    OQNRSJ,
-    DNQGVU,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NQGVUN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    QGVUNX,
-]
-IBXTIA = [DNIBXT, NIBXTI]
-IIDNIB = [DQLAII, QLAIID, LAIIDN, AIIDNI]
-IUSOOQ = [ASSAKQ, JHIUSO, HIUSOO]
-JVYFCR = [JJJVYF, JJVYFC]
-JWMNZM = [KXSJWM, QXPICX, XSJWMN, XPICXQ, SJWMNZ]
-LIUXFE = [ONPYYL, NPYYLI, PYYLIU, YYLIUX, YLIUXF]
-MKQTDK = []
-NRSJMC = [ASSAKQ, JHIUSO]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QFFTTI = [ACQFFT, CQFFTT]
-QGLRAH = [ASSAKQ, XPICXQ]
-QTDKHT = [
-    JRJHIU,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    RSJMCB,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    BFEGZU,
-    EGZUQE,
-    GZUQEX,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    KQTDKH,
-]
-RAHEOC = [ASSAKQ, LRAHEO]
-SPBWJY = [HECVYY, USPBWJ, USPBWJ, USPBWJ]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TDKHTZ = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-]
-TIACQF = [RSJMCB, XTIACQ]
-UGSELH = [
-    YIYWSK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JUGSEL,
-]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -953,262 +19,817 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return KHTZBB
+        return 58
 
     @property
     def begin(self):
-        return HTZBBE
+        return 256
 
     @property
     def end(self):
-        return TZBBEK
+        return 479
 
     @property
     def all_device_keys(self):
-        return QTDKHT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return TDKHTZ
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return DKHTZB
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, ICXQIE, IUSOOQ, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, RJHIUS, QIEFXQ, IUSOOQ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, RJHIUS, CXQIEF, IUSOOQ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, RJHIUS, VHFTHE, IUSOOQ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, ICXQIE, NRSJMC, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, QNRSJM, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, QNRSJM, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, QNRSJM, MCBFEG, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, QNRSJM, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, QNRSJM, FEGZUQ, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, QNRSJM, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XLSXUJ, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            XUJUTY: GeckoWordStructAccessor(self.struct, XUJUTY, UJUTYE, None),
-            JUTYEK: GeckoWordStructAccessor(self.struct, JUTYEK, UTYEKC, SAKQXP),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, ICXQIE, CWAONP, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, LIUXFE, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            IUXFEF: GeckoTimeStructAccessor(self.struct, IUXFEF, UXFEFJ, SAKQXP),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, SAKQXP),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, YEKCWA, QIEFXQ, CWAONP, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, LIUXFE, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            TACCPQ: GeckoTimeStructAccessor(self.struct, TACCPQ, ACCPQI, SAKQXP),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, SAKQXP),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, UYNQJY, ICXQIE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, UYNQJY, QIEFXQ, None),
-            NQJYMO: GeckoBoolStructAccessor(self.struct, NQJYMO, UYNQJY, MCBFEG, None),
-            QJYMOU: GeckoBoolStructAccessor(self.struct, QJYMOU, UYNQJY, CXQIEF, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, UYNQJY, FEGZUQ, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, JVHFTH, QIEFXQ, None),
-            MOUNBL: GeckoBoolStructAccessor(self.struct, MOUNBL, OUNBLK, MCBFEG, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, OUNBLK, FEGZUQ, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, OUNBLK, VHFTHE, None),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, JWMNZM, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, MNZMJI, FEGZUQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, MNZMJI, VHFTHE, None),
-            ZMJIGY: GeckoWordStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, JVHFTH, AHEOCT, None),
-            IGYOUS: GeckoTempStructAccessor(self.struct, IGYOUS, GYOUSP, None),
-            YOUSPB: GeckoTempStructAccessor(self.struct, YOUSPB, OUSPBW, None),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, QNRSJM, FEGZUQ, SPBWJY, None, CXQIEF, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, QIEFXQ, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, QIEFXQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, AHEOCT, None),
-            LGQPLS: GeckoBoolStructAccessor(
-                self.struct, LGQPLS, KLGQPL, QIEFXQ, SAKQXP
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, AHEOCT, None),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, ICXQIE, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, JVHFTH, MCBFEG, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, OUNBLK, ICXQIE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, OUNBLK, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, QIEFXQ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, FJBIAM, MCBFEG, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, MCBFEG, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, CXQIEF, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, IAMJMA, FEGZUQ, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, IAMJMA, VHFTHE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, MCBFEG, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, AOAWBS, CXQIEF, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, AOAWBS, FEGZUQ, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, AOAWBS, VHFTHE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, QIEFXQ, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, SIRYXB, MCBFEG, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, QPLSPF, MCBFEG, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, MNZMJI, ICXQIE, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, MNZMJI, AHEOCT, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, JYKLGQ, ICXQIE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FJBIAM, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FJBIAM, AHEOCT, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FJBIAM, CXQIEF, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IKFWRK, ICXQIE, None),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, IKFWRK, AHEOCT, FWRKIN, None, CXQIEF, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            WRKINE: GeckoWordStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, INEJNI, ICXQIE, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, EJNIBX, ICXQIE, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, EJNIBX, AHEOCT, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, SIRYXB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, SIRYXB, AHEOCT, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, SIRYXB, CXQIEF, None),
-            XYBQSN: GeckoWordStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, None),
-            SNQLNM: GeckoByteStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, AJVDQL, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, ICXQIE, IIDNIB, None, CXQIEF, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, VDQLAI, QIEFXQ, IBXTIA, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, VDQLAI, MCBFEG, TIACQF, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, VDQLAI, CXQIEF, QFFTTI, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, VDQLAI, FEGZUQ, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, VDQLAI, VHFTHE, None),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, VDQLAI, UBSSUH, DUBSSU, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoWordStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoWordStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, JVYFCR, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, EUTOPH, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            UTOPHU: GeckoWordStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoByteStructAccessor(self.struct, HUGTYI, UGTYIY, None),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, GVUNXN, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, GVUNXN, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, GVUNXN, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, GVUNXN, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, LOIJUG, None, GVUNXN, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, UGSELH, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, SAKQXP),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, SAKQXP),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, AFIKJP, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, SAKQXP),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyj-v2.py
+++ b/src/geckolib/driver/packs/inyj-v2.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inyj-v3-cfg-62.py
+++ b/src/geckolib/driver/packs/inyj-v3-cfg-62.py
@@ -12,953 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-ACQFFT = 108
-AFIKJP = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-AHEOCT = 15
-AIIDNI = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-AKSTSE = "".join(chr(c) for c in [50])
-AMJMAO = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-AOAWBS = "".join(chr(c) for c in [70, 50])
-AONPYY = 58
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-ATDZXN = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-AWBSIR = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-BDJQRJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-BFEGZU = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-BIAMJM = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BJEUTO = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BLKXSJ = "".join(chr(c) for c in [67])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 86
-BQNRXC = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-BQSNQL = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-BSSUHB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-BVWVUB = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-BWJYKL = 68
-BXIBHZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-BXTIAC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-BXYBQS = 23
-BYGDSB = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-CBFEGZ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-CCPQIP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-CGETIX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-CHWDAF = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CRTFMN = "".join(chr(c) for c in [67, 89, 65, 78])
-CTHBSK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 1
-CXQIEF = 16
-DGKEAK = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-DJQRJJ = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DNIBXT = 107
-DNQGVU = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DQLAII = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-DSBDJQ = 43
-DUBSSU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-DZXNQT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-EAKSTS = "".join(chr(c) for c in [49])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [80, 49])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-EJNIBX = 4
-EKVKZI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ELHBQN = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-EMCGET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-EOCTHB = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-ETIXQV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-EUTOPH = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-FCRTFM = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-FEFJTA = 78
-FEGZUQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-FFTTID = "".join(chr(c) for c in [65, 109, 80, 109])
-FIKJPU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FJBIAM = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-FMNHTB = 8
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 69])
-FTTIDU = "".join(chr(c) for c in [50, 52, 104])
-FXQGLR = 37
-FYLJUI = 87
-FZDGKE = 126
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GETIXQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-GKEAKS = 127
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-GQPLSP = 77
-GSELHB = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-GTYIYW = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GVUNXN = "".join(chr(c) for c in [77, 65, 65, 88])
-GYOUSP = 3
-GZUQEX = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-HBQNRX = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-HBSKSO = 2
-HBVWVU = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HBXIBH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 81
-HTBJEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-HUGTYI = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-HUOJRJ = 54
-HWDAFI = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-IACQFF = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-IAMJMA = 74
-IBXTIA = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-IBXYBQ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IDNIBX = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IDUBSS = 64
-IEFXQG = 36
-IFJBIA = 52
-IHBXIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-IIDNIB = 75
-IJUGSE = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-IKFWRK = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-IKJPUN = 46
-ILXWAJ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-INEJNI = 3
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IRYXBQ = 84
-IUSOOQ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-IUXFEF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-IVDNQG = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-IYWSKW = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-JBIAMJ = 53
-JEUTOP = 44
-JHIUSO = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-JIGYOU = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-JJVYFC = "".join(chr(c) for c in [82, 69, 68])
-JMAOAW = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JMCBFE = 32
-JNIBXY = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JPUNRJ = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JRJHIU = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-JTACCP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-JUGSEL = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-JUIKFW = "".join(chr(c) for c in [70, 52, 67, 117, 114, 114, 101, 110, 116])
-JVDQLA = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JWMNZM = 25
-JYKLGQ = 70
-JYMOUN = 63
-KCWAON = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-KEAKST = "".join(chr(c) for c in [78, 111, 110, 101])
-KFWRKI = 104
-KINEJN = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-KJPUNR = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-KMLOIJ = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-KPHUOJ = 80
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 50])
-KSOKPH = "".join(chr(c) for c in [76, 73])
-KSTSEM = "".join(chr(c) for c in [51])
-KVKZIL = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-KWIVDN = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-KXSJWM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-LHBQNR = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-LIUXFE = 61
-LJUIKF = 98
-LOIJUG = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-LRAHEO = 40
-LSPFTS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-LSXUJU = 57
-LXWAJV = 76
-MAOAWB = 83
-MCBFEG = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-MCGETI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-MFZDGK = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-MHXEKV = 82
-MJIGYO = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-MNZMJI = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-MOUNBL = 1
-NBLKXS = "".join(chr(c) for c in [70])
-NEJNIB = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-NHTBJE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NIBXTI = "".join(chr(c) for c in [79, 70, 70])
-NIBXYB = 6
-NKMLOI = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NMHXEK = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NPYYLI = 59
-NQGVUN = "".join(chr(c) for c in [76, 65])
-NQLNMH = 71
-NQTMFZ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-NRJZTA = 123
-NRSJMC = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-NXNKML = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-OAWBSI = "".join(chr(c) for c in [70, 52])
-OCTHBS = 39
-OIHBXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-OIJUGS = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-OJRJHI = 55
-OKPHUO = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-ONPYYL = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OOQNRS = 0
-OPHUGT = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-OQNRSJ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-OUNBLK = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-OUSPBW = 35
-OUYNQJ = 30
-PBWJYK = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PFTSIF = "".join(chr(c) for c in [85, 76])
-PHUGTY = "".join(chr(c) for c in [65, 108, 112, 115])
-PHUOJR = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-PICXQI = 14
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 26
-POUYNQ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PQIPOU = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PUNRJZ = 121
-PYYLIU = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-QFFTTI = 34
-QFYLJU = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-QGLRAH = 38
-QGVUNX = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-QIPOUY = 29
-QJYMOU = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-QLAIID = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QLNMHX = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-QNRSJM = 48
-QNRXCH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-QPLSPF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-QSNQLN = 10
-QTMFZD = 125
-QVXOIH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-QXPICX = 13
-RAHEOC = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJHIUS = 56
-RJJJVY = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RJZTAT = "".join(chr(c) for c in [82, 71, 66])
-RKINEJ = 105
-RSJMCB = 118
-RTFMNH = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-RXCHWD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-RYXBQF = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-SAKQXP = "".join(chr(c) for c in [65, 85, 88])
-SBDJQR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SELHBQ = "".join(chr(c) for c in [73, 100, 111, 108])
-SEMCGE = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-SIFJBI = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-SIRYXB = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-SJMCBF = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-SJWMNZ = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-SKSOKP = 79
-SKWIVD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SPBWJY = 66
-SPFTSI = 51
-SSAKQX = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-STSEMC = "".join(chr(c) for c in [52])
-SUHBVW = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-SXUJUT = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TACCPQ = 28
-TATDZX = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-THBSKS = 47
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIDUBS = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-TIXQVX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-TMFZDG = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-TOPHUG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-TYEKCW = "".join(chr(c) for c in [76, 111])
-TYIYWS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-UBSSUH = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBYGDS = 6
-UGSELH = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-UGTYIY = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-UHBVWV = 4
-UIKFWR = 99
-UJUTYE = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-UNBLKX = 33
-UNRJZT = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-UNXNKM = "".join(chr(c) for c in [80, 68, 67])
-UOJRJH = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-UQEXLS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-USOOQN = "".join(chr(c) for c in [79, 119, 110])
-USPBWJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-UTOPHU = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UTYEKC = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-UXFEFJ = 62
-UYNQJY = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-VDNQGV = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VDQLAI = 73
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-VUNXNK = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-VWVUBY = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-VXOIHB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-VYFCRT = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WAONPY = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-WBSIRY = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-WDAFIK = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-WIVDNQ = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-WJYKLG = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-WMNZMJ = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-WRKINE = "".join(chr(c) for c in [70, 52, 76, 105, 110, 101])
-WSKWIV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-XBQFYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-XCHWDA = 45
-XEKVKZ = 72
-XFEFJT = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-XIBHZV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-XNKMLO = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-XNQTMF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-XOIHBX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 51])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-XQVXOI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-XSJWMN = 31
-XTIACQ = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-XUJUTY = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-XWAJVD = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-XYBQSN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-YBQSNQ = 8
-YEKCWA = "".join(chr(c) for c in [72, 105])
-YFCRTF = "".join(chr(c) for c in [66, 76, 85, 69])
-YGDSBD = 7
-YIYWSK = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-YKLGQP = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YLJUIK = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-YMOUNB = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-YNQJYM = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-YOUSPB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-YXBQFY = 85
-YYLIUX = 60
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ZILXWA = 5
-ZMJIGY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-ZTATDZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-ZUQEXL = 27
-ZVOACM = 62
-ZXNQTM = 124
-AJVDQL = [XWAJVD, WAJVDQ]
-AKQXPI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-]
-BHZVOA = [KSOKPH]
-BSIRYX = [AOAWBS, OAWBSI, VLASSA, VLASSA, VLASSA, VLASSA, AWBSIR, WBSIRY]
-CPQIPO = [ACCPQI, CCPQIP]
-DAFIKJ = [HWDAFI, WDAFIK, VLASSA, VLASSA]
-EGZUQE = [MCBFEG, CBFEGZ, BFEGZU, FEGZUQ]
-EKCWAO = [TYEKCW, YEKCWA]
-EXLSXU = [UQEXLS, QEXLSX]
-FJTACC = [JVHFTH, EFJTAC, PIPIVL]
-FWRKIN = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, AWBSIR, WBSIRY]
-HEOCTH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-HZVOAC = []
-IBHZVO = [BMJVHF, KQXPIC, XPICXQ, ICXQIE, RAHEOC, BSKSOK]
-IGYOUS = [MJIGYO, JIGYOU]
-IPOUYN = [PIPIVL, EFJTAC]
-JUTYEK = [SXUJUT, XUJUTY, UJUTYE]
-JZTATD = [RJZTAT, RTFMNH]
-KLGQPL = [UYNQJY, YKLGQP]
-LAIIDN = [VLASSA, DQLAII, QLAIID]
-LKXSJW = [NBLKXS, BLKXSJ]
-LNMHXE = [JVHFTH, UQEXLS, QLNMHX]
-MJMAOA = [UYNQJY, AMJMAO]
-NQJYMO = [UYNQJY, YNQJYM]
-NRXCHW = [
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-]
-NZMJIG = [WMNZMJ, MNZMJI]
-QRJJJV = [DJQRJJ, JQRJJJ]
-SOKPHU = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KSOKPH,
-]
-SOOQNR = [IUSOOQ, USOOQN]
-SSUHBV = [UBSSUH, BSSUHB]
-TBJEUT = [NHTBJE, HTBJEU]
-TDZXNQ = [TATDZX, ATDZXN]
-TFMNHT = [NIBXTI, JJVYFC, JVYFCR, VYFCRT, YFCRTF, FCRTFM, CRTFMN, RTFMNH]
-TIACQF = [JVHFTH, NIBXTI, IBXTIA, BXTIAC, XTIACQ]
-TSEMCG = [KEAKST, EAKSTS, AKSTSE, KSTSEM, STSEMC]
-TSIFJB = [PFTSIF, FTSIFJ]
-TTIDUB = [JVHFTH, FFTTID, FTTIDU]
-WVUBYG = [BVWVUB, VWVUBY]
-XQIEFX = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -966,267 +19,682 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return ZVOACM
+        return 62
 
     @property
     def output_keys(self):
-        return IBHZVO
+        return ["Out1", "Out2", "Out3", "OutHtr", "Direct", "OutLi"]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, AKQXPI, None, None, QBMJVH
-            ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, AKQXPI, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, AKQXPI, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, XQIEFX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Protection",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                16,
+                None,
+                ["NA", "P1H", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 40, "ALL"),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                15,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 39, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 47, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(self.struct, "AuxTimeOut", 48, "ALL"),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 47, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                25,
+                None,
+                ["inFlo", "NotInstalled"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 26, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                86,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                87,
+                None,
+                ["F2", "F4", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 98, "ALL"),
+            "F4Current": GeckoByteStructAccessor(self.struct, "F4Current", 99, "ALL"),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F4Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F4Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 23, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                107,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 108, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 43, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 43, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                43,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                43,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                43,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                43,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 45, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                45,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 45, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 46, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 47, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["None", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QIEFXQ: GeckoByteStructAccessor(self.struct, QIEFXQ, IEFXQG, QBMJVH),
-            EFXQGL: GeckoByteStructAccessor(self.struct, EFXQGL, FXQGLR, QBMJVH),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, HEOCTH, None, None, QBMJVH
-            ),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoBoolStructAccessor(
-                self.struct, CTHBSK, THBSKS, HBSKSO, QBMJVH
-            ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, SOKPHU, None, None, None
-            ),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, None),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, QBMJVH),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, QBMJVH),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, QBMJVH),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, OOQNRS, SOOQNR, None, HBSKSO, QBMJVH
-            ),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, EGZUQE, None, None, QBMJVH
-            ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, JUTYEK, None, None, QBMJVH
-            ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, HIUSOO, HBSKSO, EKCWAO, None, HBSKSO, QBMJVH
-            ),
-            KCWAON: GeckoBoolStructAccessor(
-                self.struct, KCWAON, THBSKS, CWAONP, QBMJVH
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoEnumStructAccessor(
-                self.struct, XFEFJT, FEFJTA, None, FJTACC, None, None, QBMJVH
-            ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, IPOUYN, None, None, QBMJVH
-            ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, OUYNQJ, None, NQJYMO, None, None, QBMJVH
-            ),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, QBMJVH),
-            YMOUNB: GeckoTempStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, XSJWMN, None, IPOUYN, None, None, QBMJVH
-            ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, NZMJIG, None, None, QBMJVH
-            ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, HIUSOO, GYOUSP, IGYOUS, None, HBSKSO, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoTempStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, QBMJVH),
-            WJYKLG: GeckoEnumStructAccessor(
-                self.struct, WJYKLG, JYKLGQ, None, KLGQPL, None, None, QBMJVH
-            ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoByteStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, TSIFJB, None, None, QBMJVH
-            ),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, QBMJVH),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, IAMJMA, None, MJMAOA, None, None, QBMJVH
-            ),
-            JMAOAW: GeckoEnumStructAccessor(
-                self.struct, JMAOAW, MAOAWB, None, BSIRYX, None, None, QBMJVH
-            ),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, IRYXBQ, None, BSIRYX, None, None, QBMJVH
-            ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BSIRYX, None, None, QBMJVH
-            ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, BSIRYX, None, None, QBMJVH
-            ),
-            QFYLJU: GeckoEnumStructAccessor(
-                self.struct, QFYLJU, FYLJUI, None, BSIRYX, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoByteStructAccessor(self.struct, JUIKFW, UIKFWR, QBMJVH),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, FWRKIN, None, None, QBMJVH
-            ),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, FWRKIN, None, None, QBMJVH
-            ),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoTimeStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoTimeStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTimeStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoTimeStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoTimeStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, None, LNMHXE, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoBoolStructAccessor(
-                self.struct, NMHXEK, MHXEKV, OOQNRS, QBMJVH
-            ),
-            HXEKVK: GeckoBoolStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, HBSKSO, QBMJVH
-            ),
-            EKVKZI: GeckoBoolStructAccessor(
-                self.struct, EKVKZI, XEKVKZ, OOQNRS, QBMJVH
-            ),
-            KVKZIL: GeckoBoolStructAccessor(
-                self.struct, KVKZIL, XEKVKZ, CWAONP, QBMJVH
-            ),
-            VKZILX: GeckoBoolStructAccessor(
-                self.struct, VKZILX, XEKVKZ, GYOUSP, QBMJVH
-            ),
-            KZILXW: GeckoBoolStructAccessor(
-                self.struct, KZILXW, XEKVKZ, ZILXWA, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, LAIIDN, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, QBMJVH),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, TIACQF, None, None, QBMJVH
-            ),
-            IACQFF: GeckoTimeStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoWordStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, HIUSOO, CWAONP, SSUHBV, None, HBSKSO, QBMJVH
-            ),
-            SUHBVW: GeckoBoolStructAccessor(
-                self.struct, SUHBVW, HIUSOO, UHBVWV, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, HIUSOO, ZILXWA, WVUBYG, None, HBSKSO, QBMJVH
-            ),
-            VUBYGD: GeckoBoolStructAccessor(
-                self.struct, VUBYGD, HIUSOO, UBYGDS, QBMJVH
-            ),
-            BYGDSB: GeckoBoolStructAccessor(
-                self.struct, BYGDSB, HIUSOO, YGDSBD, QBMJVH
-            ),
-            GDSBDJ: GeckoBoolStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, OOQNRS, QBMJVH
-            ),
-            SBDJQR: GeckoBoolStructAccessor(
-                self.struct, SBDJQR, DSBDJQ, CWAONP, QBMJVH
-            ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DSBDJQ, HBSKSO, QRJJJV, None, HBSKSO, QBMJVH
-            ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, DSBDJQ, GYOUSP, QRJJJV, None, HBSKSO, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, DSBDJQ, UHBVWV, TFMNHT, None, FMNHTB, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, DSBDJQ, YGDSBD, TBJEUT, None, HBSKSO, QBMJVH
-            ),
-            RXCHWD: GeckoBoolStructAccessor(
-                self.struct, RXCHWD, XCHWDA, CWAONP, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, XCHWDA, HBSKSO, DAFIKJ, None, UHBVWV, QBMJVH
-            ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, XCHWDA, UHBVWV, QBMJVH
-            ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoBoolStructAccessor(
-                self.struct, KJPUNR, THBSKS, OOQNRS, QBMJVH
-            ),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, QBMJVH),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, NRJZTA, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, NRJZTA, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, ZXNQTM, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, QTMFZD, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, FZDGKE, OOQNRS, JZTATD, None, HBSKSO, None
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, FZDGKE, CWAONP, TDZXNQ, None, HBSKSO, None
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, GKEAKS, OOQNRS, TSEMCG, None, FMNHTB, None
-            ),
-            SEMCGE: GeckoBoolStructAccessor(self.struct, SEMCGE, GKEAKS, YGDSBD, None),
-            EMCGET: GeckoBoolStructAccessor(self.struct, EMCGET, NRJZTA, UHBVWV, None),
-            MCGETI: GeckoBoolStructAccessor(self.struct, MCGETI, NRJZTA, ZILXWA, None),
-            CGETIX: GeckoBoolStructAccessor(self.struct, CGETIX, NRJZTA, UBYGDS, None),
-            GETIXQ: GeckoBoolStructAccessor(self.struct, GETIXQ, NRJZTA, YGDSBD, None),
-            ETIXQV: GeckoBoolStructAccessor(self.struct, ETIXQV, ZXNQTM, UHBVWV, None),
-            TIXQVX: GeckoBoolStructAccessor(self.struct, TIXQVX, ZXNQTM, ZILXWA, None),
-            IXQVXO: GeckoBoolStructAccessor(self.struct, IXQVXO, ZXNQTM, UBYGDS, None),
-            XQVXOI: GeckoBoolStructAccessor(self.struct, XQVXOI, ZXNQTM, YGDSBD, None),
-            QVXOIH: GeckoBoolStructAccessor(self.struct, QVXOIH, QTMFZD, UHBVWV, None),
-            VXOIHB: GeckoBoolStructAccessor(self.struct, VXOIHB, QTMFZD, ZILXWA, None),
-            XOIHBX: GeckoBoolStructAccessor(self.struct, XOIHBX, QTMFZD, UBYGDS, None),
-            OIHBXI: GeckoBoolStructAccessor(self.struct, OIHBXI, QTMFZD, YGDSBD, None),
-            IHBXIB: GeckoBoolStructAccessor(self.struct, IHBXIB, FZDGKE, UHBVWV, None),
-            HBXIBH: GeckoBoolStructAccessor(self.struct, HBXIBH, FZDGKE, ZILXWA, None),
-            BXIBHZ: GeckoBoolStructAccessor(self.struct, BXIBHZ, FZDGKE, UBYGDS, None),
-            XIBHZV: GeckoBoolStructAccessor(self.struct, XIBHZV, FZDGKE, YGDSBD, None),
         }

--- a/src/geckolib/driver/packs/inyj-v3-log-59.py
+++ b/src/geckolib/driver/packs/inyj-v3-log-59.py
@@ -12,999 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ACQFFT = "".join(chr(c) for c in [67, 69])
-AFIKJP = 331
-AHEOCT = 1
-AJVDQL = "".join(chr(c) for c in [75, 54, 48, 48])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 457
-AMJMAO = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-AOAWBS = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 50])
-AWBSIR = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-AZMKQT = 476
-BBEKBD = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-BDFSRO = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-BDJQRJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-BEKBDF = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = 468
-BIAMJM = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-BJEUTO = "".join(chr(c) for c in [75, 52])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-BQNRXC = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-BQSNQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BSIRYX = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 78, 111, 73, 110, 70, 108, 111])
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BWJYKL = 275
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-BXTIAC = "".join(chr(c) for c in [54, 52, 75])
-BXYBQS = 314
-BYGDSB = 294
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-CHWDAF = 329
-CMCVDS = 471
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CRTFMN = "".join(chr(c) for c in [70, 117, 108, 108])
-CTHBSK = 307
-CVDSSR = 472
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-DGKEAK = 455
-DJQRJJ = 297
-DKHTZB = 479
-DNIBXT = "".join(chr(c) for c in [49, 54, 75])
-DNQGVU = "".join(chr(c) for c in [80, 50, 76])
-DPMXFU = 59
-DQLAII = "".join(chr(c) for c in [105, 110, 89, 84])
-DSBDJQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-DSSRUR = 473
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 51])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 57])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EKBDFS = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-ELHBQN = 326
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FCRTFM = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FFTTID = "".join(chr(c) for c in [80, 50, 50])
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-FMNHTB = 357
-FSROGM = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-FWRKIN = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FZDGKE = 454
-GDSBDJ = 295
-GETIXQ = 461
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 56])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = 279
-GSELHB = 324
-GTYIYW = 358
-GVUNXN = "".join(chr(c) for c in [80, 52, 72])
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBSKSO = 363
-HBXIBH = 466
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [75, 56, 53])
-HTZBBE = 371
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IACQFF = "".join(chr(c) for c in [85, 76])
-IAMJMA = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IBXTIA = "".join(chr(c) for c in [52, 56, 75])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ICXQIE = 0
-IDNIBX = 290
-IDUBSS = "".join(chr(c) for c in [51, 79, 80])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = 377
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-IIDNIB = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-IKFWRK = 354
-IKJPUN = 333
-ILXWAJ = "".join(chr(c) for c in [77, 73, 65])
-INEJNI = 309
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = 350
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [80, 49, 76])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-IYWSKW = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-JBIAMJ = 383
-JEUTOP = "".join(chr(c) for c in [75, 53])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = 300
-JJVYFC = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JMAOAW = 283
-JMCBFE = 260
-JNIBXY = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-JPUNRJ = 325
-JQRJJJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = 323
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-JVHFTH = 274
-JVYFCR = 301
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 448
-KBDFSR = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-KCWAON = 365
-KEAKST = 456
-KFWRKI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KHTZBB = "".join(
-    chr(c)
-    for c in [105, 110, 70, 108, 111, 80, 117, 108, 115, 101, 87, 105, 100, 116, 104]
-)
-KINEJN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-KJPUNR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KPHUOJ = 304
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KVKZIL = 289
-KWIVDN = "".join(chr(c) for c in [78, 65])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 88, 69])
-LAIIDN = "".join(chr(c) for c in [105, 110, 89, 74])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = "".join(chr(c) for c in [72, 84, 82])
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 285
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [68, 74, 83, 52])
-MAOAWB = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-MCGETI = 460
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 54])
-MHXEKV = 287
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 477
-MLOIJU = 321
-MNHTBJ = "".join(chr(c) for c in [75, 50, 48, 48])
-MNZMJI = 313
-MOUNBL = 273
-MXFUBJ = 479
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-NHTBJE = "".join(chr(c) for c in [75, 52, 48, 48])
-NIBXTI = "".join(chr(c) for c in [51, 50, 75])
-NIBXYB = 311
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [80, 51, 72])
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-NQTMFZ = 452
-NRJZTA = 332
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-NXNKML = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = 470
-OAWBSI = 284
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [76, 73])
-OIHBXI = 465
-OIJUGS = 322
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [75, 51, 48, 48])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-PHUGTY = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = 280
-PMXFUB = 256
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 88, 101, 80, 50, 50, 66, 76])
-QFYLJU = 351
-QGVUNX = "".join(chr(c) for c in [80, 51, 76])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [75, 56, 48, 48])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = 327
-QPLSPF = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-QRJJJV = 299
-QSNQLN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QTDKHT = 478
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 53])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 48])
-RKINEJ = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-RXCHWD = 328
-RYXBQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = 296
-SELHBQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-SEMCGE = 459
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = 320
-SNQLNM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = 281
-SROGMD = 375
-SRURAZ = 474
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-SSUHBV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 70, 117, 115, 101, 49, 82, 97, 116, 105, 110, 103]
-)
-STSEMC = 458
-SUHBVW = "".join(chr(c) for c in [50, 53, 65])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = 449
-TBJEUT = "".join(chr(c) for c in [75, 56])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-TDZXNQ = 450
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-TIDUBS = "".join(chr(c) for c in [53, 79, 80])
-TIXQVX = 462
-TMFZDG = 453
-TOPHUG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TSIFJB = 352
-TTIDUB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 88, 101, 79, 117, 116, 112, 117, 116, 115]
-)
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-TZBBEK = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        80,
-        97,
-        99,
-        107,
-        88,
-        101,
-        67,
-        69,
-        65,
-        99,
-        99,
-        79,
-        110,
-        70,
-        117,
-        115,
-        101,
-        50,
-    ]
-)
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-UGSELH = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UHBVWV = "".join(chr(c) for c in [51, 48, 65])
-UIKFWR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-UNXNKM = "".join(chr(c) for c in [66, 76, 79])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = 475
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [75, 49, 48, 48])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = "".join(chr(c) for c in [80, 50, 72])
-VDQLAI = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-VUBYGD = 293
-VUNXNK = "".join(chr(c) for c in [80, 52, 76])
-VWVUBY = 291
-VXOIHB = 464
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 88, 77])
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-WDAFIK = 330
-WIVDNQ = "".join(chr(c) for c in [80, 49, 72])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-WVUBYG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-XCHWDA = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-XEKVKZ = 288
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XIBHZV = 467
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [65, 85, 88])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 52])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 463
-XSJWMN = 282
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-XYBQSN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = 315
-YEKCWA = 364
-YFCRTF = 316
-YGDSBD = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-YIYWSK = 360
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = 361
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 374
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 55])
-ZILXWA = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49])
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = 469
-ZXNQTM = 451
-AIIDNI = [
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-    DQLAII,
-    QLAIID,
-    LAIIDN,
-]
-CQFFTT = [IACQFF, ACQFFT]
-DDPMXF = [
-    QSNQLN,
-    FYLJUI,
-    JUIKFW,
-    AWBSIR,
-    SPBWJY,
-    BQSNQL,
-    SNQLNM,
-    LGQPLS,
-    BLKXSJ,
-    XBQFYL,
-    SIRYXB,
-    BIAMJM,
-    FTSIFJ,
-    XYBQSN,
-    BSIRYX,
-    BQFYLJ,
-    YXBQFY,
-    MAOAWB,
-    UIKFWR,
-    MJMAOA,
-    IAMJMA,
-    YLJUIK,
-    WRKINE,
-    LJUIKF,
-    AMJMAO,
-    RYXBQF,
-    WBSIRY,
-    AOAWBS,
-]
-DFSROG = [BBEKBD, BEKBDF, EKBDFS, KBDFSR, BDFSRO]
-DUBSSU = [TIDUBS, IDUBSS]
-EJNIBX = [HECVYY, NEJNIB, NEJNIB, NEJNIB]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FTTIDU = [CBFEGZ, FFTTID]
-GMDDPM = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    OGMDDP,
-]
-HBQNRX = [
-    KWIVDN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LHBQNR,
-]
-HBVWVU = [SUHBVW, UHBVWV]
-HUGTYI = [
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    QLAIID,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDDPMX = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-NKMLOI = [
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    SJMCBF,
-    UNXNKM,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NXNKML,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    XNKMLO,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PUNRJZ = [
-    KWIVDN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-ROGMDD = []
-RTFMNH = [FCRTFM, CRTFMN]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XTIACQ = [DNIBXT, NIBXTI, IBXTIA, BXTIAC]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1012,276 +19,851 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return DPMXFU
+        return 59
 
     @property
     def begin(self):
-        return PMXFUB
+        return 256
 
     @property
     def end(self):
-        return MXFUBJ
+        return 479
 
     @property
     def all_device_keys(self):
-        return GMDDPM
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return MDDPMX
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return DDPMXF
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, AHEOCT, None),
-            PFTSIF: GeckoBoolStructAccessor(
-                self.struct, PFTSIF, SPFTSI, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, AHEOCT, None),
-            SIFJBI: GeckoByteStructAccessor(self.struct, SIFJBI, IFJBIA, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, ICXQIE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JVHFTH, EGZUQE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, XSJWMN, ICXQIE, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, XSJWMN, AHEOCT, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, QIEFXQ, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, EGZUQE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, EGZUQE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, OAWBSI, UQEXLS, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, OAWBSI, VHFTHE, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, EGZUQE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, IRYXBQ, CXQIEF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, IRYXBQ, UQEXLS, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, IRYXBQ, VHFTHE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, QFYLJU, QIEFXQ, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, QFYLJU, EGZUQE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, TSIFJB, EGZUQE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, GYOUSP, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, GYOUSP, AHEOCT, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IKFWRK, ICXQIE, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, PLSPFT, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, JMAOAW, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, JMAOAW, AHEOCT, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, JMAOAW, CXQIEF, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, INEJNI, ICXQIE, None),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, INEJNI, AHEOCT, EJNIBX, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            JNIBXY: GeckoWordStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, YBQSNQ, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YBQSNQ, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, QFYLJU, ICXQIE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, QFYLJU, AHEOCT, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QFYLJU, CXQIEF, None),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoByteStructAccessor(self.struct, HXEKVK, XEKVKZ, None),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, AIIDNI, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, ICXQIE, XTIACQ, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IDNIBX, QIEFXQ, CQFFTT, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, IDNIBX, EGZUQE, FTTIDU, None, QIEFXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, IDNIBX, CXQIEF, DUBSSU, None, QIEFXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, IDNIBX, UQEXLS, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, IDNIBX, VHFTHE, None),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, IDNIBX, XLSXUJ, HBVWVU, None, QIEFXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BVWVUB: GeckoWordStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, None),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, None),
-            BDJQRJ: GeckoWordStructAccessor(self.struct, BDJQRJ, DJQRJJ, None),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, None),
-            RJJJVY: GeckoByteStructAccessor(self.struct, RJJJVY, JJJVYF, None),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, None, RTFMNH, None, QIEFXQ, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, HUGTYI, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, NKMLOI, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, NKMLOI, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, NKMLOI, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, NKMLOI, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, GSELHB, None, NKMLOI, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            SELHBQ: GeckoEnumStructAccessor(
-                self.struct, SELHBQ, ELHBQN, None, HBQNRX, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, SAKQXP),
-            NRXCHW: GeckoByteStructAccessor(self.struct, NRXCHW, RXCHWD, SAKQXP),
-            XCHWDA: GeckoByteStructAccessor(self.struct, XCHWDA, CHWDAF, SAKQXP),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, SAKQXP),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, SAKQXP),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, SAKQXP),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, PUNRJZ, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            KHTZBB: GeckoByteStructAccessor(self.struct, KHTZBB, HTZBBE, None),
-            TZBBEK: GeckoEnumStructAccessor(
-                self.struct, TZBBEK, ZBBEKB, None, DFSROG, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FSROGM: GeckoBoolStructAccessor(
-                self.struct, FSROGM, SROGMD, ICXQIE, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "K800",
+                    "inYJ",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackXeP22BL": GeckoEnumStructAccessor(
+                self.struct, "PackXeP22BL", 290, 3, ["BL", "P22"], None, 2, None
+            ),
+            "PackXeOutputs": GeckoEnumStructAccessor(
+                self.struct, "PackXeOutputs", 290, 4, ["5OP", "3OP"], None, 2, None
+            ),
+            "PackXeCEAccOnFuse2": GeckoBoolStructAccessor(
+                self.struct, "PackXeCEAccOnFuse2", 290, 5, None
+            ),
+            "PackNoInFlo": GeckoBoolStructAccessor(
+                self.struct, "PackNoInFlo", 290, 6, None
+            ),
+            "PackFuse1Rating": GeckoEnumStructAccessor(
+                self.struct, "PackFuse1Rating", 290, 7, ["25A", "30A"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 332, "ALL"
+            ),
+            "inFloPulseWidth": GeckoByteStructAccessor(
+                self.struct, "inFloPulseWidth", 371, None
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyj-v3.py
+++ b/src/geckolib/driver/packs/inyj-v3.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inyj.py
+++ b/src/geckolib/driver/packs/inyj.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inyt-cfg-50.py
+++ b/src/geckolib/driver/packs/inyt-cfg-50.py
@@ -12,467 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = 50
-AKQXPI = 14
-AMJMAO = "".join(chr(c) for c in [67, 69])
-AOAWBS = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-AONPYY = 85
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-AWBSIR = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = 51
-BLKXSJ = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-BQSNQL = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-BSIRYX = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-BSKSOK = 19
-BWJYKL = "".join(chr(c) for c in [70])
-BXYBQS = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-CBFEGZ = 46
-CPQIPO = "".join(
-    chr(c) for c in [79, 84, 65, 99, 116, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = 17
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-EKCWAO = 55
-EKVKZI = 34
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = 50
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 47
-FJBIAM = 81
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 74
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GLRAHE = 38
-GQPLSP = 35
-GYOUSP = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-GZUQEX = 48
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = 79
-IAMJMA = "".join(chr(c) for c in [85, 76])
-IBXYBQ = 3
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IKFWRK = 75
-ILXWAJ = 68
-INEJNI = 76
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = 59
-IRYXBQ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVLASS = "".join(chr(c) for c in [])
-JBIAMJ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-JHIUSO = 25
-JIGYOU = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-JMAOAW = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-JMCBFE = 45
-JNIBXY = 1
-JRJHIU = 24
-JTACCP = 27
-JUIKFW = 10
-JUTYEK = 84
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-JYMOUN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-KINEJN = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-KLGQPL = 31
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 20
-KVKZIL = "".join(chr(c) for c in [65, 109, 80, 109])
-KXSJWM = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LGQPLS = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-LKXSJW = 28
-LNMHXE = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LSXUJU = 83
-MAOAWB = 52
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-MJIGYO = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-MJVHFT = 12
-MOUNBL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NIBXYB = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQJYMO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NQLNMH = 77
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-OAWBSI = 53
-OCTHBS = 41
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 21
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 42
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 82
-OUSPBW = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-OUYNQJ = 60
-PBWJYK = 33
-PFTSIF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-PHUOJR = 22
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 70
-POUYNQ = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFYLJU = 6
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-QJYMOU = 64
-QLNMHX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-QNRSJM = 43
-QPLSPF = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-QXPICX = 15
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RKINEJ = 86
-RSJMCB = 44
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SNQLNM = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-SPFTSI = 72
-SSAKQX = 13
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-THBSKS = 18
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-TYEKCW = 54
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(chr(c) for c in [80, 49])
-UOJRJH = 23
-UQEXLS = 49
-USOOQN = 26
-USPBWJ = 1
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [50, 52, 104])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = 78
-WJYKLG = "".join(chr(c) for c in [67])
-WMNZMJ = 29
-WRKINE = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-XBQFYL = 4
-XEKVKZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 37
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-XYBQSN = 80
-YBQSNQ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-YLIUXF = 2
-YLJUIK = 8
-YMOUNB = 66
-YNQJYM = 62
-YOUSPB = 67
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ZMJIGY = 30
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-CCPQIP = [TACCPQ, ACCPQI]
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-FWRKIN = [JVHFTH, KFWRKI]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-IGYOUS = [MJIGYO, JIGYOU]
-JYKLGQ = [BWJYKL, WJYKLG]
-KZILXW = [JVHFTH, KVKZIL, VKZILX]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LXWAJV = [
-    BMJVHF,
-    ASSAKQ,
-    SAKQXP,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-MJMAOA = [IAMJMA, AMJMAO]
-MNZMJI = [PIPIVL, UNBLKX]
-NBLKXS = [JVHFTH, UNBLKX, PIPIVL]
-NMHXEK = [IVLASS, QLNMHX, LNMHXE]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QSNQLN = [YBQSNQ, BQSNQL]
-SIFJBI = [MJIGYO, TSIFJB]
-SIRYXB = [MJIGYO, BSIRYX]
-SJWMNZ = [KXSJWM, XSJWMN]
-WAJVDQ = []
-XUJUTY = [
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    SXUJUT,
-]
-XWAJVD = [SXUJUT]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -480,165 +19,657 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return AJVDQL
+        return 50
 
     @property
     def output_keys(self):
-        return LXWAJV
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, LASSAK, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                17,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, LASSAK, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 41, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, LASSAK, None, None, QBMJVH
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, LASSAK, None, None, QBMJVH
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, LASSAK, None, None, QBMJVH
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, LASSAK, None, None, QBMJVH
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, LASSAK, None, None, QBMJVH
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                24,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 42, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 43, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 44, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 45, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 46, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 47, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 48, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 49, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 50, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                83,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 84, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CPQIPO: GeckoTempStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoWordStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoWordStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoWordStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, NBLKXS, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, SJWMNZ, None, None, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 85, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, WMNZMJ, None, MNZMJI, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, None, IGYOUS, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoTempStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, JYKLGQ, None, None, QBMJVH
+            "OTActSetpointG": GeckoTempStructAccessor(
+                self.struct, "OTActSetpointG", 57, "ALL"
             ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, MNZMJI, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 59, "ALL"),
+            "CpOnTimeDuringOT": GeckoWordStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 60, "ALL"
             ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoTempStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoTempStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, SIFJBI, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoWordStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 62, "ALL"
             ),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, MJMAOA, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoWordStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 64, "ALL"
             ),
-            JMAOAW: GeckoByteStructAccessor(self.struct, JMAOAW, MAOAWB, QBMJVH),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, QBMJVH),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, WBSIRY, None, SIRYXB, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 66, "ALL"
             ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoTimeStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTimeStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTimeStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoTimeStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, IKFWRK, None, FWRKIN, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                82,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(
-                self.struct, WRKINE, RKINEJ, YYLIUX, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            KINEJN: GeckoBoolStructAccessor(
-                self.struct, KINEJN, INEJNI, YLIUXF, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            NEJNIB: GeckoBoolStructAccessor(
-                self.struct, NEJNIB, INEJNI, YYLIUX, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            EJNIBX: GeckoBoolStructAccessor(
-                self.struct, EJNIBX, INEJNI, JNIBXY, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 67, "ALL"
             ),
-            NIBXYB: GeckoBoolStructAccessor(
-                self.struct, NIBXYB, INEJNI, IBXYBQ, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, QSNQLN, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, None, NMHXEK, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, KZILXW, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 70, "ALL"
             ),
-            ZILXWA: GeckoWordStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 72, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                74,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 81, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                78,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                75,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 86, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 76, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 76, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 76, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 76, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                80,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                77,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 79, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 68, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-51.py
+++ b/src/geckolib/driver/packs/inyt-cfg-51.py
@@ -12,473 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AJVDQL = 64
-AKQXPI = 14
-AMJMAO = 77
-AOAWBS = "".join(chr(c) for c in [67, 69])
-AONPYY = 81
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-AWBSIR = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BLKXSJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-BQSNQL = 3
-BSIRYX = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-BSKSOK = 18
-BWJYKL = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BXYBQS = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-CBFEGZ = 45
-CPQIPO = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-CQBMJV = 0
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = 26
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = 82
-EKCWAO = 55
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EXLSXU = 49
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 46
-FJBIAM = 70
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 66
-FWRKIN = 10
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-GLRAHE = 38
-GYOUSP = 30
-GZUQEX = 47
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IAMJMA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-IGYOUS = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-IKFWRK = 8
-ILXWAJ = "".join(chr(c) for c in [65, 109, 80, 109])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IRYXBQ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVLASS = "".join(chr(c) for c in [])
-JBIAMJ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-JHIUSO = 24
-JMAOAW = 51
-JMCBFE = 44
-JNIBXY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-JRJHIU = 23
-JTACCP = 27
-JUIKFW = 6
-JUTYEK = 80
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JWMNZM = 28
-JYKLGQ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-KINEJN = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-KLGQPL = "".join(chr(c) for c in [70])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 19
-KVKZIL = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-KXSJWM = "".join(chr(c) for c in [80, 49])
-KZILXW = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-LGQPLS = "".join(chr(c) for c in [67])
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LKXSJW = 78
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-LSXUJU = 79
-LXWAJV = "".join(chr(c) for c in [50, 52, 104])
-MAOAWB = "".join(chr(c) for c in [85, 76])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = 73
-MJIGYO = 29
-MJMAOA = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-MJVHFT = 12
-MNZMJI = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NBLKXS = 62
-NEJNIB = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NIBXYB = 72
-NMHXEK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQJYMO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-NQLNMH = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-OCTHBS = 50
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 41
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 61
-OUSPBW = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-PBWJYK = 63
-PFTSIF = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-PHUOJR = 21
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 31
-POUYNQ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFYLJU = 3
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-QJYMOU = 59
-QLAIID = 51
-QLNMHX = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-QNRSJM = 42
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QSNQLN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-QXPICX = 15
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RKINEJ = 71
-RSJMCB = 43
-RYXBQF = 74
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SIFJBI = 68
-SIRYXB = 53
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SNQLNM = 76
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SPFTSI = 35
-SSAKQX = 13
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TSIFJB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-TYEKCW = 54
-UIKFWR = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 75
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = 52
-WJYKLG = 1
-WMNZMJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 37
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XYBQSN = 1
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YKLGQP = 33
-YLIUXF = 2
-YLJUIK = 4
-YMOUNB = 60
-YNQJYM = 58
-YOUSPB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 34
-ZMJIGY = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BIAMJM = [YOUSPB, JBIAMJ]
-CCPQIP = [TACCPQ, ACCPQI]
-DQLAII = []
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-EKVKZI = [IVLASS, HXEKVK, XEKVKZ]
-GQPLSP = [KLGQPL, LGQPLS]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-INEJNI = [JVHFTH, KINEJN]
-JIGYOU = [PIPIVL, KXSJWM]
-JVDQLA = [
-    BMJVHF,
-    ASSAKQ,
-    SAKQXP,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-LNMHXE = [NQLNMH, QLNMHX]
-NZMJIG = [WMNZMJ, MNZMJI]
-OAWBSI = [MAOAWB, AOAWBS]
-OUYNQJ = [QIPOUY, IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-USPBWJ = [YOUSPB, OUSPBW]
-VDQLAI = [SXUJUT]
-XBQFYL = [YOUSPB, YXBQFY]
-XSJWMN = [JVHFTH, KXSJWM, PIPIVL]
-XUJUTY = [
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    SXUJUT,
-]
-XWAJVD = [JVHFTH, ILXWAJ, LXWAJV]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -486,167 +19,664 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return QLAIID
+        return 51
 
     @property
     def output_keys(self):
-        return JVDQLA
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, LASSAK, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, LASSAK, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, LASSAK, None, None, QBMJVH
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, LASSAK, None, None, QBMJVH
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, LASSAK, None, None, QBMJVH
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, LASSAK, None, None, QBMJVH
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, LASSAK, None, None, QBMJVH
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, OUYNQJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoByteStructAccessor(self.struct, NQJYMO, QJYMOU, QBMJVH),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoEnumStructAccessor(
-                self.struct, BLKXSJ, LKXSJW, None, XSJWMN, None, None, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, NZMJIG, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, None, JIGYOU, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            IGYOUS: GeckoEnumStructAccessor(
-                self.struct, IGYOUS, GYOUSP, None, USPBWJ, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoTempStructAccessor(self.struct, BWJYKL, WJYKLG, QBMJVH),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, JIGYOU, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            LSPFTS: GeckoByteStructAccessor(self.struct, LSPFTS, SPFTSI, QBMJVH),
-            PFTSIF: GeckoTempStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoTempStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, BIAMJM, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, QBMJVH),
-            MJMAOA: GeckoEnumStructAccessor(
-                self.struct, MJMAOA, JMAOAW, None, OAWBSI, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, QBMJVH),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, RYXBQF, None, XBQFYL, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTimeStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoTimeStructAccessor(self.struct, LJUIKF, JUIKFW, QBMJVH),
-            UIKFWR: GeckoTimeStructAccessor(self.struct, UIKFWR, IKFWRK, QBMJVH),
-            KFWRKI: GeckoTimeStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, INEJNI, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            NEJNIB: GeckoBoolStructAccessor(
-                self.struct, NEJNIB, EJNIBX, YYLIUX, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            JNIBXY: GeckoBoolStructAccessor(
-                self.struct, JNIBXY, NIBXYB, YLIUXF, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            IBXYBQ: GeckoBoolStructAccessor(
-                self.struct, IBXYBQ, NIBXYB, YYLIUX, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            BXYBQS: GeckoBoolStructAccessor(
-                self.struct, BXYBQS, NIBXYB, XYBQSN, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            YBQSNQ: GeckoBoolStructAccessor(
-                self.struct, YBQSNQ, NIBXYB, BQSNQL, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, LNMHXE, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, EKVKZI, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            KVKZIL: GeckoByteStructAccessor(self.struct, KVKZIL, VKZILX, QBMJVH),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, XWAJVD, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            WAJVDQ: GeckoWordStructAccessor(self.struct, WAJVDQ, AJVDQL, QBMJVH),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-52.py
+++ b/src/geckolib/driver/packs/inyt-cfg-52.py
@@ -12,563 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-ACQFFT = 104
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = 99
-AJVDQL = 96
-AKQXPI = 14
-AMJMAO = 70
-AOAWBS = 77
-AONPYY = 81
-ASSAKQ = "".join(chr(c) for c in [79, 117, 116, 50])
-AWBSIR = 51
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = 68
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BQSNQL = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-BSIRYX = "".join(chr(c) for c in [67, 69])
-BSKSOK = 18
-BSSUHB = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-BVWVUB = 4
-BWJYKL = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-BXTIAC = 102
-BXYBQS = 85
-BYGDSB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-CBFEGZ = 45
-CPQIPO = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-CQBMJV = 0
-CRTFMN = 76
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = 26
-DJQRJJ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-DNIBXT = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DQLAII = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-DSBDJQ = 71
-DUBSSU = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EKCWAO = 55
-EKVKZI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EUTOPH = 75
-EXLSXU = 49
-FCRTFM = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 46
-FFTTID = 105
-FJBIAM = 66
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 31
-FTTIDU = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FWRKIN = "".join(chr(c) for c in [70, 50, 49])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-GTYIYW = 64
-GVUNXN = 52
-GYOUSP = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-GZUQEX = 47
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HBVWVU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HTBJEU = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IACQFF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-IAMJMA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-IBXTIA = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-IBXYBQ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IDNIBX = 100
-IDUBSS = 107
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IIDNIB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-IKFWRK = "".join(chr(c) for c in [70, 50])
-ILXWAJ = 94
-INEJNI = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IRYXBQ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVDNQG = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-IVLASS = "".join(chr(c) for c in [])
-IYWSKW = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-JBIAMJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JEUTOP = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-JHIUSO = 24
-JIGYOU = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JJJVYF = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JJVYFC = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JMCBFE = 44
-JNIBXY = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-JQRJJJ = 82
-JRJHIU = 23
-JTACCP = 27
-JUIKFW = 83
-JUTYEK = 80
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = 1
-JWMNZM = 78
-JYKLGQ = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JYMOUN = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [70, 51])
-KINEJN = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-KLGQPL = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 52])
-KSOKPH = 19
-KVKZIL = 92
-KWIVDN = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-KXSJWM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KZILXW = 93
-LAIIDN = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-LGQPLS = 1
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-LKXSJW = 61
-LNMHXE = 89
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67])
-LSXUJU = 79
-LXWAJV = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-MAOAWB = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = 90
-MJIGYO = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-MJMAOA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-MJVHFT = 12
-MNHTBJ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-MOUNBL = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-NBLKXS = 60
-NEJNIB = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-NHTBJE = 73
-NIBXTI = 101
-NIBXYB = 84
-NMHXEK = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQJYMO = "".join(chr(c) for c in [72, 105])
-NQLNMH = 88
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-OAWBSI = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-OCTHBS = 50
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 41
-OPHUGT = "".join(chr(c) for c in [65, 109, 80, 109])
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 59
-PBWJYK = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-PFTSIF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-PHUGTY = "".join(chr(c) for c in [50, 52, 104])
-PHUOJR = 21
-PICXQI = 16
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70])
-POUYNQ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFFTTI = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-QFYLJU = 74
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-QLAIID = 98
-QLNMHX = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QNRSJM = 42
-QPLSPF = 33
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-QSNQLN = 87
-QXPICX = 15
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJJJVY = 72
-RKINEJ = "".join(chr(c) for c in [70, 50, 51])
-RSJMCB = 43
-RTFMNH = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-RYXBQF = 52
-SAKQXP = "".join(chr(c) for c in [79, 117, 116, 51])
-SBDJQR = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-SIFJBI = 35
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SKWIVD = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-SNQLNM = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = 30
-SSAKQX = 13
-SSUHBV = 109
-SUHBVW = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-TBJEUT = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-TFMNHT = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 103
-TIDUBS = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-TOPHUG = 34
-TSIFJB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-TTIDUB = 106
-TYEKCW = 54
-TYIYWS = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UBSSUH = 108
-UBYGDS = 8
-UGTYIY = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-UHBVWV = 3
-UIKFWR = "".join(chr(c) for c in [70, 49])
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-USPBWJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-UTOPHU = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-VDNQGV = 4
-VDQLAI = 97
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-VLASSA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VUBYGD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-VWVUBY = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-VYFCRT = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = "".join(chr(c) for c in [85, 76])
-WMNZMJ = "".join(chr(c) for c in [80, 49])
-WRKINE = "".join(chr(c) for c in [70, 50, 50])
-WSKWIV = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-WVUBYG = 6
-XBQFYL = 53
-XEKVKZ = 91
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-XQGLRA = 37
-XQIEFX = "".join(chr(c) for c in [72, 84, 82])
-XSJWMN = 62
-XTIACQ = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-XWAJVD = 95
-XYBQSN = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-YBQSNQ = 86
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YFCRTF = 3
-YGDSBD = 10
-YIYWSK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-YKLGQP = 63
-YLIUXF = 2
-YMOUNB = 58
-YNQJYM = "".join(chr(c) for c in [76, 111])
-YOUSPB = 29
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-ZMJIGY = 28
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-BDJQRJ = [JVHFTH, SBDJQR]
-BJEUTO = [IVLASS, HTBJEU, TBJEUT]
-CCPQIP = [TACCPQ, ACCPQI]
-CQFFTT = [IVLASS, IVLASS, IVLASS, IVLASS, IVLASS, IVLASS, KINEJN, INEJNI, NEJNIB]
-DNQGVU = [
-    BMJVHF,
-    ASSAKQ,
-    SAKQXP,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-EJNIBX = [UIKFWR, IKFWRK, KFWRKI, FWRKIN, WRKINE, RKINEJ, KINEJN, INEJNI, NEJNIB]
-FMNHTB = [RTFMNH, TFMNHT]
-HIUSOO = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    PIPIVL,
-]
-HUGTYI = [JVHFTH, OPHUGT, PHUGTY]
-IGYOUS = [MJIGYO, JIGYOU]
-JMAOAW = [PBWJYK, MJMAOA]
-LASSAK = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    VLASSA,
-]
-MNZMJI = [JVHFTH, WMNZMJ, PIPIVL]
-NQGVUN = [SXUJUT]
-OUSPBW = [PIPIVL, WMNZMJ]
-OUYNQJ = [QIPOUY, IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-QGVUNX = []
-QIEFXQ = [
-    JVHFTH,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    XQIEFX,
-]
-QJYMOU = [YNQJYM, NQJYMO]
-SIRYXB = [WBSIRY, BSIRYX]
-SPFTSI = [PLSPFT, LSPFTS]
-WIVDNQ = [SKWIVD, KWIVDN]
-WJYKLG = [PBWJYK, BWJYKL]
-XUJUTY = [
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    IVLASS,
-    SXUJUT,
-]
-YLJUIK = [PBWJYK, FYLJUI]
-YWSKWI = [YIYWSK, IYWSKW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -576,248 +19,912 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GVUNXN
+        return 52
 
     @property
     def output_keys(self):
-        return DNQGVU
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, LASSAK, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, LASSAK, None, None, QBMJVH
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, LASSAK, None, None, QBMJVH
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, LASSAK, None, None, QBMJVH
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, LASSAK, None, None, QBMJVH
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QIEFXQ, None, None, QBMJVH
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, LASSAK, None, None, QBMJVH
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, LASSAK, None, None, QBMJVH
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, LASSAK, None, None, QBMJVH
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, LASSAK, None, None, QBMJVH
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, LASSAK, None, None, QBMJVH
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, LASSAK, None, None, QBMJVH
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, LASSAK, None, None, QBMJVH
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
             ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
             ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, OUYNQJ, None, None, QBMJVH
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
             ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, AONPYY, YLIUXF, QJYMOU, None, YLIUXF, QBMJVH
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
             ),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, MNZMJI, None, None, QBMJVH
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
             ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, None, IGYOUS, None, None, QBMJVH
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, OUSPBW, None, None, QBMJVH
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
             ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, None, WJYKLG, None, None, QBMJVH
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
             ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
             ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, OUSPBW, None, None, QBMJVH
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
             ),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, JMAOAW, None, None, QBMJVH
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
             ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SIRYXB, None, None, QBMJVH
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
             ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
             ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, EJNIBX, None, None, QBMJVH
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
             ),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, NIBXYB, None, EJNIBX, None, None, QBMJVH
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
             ),
-            IBXYBQ: GeckoEnumStructAccessor(
-                self.struct, IBXYBQ, BXYBQS, None, EJNIBX, None, None, QBMJVH
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
             ),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, EJNIBX, None, None, QBMJVH
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
             ),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, EJNIBX, None, None, QBMJVH
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, None, EJNIBX, None, None, QBMJVH
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
             ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, EJNIBX, None, None, QBMJVH
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
             ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, EJNIBX, None, None, QBMJVH
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
             ),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, EJNIBX, None, None, QBMJVH
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
             ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, EJNIBX, None, None, QBMJVH
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, EJNIBX, None, None, QBMJVH
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
             ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, ILXWAJ, None, EJNIBX, None, None, QBMJVH
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
             ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, EJNIBX, None, None, QBMJVH
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, EJNIBX, None, None, QBMJVH
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
             ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, EJNIBX, None, None, QBMJVH
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoByteStructAccessor(self.struct, LAIIDN, AIIDNI, QBMJVH),
-            IIDNIB: GeckoByteStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoByteStructAccessor(self.struct, DNIBXT, NIBXTI, QBMJVH),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, QBMJVH),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, CQFFTT, None, None, QBMJVH
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, CQFFTT, None, None, QBMJVH
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, CQFFTT, None, None, QBMJVH
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, CQFFTT, None, None, QBMJVH
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, CQFFTT, None, None, QBMJVH
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, CQFFTT, None, None, QBMJVH
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoTimeStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoTimeStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoTimeStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoTimeStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, BDJQRJ, None, None, QBMJVH
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            DJQRJJ: GeckoBoolStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, YYLIUX, QBMJVH
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            QRJJJV: GeckoBoolStructAccessor(
-                self.struct, QRJJJV, RJJJVY, YLIUXF, QBMJVH
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            JJJVYF: GeckoBoolStructAccessor(
-                self.struct, JJJVYF, RJJJVY, YYLIUX, QBMJVH
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            JJVYFC: GeckoBoolStructAccessor(
-                self.struct, JJVYFC, RJJJVY, JVYFCR, QBMJVH
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            VYFCRT: GeckoBoolStructAccessor(
-                self.struct, VYFCRT, RJJJVY, YFCRTF, QBMJVH
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, FMNHTB, None, None, QBMJVH
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, BJEUTO, None, None, QBMJVH
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
             ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, HUGTYI, None, None, QBMJVH
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
             ),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, QBMJVH),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, AONPYY, JVYFCR, YWSKWI, None, YLIUXF, QBMJVH
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, AONPYY, YFCRTF, WIVDNQ, None, YLIUXF, QBMJVH
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
             ),
-            IVDNQG: GeckoBoolStructAccessor(
-                self.struct, IVDNQG, AONPYY, VDNQGV, QBMJVH
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                81,
+                3,
+                ["inFlo", "PressureSwitch"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-53.py
+++ b/src/geckolib/driver/packs/inyt-cfg-53.py
@@ -12,587 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-ACQFFT = 104
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = 99
-AJVDQL = 96
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = 70
-AOAWBS = 77
-AONPYY = 81
-AWBSIR = 51
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = 68
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BQSNQL = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-BSIRYX = "".join(chr(c) for c in [67, 69])
-BSKSOK = 18
-BSSUHB = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-BVWVUB = 4
-BWJYKL = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-BXTIAC = 102
-BXYBQS = 85
-BYGDSB = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-CBFEGZ = 45
-CPQIPO = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-CQBMJV = 0
-CRTFMN = 76
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DJQRJJ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-DNIBXT = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DNQGVU = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-DQLAII = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-DSBDJQ = 71
-DUBSSU = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EKCWAO = 55
-EKVKZI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EUTOPH = 75
-EXLSXU = 49
-FCRTFM = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 46
-FFTTID = 105
-FJBIAM = 66
-FJTACC = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 31
-FTTIDU = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-FWRKIN = "".join(chr(c) for c in [70, 50, 49])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-GLRAHE = 38
-GQPLSP = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-GSELHB = 53
-GTYIYW = 64
-GYOUSP = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-GZUQEX = 47
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HBVWVU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HTBJEU = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HXEKVK = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IACQFF = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-IAMJMA = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-IBXTIA = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-IBXYBQ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-ICXQIE = 16
-IDNIBX = 100
-IDUBSS = 107
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IIDNIB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-IKFWRK = "".join(chr(c) for c in [70, 50])
-ILXWAJ = 94
-INEJNI = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IRYXBQ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVDNQG = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-JBIAMJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-JEUTOP = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-JHIUSO = 24
-JIGYOU = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-JJJVYF = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JJVYFC = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-JMCBFE = 44
-JNIBXY = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-JQRJJJ = 82
-JRJHIU = 23
-JTACCP = 27
-JUIKFW = 83
-JUTYEK = 80
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = 1
-JWMNZM = 78
-JYKLGQ = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JYMOUN = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [70, 51])
-KINEJN = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-KLGQPL = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-KMLOIJ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = 14
-KSOKPH = 19
-KVKZIL = 92
-KWIVDN = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-KXSJWM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-KZILXW = 93
-LAIIDN = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = 1
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-LKXSJW = 61
-LNMHXE = 89
-LOIJUG = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [67])
-LSXUJU = 79
-LXWAJV = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-MAOAWB = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = 90
-MJIGYO = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-MJMAOA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-MJVHFT = 12
-MLOIJU = 112
-MNHTBJ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-MOUNBL = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-NBLKXS = 60
-NEJNIB = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-NHTBJE = 73
-NIBXTI = 101
-NIBXYB = 84
-NKMLOI = 111
-NMHXEK = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQGVUN = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-NQJYMO = "".join(chr(c) for c in [72, 105])
-NQLNMH = 88
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NXNKML = 110
-NZMJIG = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-OAWBSI = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-OCTHBS = 50
-OIJUGS = 113
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 41
-OPHUGT = "".join(chr(c) for c in [65, 109, 80, 109])
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = 59
-PBWJYK = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-PFTSIF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-PHUGTY = "".join(chr(c) for c in [50, 52, 104])
-PHUOJR = 21
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70])
-POUYNQ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-PQIPOU = 57
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFFTTI = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-QFYLJU = 74
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-QIPOUY = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-QLAIID = 98
-QLNMHX = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QNRSJM = 42
-QPLSPF = 33
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-QSNQLN = 87
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJJJVY = 72
-RKINEJ = "".join(chr(c) for c in [70, 50, 51])
-RSJMCB = 43
-RTFMNH = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-RYXBQF = 52
-SAKQXP = 13
-SBDJQR = "".join(chr(c) for c in [65, 118, 97, 105, 108, 97, 98, 108, 101])
-SIFJBI = 35
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SKWIVD = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-SNQLNM = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = 30
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = 109
-SUHBVW = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-TBJEUT = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-TFMNHT = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 103
-TIDUBS = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-TOPHUG = 34
-TSIFJB = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-TTIDUB = 106
-TYEKCW = 54
-TYIYWS = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UBSSUH = 108
-UBYGDS = 8
-UGTYIY = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-UHBVWV = 3
-UIKFWR = "".join(chr(c) for c in [70, 49])
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-UNXNKM = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-USPBWJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-UTOPHU = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-UYNQJY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-VDNQGV = 4
-VDQLAI = 97
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-VUNXNK = 5
-VWVUBY = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-VYFCRT = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = "".join(chr(c) for c in [85, 76])
-WMNZMJ = "".join(chr(c) for c in [80, 49])
-WRKINE = "".join(chr(c) for c in [70, 50, 50])
-WSKWIV = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-WVUBYG = 6
-XBQFYL = 53
-XEKVKZ = 91
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XNKMLO = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 26
-XSJWMN = 62
-XTIACQ = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-XWAJVD = 95
-XYBQSN = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-YBQSNQ = 86
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YFCRTF = 3
-YGDSBD = 10
-YIYWSK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-YKLGQP = 63
-YLIUXF = 2
-YMOUNB = 58
-YNQJYM = "".join(chr(c) for c in [76, 111])
-YOUSPB = 29
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YXBQFY = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-ZMJIGY = 28
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BDJQRJ = [JVHFTH, SBDJQR]
-BJEUTO = [VLASSA, HTBJEU, TBJEUT]
-CCPQIP = [TACCPQ, ACCPQI]
-CQFFTT = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, KINEJN, INEJNI, NEJNIB]
-EFJTAC = [UXFEFJ, XFEFJT, FEFJTA]
-EJNIBX = [UIKFWR, IKFWRK, KFWRKI, FWRKIN, WRKINE, RKINEJ, KINEJN, INEJNI, NEJNIB]
-FMNHTB = [RTFMNH, TFMNHT]
-GVUNXN = [NQGVUN, QGVUNX]
-HIUSOO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-HUGTYI = [JVHFTH, OPHUGT, PHUGTY]
-IGYOUS = [MJIGYO, JIGYOU]
-IJUGSE = [
-    BMJVHF,
-    SSAKQX,
-    AKQXPI,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-JMAOAW = [PBWJYK, MJMAOA]
-JUGSEL = [SXUJUT]
-MNZMJI = [JVHFTH, WMNZMJ, PIPIVL]
-OUSPBW = [PIPIVL, WMNZMJ]
-OUYNQJ = [QIPOUY, IPOUYN, POUYNQ]
-PYYLIU = [ONPYYL, NPYYLI]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QJYMOU = [YNQJYM, NQJYMO]
-SIRYXB = [WBSIRY, BSIRYX]
-SPFTSI = [PLSPFT, LSPFTS]
-UGSELH = []
-WIVDNQ = [SKWIVD, KWIVDN]
-WJYKLG = [PBWJYK, BWJYKL]
-XUJUTY = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SXUJUT,
-]
-YLJUIK = [PBWJYK, FYLJUI]
-YWSKWI = [YIYWSK, IYWSKW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -600,255 +19,934 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GSELHB
+        return 53
 
     @property
     def output_keys(self):
-        return IJUGSE
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, ASSAKQ, None, None, QBMJVH
-            ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "Available"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                81,
+                3,
+                ["inFlo", "PressureSwitch"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 110, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 111, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 112, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, ASSAKQ, None, None, QBMJVH
-            ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, ASSAKQ, None, None, QBMJVH
-            ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, ASSAKQ, None, None, QBMJVH
-            ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
-            ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
-            ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, EFJTAC, None, None, QBMJVH
-            ),
-            FJTACC: GeckoEnumStructAccessor(
-                self.struct, FJTACC, JTACCP, None, CCPQIP, None, None, QBMJVH
-            ),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, AONPYY, YLIUXF, QJYMOU, None, YLIUXF, QBMJVH
-            ),
-            JYMOUN: GeckoByteStructAccessor(self.struct, JYMOUN, YMOUNB, QBMJVH),
-            MOUNBL: GeckoByteStructAccessor(self.struct, MOUNBL, OUNBLK, QBMJVH),
-            UNBLKX: GeckoByteStructAccessor(self.struct, UNBLKX, NBLKXS, QBMJVH),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, MNZMJI, None, None, QBMJVH
-            ),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, None, IGYOUS, None, None, QBMJVH
-            ),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, OUSPBW, None, None, QBMJVH
-            ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, None, WJYKLG, None, None, QBMJVH
-            ),
-            JYKLGQ: GeckoByteStructAccessor(self.struct, JYKLGQ, YKLGQP, QBMJVH),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, QBMJVH),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, OUSPBW, None, None, QBMJVH
-            ),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, JMAOAW, None, None, QBMJVH
-            ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SIRYXB, None, None, QBMJVH
-            ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, NIBXYB, None, EJNIBX, None, None, QBMJVH
-            ),
-            IBXYBQ: GeckoEnumStructAccessor(
-                self.struct, IBXYBQ, BXYBQS, None, EJNIBX, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, EJNIBX, None, None, QBMJVH
-            ),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, EJNIBX, None, None, QBMJVH
-            ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, None, EJNIBX, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, EJNIBX, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, EJNIBX, None, None, QBMJVH
-            ),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, EJNIBX, None, None, QBMJVH
-            ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, EJNIBX, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, EJNIBX, None, None, QBMJVH
-            ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, ILXWAJ, None, EJNIBX, None, None, QBMJVH
-            ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, EJNIBX, None, None, QBMJVH
-            ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, EJNIBX, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, EJNIBX, None, None, QBMJVH
-            ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoByteStructAccessor(self.struct, LAIIDN, AIIDNI, QBMJVH),
-            IIDNIB: GeckoByteStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoByteStructAccessor(self.struct, DNIBXT, NIBXTI, QBMJVH),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, QBMJVH),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, CQFFTT, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, CQFFTT, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, CQFFTT, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, CQFFTT, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, CQFFTT, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, CQFFTT, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoTimeStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoTimeStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoTimeStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoTimeStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, BDJQRJ, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoBoolStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, YYLIUX, QBMJVH
-            ),
-            QRJJJV: GeckoBoolStructAccessor(
-                self.struct, QRJJJV, RJJJVY, YLIUXF, QBMJVH
-            ),
-            JJJVYF: GeckoBoolStructAccessor(
-                self.struct, JJJVYF, RJJJVY, YYLIUX, QBMJVH
-            ),
-            JJVYFC: GeckoBoolStructAccessor(
-                self.struct, JJVYFC, RJJJVY, JVYFCR, QBMJVH
-            ),
-            VYFCRT: GeckoBoolStructAccessor(
-                self.struct, VYFCRT, RJJJVY, YFCRTF, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, FMNHTB, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, BJEUTO, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, HUGTYI, None, None, QBMJVH
-            ),
-            UGTYIY: GeckoWordStructAccessor(self.struct, UGTYIY, GTYIYW, QBMJVH),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, AONPYY, JVYFCR, YWSKWI, None, YLIUXF, QBMJVH
-            ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, AONPYY, YFCRTF, WIVDNQ, None, YLIUXF, QBMJVH
-            ),
-            IVDNQG: GeckoBoolStructAccessor(
-                self.struct, IVDNQG, AONPYY, VDNQGV, QBMJVH
-            ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, AONPYY, VUNXNK, GVUNXN, None, YLIUXF, QBMJVH
-            ),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, QBMJVH),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, QBMJVH),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-54.py
+++ b/src/geckolib/driver/packs/inyt-cfg-54.py
@@ -12,636 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-ACQFFT = 97
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = 92
-AJVDQL = 89
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-AOAWBS = 3
-AONPYY = 81
-AWBSIR = 35
-BDJQRJ = 109
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-BJEUTO = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-BLKXSJ = 60
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQNRXC = 110
-BQSNQL = "".join(chr(c) for c in [70, 51])
-BSIRYX = 66
-BSKSOK = 18
-BSSUHB = 102
-BWJYKL = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-BXTIAC = 95
-BXYBQS = 83
-BYGDSB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-CBFEGZ = 45
-CCPQIP = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-CHWDAF = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CRTFMN = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 56
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DJQRJJ = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-DNIBXT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-DNQGVU = "".join(chr(c) for c in [65, 109, 80, 109])
-DQLAII = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-DSBDJQ = 108
-DUBSSU = 101
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = 74
-EKCWAO = 55
-EKVKZI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-ELHBQN = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EUTOPH = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-EXLSXU = 49
-FCRTFM = 8
-FEFJTA = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FEGZUQ = 46
-FFTTID = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-FIKJPU = 54
-FJBIAM = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-FMNHTB = 71
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-FTTIDU = 99
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-FYLJUI = 77
-GDSBDJ = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-GLRAHE = 38
-GQPLSP = 1
-GSELHB = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-GTYIYW = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-GVUNXN = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-GZUQEX = 47
-HBQNRX = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HBVWVU = 104
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HTBJEU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-HUGTYI = 76
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HWDAFI = 113
-HXEKVK = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IACQFF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IBXTIA = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-IBXYBQ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-ICXQIE = 16
-IDNIBX = 93
-IDUBSS = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = 115
-IGYOUS = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-IIDNIB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-IJUGSE = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-IKFWRK = "".join(chr(c) for c in [85, 76])
-ILXWAJ = 87
-INEJNI = 53
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-IRYXBQ = 68
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 32
-IVDNQG = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 73
-JBIAMJ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-JEUTOP = 72
-JHIUSO = 24
-JIGYOU = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-JJJVYF = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JJVYFC = 6
-JMAOAW = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-JMCBFE = 44
-JNIBXY = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-JQRJJJ = 3
-JRJHIU = 23
-JTACCP = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-JUIKFW = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-JUTYEK = 80
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-JWMNZM = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-KCWAON = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-KFWRKI = "".join(chr(c) for c in [67, 69])
-KINEJN = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-KLGQPL = 63
-KMLOIJ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = 14
-KSOKPH = 19
-KVKZIL = 85
-KWIVDN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-KXSJWM = 61
-KZILXW = 86
-LAIIDN = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-LHBQNR = 7
-LIUXFE = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LJUIKF = 114
-LKXSJW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-LNMHXE = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LOIJUG = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [70])
-LSXUJU = 79
-LXWAJV = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MJIGYO = 28
-MJMAOA = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MJVHFT = 12
-MLOIJU = 4
-MNHTBJ = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-MNZMJI = "".join(chr(c) for c in [80, 49])
-MOUNBL = 58
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-NIBXTI = 94
-NMHXEK = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-NPYYLI = "".join(chr(c) for c in [79, 119, 110])
-NQGVUN = "".join(chr(c) for c in [50, 52, 104])
-NQJYMO = "".join(chr(c) for c in [76, 111])
-NQLNMH = "".join(chr(c) for c in [70, 50, 51])
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NRXCHW = 111
-NXNKML = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-OAWBSI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-OCTHBS = 50
-OIJUGS = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-OOQNRS = 41
-OPHUGT = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OUSPBW = 29
-OUYNQJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-PBWJYK = 30
-PHUGTY = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-PHUOJR = 21
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 33
-POUYNQ = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-PQIPOU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFFTTI = 98
-QFYLJU = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QIPOUY = 57
-QJYMOU = "".join(chr(c) for c in [72, 105])
-QLAIID = 91
-QLNMHX = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = 42
-QNRXCH = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-QPLSPF = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QRJJJV = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-QSNQLN = "".join(chr(c) for c in [70, 50, 49])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJJJVY = 4
-RKINEJ = 52
-RSJMCB = 43
-RTFMNH = 10
-RXCHWD = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-RYXBQF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-SAKQXP = 13
-SBDJQR = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-SELHBQ = 6
-SIFJBI = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-SIRYXB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = 62
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SNQLNM = "".join(chr(c) for c in [70, 50, 50])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-SPFTSI = "".join(chr(c) for c in [67])
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-SUHBVW = 103
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TACCPQ = 27
-TBJEUT = 82
-TFMNHT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 96
-TIDUBS = 100
-TOPHUG = 1
-TSIFJB = 31
-TTIDUB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-TYEKCW = 54
-UBSSUH = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-UBYGDS = 106
-UGSELH = 5
-UGTYIY = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-UHBVWV = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-UIKFWR = 51
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = 59
-UNXNKM = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-UTOPHU = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-VDNQGV = 34
-VDQLAI = 90
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-VUNXNK = 64
-VWVUBY = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-VYFCRT = 116
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-WBSIRY = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-WIVDNQ = 75
-WJYKLG = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-WMNZMJ = 78
-WRKINE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-WSKWIV = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-WVUBYG = 105
-XBQFYL = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-XCHWDA = 112
-XEKVKZ = 84
-XFEFJT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XNKMLO = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 26
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-XTIACQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-XWAJVD = 88
-XYBQSN = "".join(chr(c) for c in [70, 49])
-YBQSNQ = "".join(chr(c) for c in [70, 50])
-YEKCWA = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-YFCRTF = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-YGDSBD = 107
-YIYWSK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-YKLGQP = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YLIUXF = 2
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YMOUNB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-YNQJYM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-YOUSPB = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-YXBQFY = 70
-YYLIUX = 0
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-ZMJIGY = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-AFIKJP = []
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BQFYLJ = [BWJYKL, XBQFYL]
-BVWVUB = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLNMHX, LNMHXE, NMHXEK]
-CPQIPO = [ACCPQI, CCPQIP]
-DAFIKJ = [SXUJUT]
-FJTACC = [UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FWRKIN = [IKFWRK, KFWRKI]
-GYOUSP = [JIGYOU, IGYOUS]
-HIUSOO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IAMJMA = [FJBIAM, JBIAMJ, BIAMJM]
-JUGSEL = [OIJUGS, IJUGSE]
-JYKLGQ = [BWJYKL, WJYKLG]
-JYMOUN = [NQJYMO, QJYMOU]
-MAOAWB = [MJMAOA, JMAOAW]
-MHXEKV = [XYBQSN, YBQSNQ, BQSNQL, QSNQLN, SNQLNM, NQLNMH, QLNMHX, LNMHXE, NMHXEK]
-NHTBJE = [JVHFTH, ACCPQI, MNHTBJ]
-NIBXYB = [BWJYKL, JNIBXY]
-NKMLOI = [NXNKML, XNKMLO]
-NZMJIG = [JVHFTH, MNZMJI, PIPIVL]
-PFTSIF = [LSPFTS, SPFTSI]
-PYYLIU = [ONPYYL, NPYYLI]
-QGVUNX = [JVHFTH, DNQGVU, NQGVUN]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-SKWIVD = [VLASSA, YWSKWI, WSKWIV]
-TYIYWS = [UGTYIY, GTYIYW]
-USPBWJ = [PIPIVL, MNZMJI]
-UYNQJY = [IPOUYN, POUYNQ, OUYNQJ]
-WDAFIK = [
-    BMJVHF,
-    SSAKQX,
-    AKQXPI,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-XUJUTY = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SXUJUT,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -649,266 +19,954 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return FIKJPU
+        return 54
 
     @property
     def output_keys(self):
-        return WDAFIK
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                115,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 110, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 111, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 112, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, ASSAKQ, None, None, QBMJVH
-            ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, ASSAKQ, None, None, QBMJVH
-            ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, ASSAKQ, None, None, QBMJVH
-            ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, ASSAKQ, None, None, QBMJVH
-            ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, ASSAKQ, None, None, QBMJVH
-            ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
-            ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, YYLIUX, PYYLIU, None, YLIUXF, QBMJVH
-            ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, FJTACC, None, None, QBMJVH
-            ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, AONPYY, YLIUXF, JYMOUN, None, YLIUXF, QBMJVH
-            ),
-            YMOUNB: GeckoByteStructAccessor(self.struct, YMOUNB, MOUNBL, QBMJVH),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, WMNZMJ, None, NZMJIG, None, None, QBMJVH
-            ),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, None, GYOUSP, None, None, QBMJVH
-            ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, USPBWJ, None, None, QBMJVH
-            ),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoTempStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, USPBWJ, None, None, QBMJVH
-            ),
-            SIFJBI: GeckoEnumStructAccessor(
-                self.struct, SIFJBI, IFJBIA, None, IAMJMA, None, None, QBMJVH
-            ),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, AONPYY, AOAWBS, MAOAWB, None, YLIUXF, QBMJVH
-            ),
-            OAWBSI: GeckoByteStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoTempStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTempStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, BQFYLJ, None, None, QBMJVH
-            ),
-            QFYLJU: GeckoByteStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, FWRKIN, None, None, QBMJVH
-            ),
-            WRKINE: GeckoByteStructAccessor(self.struct, WRKINE, RKINEJ, QBMJVH),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, NIBXYB, None, None, QBMJVH
-            ),
-            IBXYBQ: GeckoEnumStructAccessor(
-                self.struct, IBXYBQ, BXYBQS, None, MHXEKV, None, None, QBMJVH
-            ),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, MHXEKV, None, None, QBMJVH
-            ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, MHXEKV, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, MHXEKV, None, None, QBMJVH
-            ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, ILXWAJ, None, MHXEKV, None, None, QBMJVH
-            ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, MHXEKV, None, None, QBMJVH
-            ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, MHXEKV, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, MHXEKV, None, None, QBMJVH
-            ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, MHXEKV, None, None, QBMJVH
-            ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, None, MHXEKV, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, MHXEKV, None, None, QBMJVH
-            ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, MHXEKV, None, None, QBMJVH
-            ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, BXTIAC, None, MHXEKV, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, MHXEKV, None, None, QBMJVH
-            ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, MHXEKV, None, None, QBMJVH
-            ),
-            CQFFTT: GeckoByteStructAccessor(self.struct, CQFFTT, QFFTTI, QBMJVH),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, QBMJVH),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, QBMJVH),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoEnumStructAccessor(
-                self.struct, UHBVWV, HBVWVU, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, BVWVUB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, BVWVUB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, BVWVUB, None, None, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, BVWVUB, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, BVWVUB, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoTimeStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoTimeStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoTimeStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoTimeStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, NHTBJE, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoBoolStructAccessor(
-                self.struct, HTBJEU, TBJEUT, YYLIUX, QBMJVH
-            ),
-            BJEUTO: GeckoBoolStructAccessor(
-                self.struct, BJEUTO, JEUTOP, YLIUXF, QBMJVH
-            ),
-            EUTOPH: GeckoBoolStructAccessor(
-                self.struct, EUTOPH, JEUTOP, YYLIUX, QBMJVH
-            ),
-            UTOPHU: GeckoBoolStructAccessor(
-                self.struct, UTOPHU, JEUTOP, TOPHUG, QBMJVH
-            ),
-            OPHUGT: GeckoBoolStructAccessor(
-                self.struct, OPHUGT, JEUTOP, AOAWBS, QBMJVH
-            ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, TYIYWS, None, None, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, SKWIVD, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoByteStructAccessor(self.struct, KWIVDN, WIVDNQ, QBMJVH),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, QGVUNX, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, QBMJVH),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, AONPYY, TOPHUG, NKMLOI, None, YLIUXF, QBMJVH
-            ),
-            KMLOIJ: GeckoBoolStructAccessor(
-                self.struct, KMLOIJ, AONPYY, MLOIJU, QBMJVH
-            ),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, AONPYY, UGSELH, JUGSEL, None, YLIUXF, QBMJVH
-            ),
-            GSELHB: GeckoBoolStructAccessor(
-                self.struct, GSELHB, AONPYY, SELHBQ, QBMJVH
-            ),
-            ELHBQN: GeckoBoolStructAccessor(
-                self.struct, ELHBQN, AONPYY, LHBQNR, QBMJVH
-            ),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, QBMJVH),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-55.py
+++ b/src/geckolib/driver/packs/inyt-cfg-55.py
@@ -12,638 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-ACQFFT = 96
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-AIIDNI = 91
-AJVDQL = 88
-AKQXPI = "".join(chr(c) for c in [79, 117, 116, 51])
-AMJMAO = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-AOAWBS = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-AONPYY = 56
-AWBSIR = 3
-BDJQRJ = 108
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-BJEUTO = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-BLKXSJ = 59
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 70
-BQNRXC = 7
-BQSNQL = "".join(chr(c) for c in [70, 49])
-BSIRYX = 35
-BSKSOK = 18
-BSSUHB = 101
-BVWVUB = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-BWJYKL = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-BXTIAC = 94
-BYGDSB = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-CBFEGZ = 45
-CCPQIP = 27
-CHWDAF = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-CPQIPO = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-CRTFMN = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 54])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 55
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-DAFIKJ = 113
-DJQRJJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-DNIBXT = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-DNQGVU = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-DQLAII = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-DSBDJQ = 107
-DUBSSU = 100
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-EFXQGL = 36
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EJNIBX = 53
-EKCWAO = 118
-EKVKZI = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-ELHBQN = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-EUTOPH = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-EXLSXU = 49
-FCRTFM = 116
-FEFJTA = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-FEGZUQ = 46
-FFTTID = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-FJBIAM = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-FJTACC = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-FMNHTB = 10
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67])
-FTTIDU = 98
-FWRKIN = "".join(chr(c) for c in [85, 76])
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-GLRAHE = 38
-GQPLSP = 63
-GTYIYW = 76
-GVUNXN = "".join(chr(c) for c in [50, 52, 104])
-GYOUSP = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-GZUQEX = 47
-HBQNRX = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 55])
-HBVWVU = 103
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 40
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HTBJEU = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-HUGTYI = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-HWDAFI = 112
-HXEKVK = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-IACQFF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-IAMJMA = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-IBXTIA = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-IBXYBQ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-ICXQIE = 16
-IDNIBX = 92
-IDUBSS = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-IFJBIA = 31
-IGYOUS = 28
-IIDNIB = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-IJUGSE = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-IKFWRK = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-ILXWAJ = 86
-INEJNI = 52
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-IRYXBQ = 66
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-IUXFEF = 2
-IVDNQG = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = 115
-JEUTOP = 82
-JHIUSO = 24
-JIGYOU = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-JJJVYF = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-JJVYFC = 4
-JMAOAW = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-JMCBFE = 44
-JNIBXY = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-JQRJJJ = 109
-JRJHIU = 23
-JTACCP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-JUGSEL = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-JUIKFW = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-JUTYEK = 80
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-JWMNZM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JYKLGQ = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-JYMOUN = "".join(chr(c) for c in [76, 111])
-KCWAON = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-KFWRKI = 51
-KINEJN = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-KJPUNR = 55
-KMLOIJ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-KQXPIC = 14
-KSOKPH = 19
-KVKZIL = 84
-KWIVDN = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-KXSJWM = 60
-KZILXW = 85
-LAIIDN = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-LASSAK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-LGQPLS = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-LHBQNR = 6
-LIUXFE = 0
-LJUIKF = 77
-LKXSJW = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-LNMHXE = "".join(chr(c) for c in [70, 50, 51])
-LOIJUG = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-LSXUJU = 79
-LXWAJV = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-MAOAWB = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-MHXEKV = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-MJVHFT = 12
-MNHTBJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-MNZMJI = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-NBLKXS = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-NEJNIB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-NHTBJE = 71
-NIBXTI = 93
-NIBXYB = 74
-NKMLOI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-NMHXEK = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-NPYYLI = 81
-NQGVUN = 34
-NQLNMH = "".join(chr(c) for c in [70, 50, 49])
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-NRXCHW = 110
-NXNKML = 64
-NZMJIG = 78
-OCTHBS = 50
-OIJUGS = 4
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-OKPHUO = 20
-ONPYYL = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-OOQNRS = 41
-OPHUGT = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-OQNRSJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-OUNBLK = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OUYNQJ = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-PFTSIF = "".join(chr(c) for c in [70])
-PHUGTY = 1
-PHUOJR = 21
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 53])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 1
-POUYNQ = 57
-PQIPOU = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-PYYLIU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QFFTTI = 97
-QFYLJU = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [65, 109, 80, 109])
-QJYMOU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-QLAIID = 90
-QLNMHX = "".join(chr(c) for c in [70, 50, 50])
-QNRSJM = 42
-QNRXCH = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-QPLSPF = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-QRJJJV = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-QSNQLN = "".join(chr(c) for c in [70, 50])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 52])
-RAHEOC = 39
-RJHIUS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-RJJJVY = 3
-RSJMCB = 43
-RTFMNH = 8
-RXCHWD = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-RYXBQF = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SAKQXP = 13
-SBDJQR = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-SELHBQ = 5
-SIFJBI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-SIRYXB = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-SJWMNZ = 61
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 56])
-SKWIVD = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-SNQLNM = "".join(chr(c) for c in [70, 51])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 57])
-SOOQNR = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-SPBWJY = 29
-SPFTSI = 33
-SSAKQX = "".join(chr(c) for c in [79, 117, 116, 50])
-SSUHBV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-SUHBVW = 102
-SXUJUT = "".join(chr(c) for c in [76, 73])
-TFMNHT = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-THBSKS = 17
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 95
-TIDUBS = 99
-TOPHUG = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-TTIDUB = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-TYEKCW = 54
-TYIYWS = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-UBSSUH = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-UBYGDS = 105
-UGSELH = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-UGTYIY = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-UHBVWV = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-UIKFWR = 114
-UJUTYE = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-UNBLKX = 58
-UNXNKM = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-UOJRJH = 22
-UQEXLS = 48
-USOOQN = 25
-USPBWJ = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-UTOPHU = 72
-UTYEKC = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-UXFEFJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-UYNQJY = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-VDNQGV = 75
-VDQLAI = 89
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-VWVUBY = 104
-VYFCRT = 6
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-WAONPY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-WBSIRY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-WDAFIK = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-WJYKLG = 30
-WMNZMJ = 62
-WRKINE = "".join(chr(c) for c in [67, 69])
-WSKWIV = 73
-XBQFYL = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-XCHWDA = 111
-XFEFJT = 32
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XNKMLO = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XPICXQ = 15
-XQGLRA = 37
-XQIEFX = 26
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-XTIACQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-XWAJVD = 87
-XYBQSN = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-YBQSNQ = 83
-YEKCWA = "".join(chr(c) for c in [80, 49, 76, 84, 105, 109, 101, 79, 117, 116])
-YFCRTF = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-YGDSBD = 106
-YIYWSK = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-YKLGQP = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-YLJUIK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-YMOUNB = "".join(chr(c) for c in [72, 105])
-YNQJYM = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-YOUSPB = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-YXBQFY = 68
-YYLIUX = "".join(chr(c) for c in [79, 119, 110])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-ZMJIGY = "".join(chr(c) for c in [80, 49])
-ZUQEXL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-AFIKJP = [
-    BMJVHF,
-    SSAKQX,
-    AKQXPI,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    CTHBSK,
-    HBSKSO,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    IUSOOQ,
-    XLSXUJ,
-]
-ASSAKQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    LASSAK,
-]
-BXYBQS = [JYKLGQ, IBXYBQ]
-FIKJPU = [SXUJUT]
-FYLJUI = [JYKLGQ, QFYLJU]
-GSELHB = [JUGSEL, UGSELH]
-HIUSOO = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-IKJPUN = []
-IYWSKW = [TYIYWS, YIYWSK]
-KLGQPL = [JYKLGQ, YKLGQP]
-MJIGYO = [JVHFTH, ZMJIGY, PIPIVL]
-MJMAOA = [BIAMJM, IAMJMA, AMJMAO]
-MLOIJU = [NKMLOI, KMLOIJ]
-MOUNBL = [JYMOUN, YMOUNB]
-NQJYMO = [OUYNQJ, UYNQJY, YNQJYM]
-OAWBSI = [MAOAWB, AOAWBS]
-OUSPBW = [GYOUSP, YOUSPB]
-PBWJYK = [PIPIVL, ZMJIGY]
-QIEFXQ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-]
-QIPOUY = [CPQIPO, PQIPOU]
-RKINEJ = [FWRKIN, WRKINE]
-TACCPQ = [FEFJTA, EFJTAC, FJTACC, JTACCP]
-TBJEUT = [JVHFTH, CPQIPO, HTBJEU]
-TSIFJB = [PFTSIF, FTSIFJ]
-VUNXNK = [JVHFTH, QGVUNX, GVUNXN]
-WIVDNQ = [VLASSA, SKWIVD, KWIVDN]
-WVUBYG = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, NMHXEK, MHXEKV, HXEKVK]
-XEKVKZ = [BQSNQL, QSNQLN, SNQLNM, NQLNMH, QLNMHX, LNMHXE, NMHXEK, MHXEKV, HXEKVK]
-XUJUTY = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SXUJUT,
-]
-YLIUXF = [PYYLIU, YYLIUX]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -651,267 +19,957 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return KJPUNR
+        return 55
 
     @property
     def output_keys(self):
-        return AFIKJP
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, ASSAKQ, None, None, QBMJVH
-            ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, ASSAKQ, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, ASSAKQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "P1LTimeOut": GeckoByteStructAccessor(
+                self.struct, "P1LTimeOut", 118, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                115,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 110, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 111, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 112, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, ASSAKQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, QIEFXQ, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoByteStructAccessor(self.struct, IEFXQG, EFXQGL, QBMJVH),
-            FXQGLR: GeckoByteStructAccessor(self.struct, FXQGLR, XQGLRA, QBMJVH),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, THBSKS, None, ASSAKQ, None, None, QBMJVH
-            ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, ASSAKQ, None, None, QBMJVH
-            ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, ASSAKQ, None, None, QBMJVH
-            ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, ASSAKQ, None, None, QBMJVH
-            ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, ASSAKQ, None, None, QBMJVH
-            ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, ASSAKQ, None, None, QBMJVH
-            ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, HIUSOO, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, HIUSOO, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, QBMJVH),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, QBMJVH),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, XUJUTY, None, None, None
-            ),
-            UJUTYE: GeckoByteStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoByteStructAccessor(self.struct, UTYEKC, TYEKCW, QBMJVH),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, QBMJVH),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, LIUXFE, YLIUXF, None, IUXFEF, QBMJVH
-            ),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, None, TACCPQ, None, None, QBMJVH
-            ),
-            ACCPQI: GeckoEnumStructAccessor(
-                self.struct, ACCPQI, CCPQIP, None, QIPOUY, None, None, QBMJVH
-            ),
-            IPOUYN: GeckoEnumStructAccessor(
-                self.struct, IPOUYN, POUYNQ, None, NQJYMO, None, None, QBMJVH
-            ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, NPYYLI, IUXFEF, MOUNBL, None, IUXFEF, QBMJVH
-            ),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, QBMJVH),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, QBMJVH),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, QBMJVH),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, MJIGYO, None, None, QBMJVH
-            ),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, OUSPBW, None, None, QBMJVH
-            ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, None, PBWJYK, None, None, QBMJVH
-            ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, KLGQPL, None, None, QBMJVH
-            ),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, QBMJVH),
-            QPLSPF: GeckoTempStructAccessor(self.struct, QPLSPF, PLSPFT, QBMJVH),
-            LSPFTS: GeckoEnumStructAccessor(
-                self.struct, LSPFTS, SPFTSI, None, TSIFJB, None, None, QBMJVH
-            ),
-            SIFJBI: GeckoEnumStructAccessor(
-                self.struct, SIFJBI, IFJBIA, None, PBWJYK, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, JBIAMJ, None, MJMAOA, None, None, QBMJVH
-            ),
-            JMAOAW: GeckoEnumStructAccessor(
-                self.struct, JMAOAW, NPYYLI, AWBSIR, OAWBSI, None, IUXFEF, QBMJVH
-            ),
-            WBSIRY: GeckoByteStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoTempStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoTempStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FYLJUI, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoByteStructAccessor(self.struct, JUIKFW, UIKFWR, QBMJVH),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoByteStructAccessor(self.struct, KINEJN, INEJNI, QBMJVH),
-            NEJNIB: GeckoByteStructAccessor(self.struct, NEJNIB, EJNIBX, QBMJVH),
-            JNIBXY: GeckoEnumStructAccessor(
-                self.struct, JNIBXY, NIBXYB, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, XEKVKZ, None, None, QBMJVH
-            ),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, XEKVKZ, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, XEKVKZ, None, None, QBMJVH
-            ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, ILXWAJ, None, XEKVKZ, None, None, QBMJVH
-            ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, XEKVKZ, None, None, QBMJVH
-            ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, XEKVKZ, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, XEKVKZ, None, None, QBMJVH
-            ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, XEKVKZ, None, None, QBMJVH
-            ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, None, XEKVKZ, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, XEKVKZ, None, None, QBMJVH
-            ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, XEKVKZ, None, None, QBMJVH
-            ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, BXTIAC, None, XEKVKZ, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, XEKVKZ, None, None, QBMJVH
-            ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, XEKVKZ, None, None, QBMJVH
-            ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, XEKVKZ, None, None, QBMJVH
-            ),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, QBMJVH),
-            TTIDUB: GeckoByteStructAccessor(self.struct, TTIDUB, TIDUBS, QBMJVH),
-            IDUBSS: GeckoByteStructAccessor(self.struct, IDUBSS, DUBSSU, QBMJVH),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, VWVUBY, None, WVUBYG, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, WVUBYG, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, WVUBYG, None, None, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, WVUBYG, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, WVUBYG, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, WVUBYG, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoTimeStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoTimeStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoTimeStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoTimeStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, TBJEUT, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoBoolStructAccessor(
-                self.struct, BJEUTO, JEUTOP, LIUXFE, QBMJVH
-            ),
-            EUTOPH: GeckoBoolStructAccessor(
-                self.struct, EUTOPH, UTOPHU, IUXFEF, QBMJVH
-            ),
-            TOPHUG: GeckoBoolStructAccessor(
-                self.struct, TOPHUG, UTOPHU, LIUXFE, QBMJVH
-            ),
-            OPHUGT: GeckoBoolStructAccessor(
-                self.struct, OPHUGT, UTOPHU, PHUGTY, QBMJVH
-            ),
-            HUGTYI: GeckoBoolStructAccessor(
-                self.struct, HUGTYI, UTOPHU, AWBSIR, QBMJVH
-            ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, IYWSKW, None, None, QBMJVH
-            ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, WIVDNQ, None, None, QBMJVH
-            ),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, QBMJVH),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, VUNXNK, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoWordStructAccessor(self.struct, UNXNKM, NXNKML, QBMJVH),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NPYYLI, PHUGTY, MLOIJU, None, IUXFEF, QBMJVH
-            ),
-            LOIJUG: GeckoBoolStructAccessor(
-                self.struct, LOIJUG, NPYYLI, OIJUGS, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, NPYYLI, SELHBQ, GSELHB, None, IUXFEF, QBMJVH
-            ),
-            ELHBQN: GeckoBoolStructAccessor(
-                self.struct, ELHBQN, NPYYLI, LHBQNR, QBMJVH
-            ),
-            HBQNRX: GeckoBoolStructAccessor(
-                self.struct, HBQNRX, NPYYLI, BQNRXC, QBMJVH
-            ),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, QBMJVH),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, QBMJVH),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-56.py
+++ b/src/geckolib/driver/packs/inyt-cfg-56.py
@@ -12,662 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-ACQFFT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-AFIKJP = 112
-AHEOCT = 38
-AIIDNI = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-AJVDQL = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-AMJMAO = 115
-AONPYY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AWBSIR = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BDJQRJ = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-BFEGZU = 44
-BIAMJM = 31
-BJEUTO = 71
-BLKXSJ = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 54])
-BSSUHB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-BVWVUB = 102
-BWJYKL = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BXYBQS = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-CHWDAF = 110
-CQBMJV = 0
-CQFFTT = 95
-CRTFMN = 6
-CTHBSK = 40
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-CXQIEF = 15
-DAFIKJ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-DJQRJJ = 107
-DNIBXT = 91
-DQLAII = 88
-DSBDJQ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-DUBSSU = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-EFXQGL = 26
-EGZUQE = 45
-EJNIBX = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-EKCWAO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-EKVKZI = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-ELHBQN = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-EOCTHB = 39
-EXLSXU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-FCRTFM = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-FEFJTA = 118
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-FFTTID = 96
-FIKJPU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FJTACC = 32
-FMNHTB = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-FWRKIN = 114
-FYLJUI = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-GDSBDJ = 105
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GQPLSP = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-GSELHB = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-GTYIYW = 1
-GVUNXN = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-HBQNRX = 5
-HBSKSO = 50
-HBVWVU = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 23
-HTBJEU = 10
-HUGTYI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-HUOJRJ = 20
-HWDAFI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-HXEKVK = "".join(chr(c) for c in [70, 50, 51])
-IACQFF = 94
-IAMJMA = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-IBXTIA = 92
-IBXYBQ = 53
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 52])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IDUBSS = 98
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IFJBIA = "".join(chr(c) for c in [67])
-IGYOUS = "".join(chr(c) for c in [80, 49])
-IIDNIB = 90
-IKFWRK = 77
-IKJPUN = 113
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [67, 69])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-IRYXBQ = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-IUXFEF = 0
-IVDNQG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 76
-JBIAMJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-JEUTOP = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-JIGYOU = 78
-JJJVYF = 109
-JJVYFC = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JMAOAW = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-JNIBXY = 52
-JQRJJJ = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JTACCP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JUGSEL = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-JUTYEK = "".join(chr(c) for c in [76, 73])
-JVDQLA = 87
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = 3
-JWMNZM = 60
-JYMOUN = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-KCWAON = 54
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [85, 76])
-KLGQPL = 30
-KMLOIJ = 64
-KPHUOJ = 19
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 50])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 55])
-KVKZIL = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-KWIVDN = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-KXSJWM = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-KZILXW = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-LAIIDN = 89
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-LJUIKF = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-LKXSJW = 58
-LNMHXE = "".join(chr(c) for c in [70, 51])
-LOIJUG = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-LRAHEO = 37
-LSPFTS = 63
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-LXWAJV = 85
-MAOAWB = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-MCBFEG = 43
-MHXEKV = "".join(chr(c) for c in [70, 50, 50])
-MJIGYO = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-MJMAOA = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-MNHTBJ = 8
-MNZMJI = 61
-MOUNBL = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-NHTBJE = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-NIBXYB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-NKMLOI = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-NMHXEK = "".join(chr(c) for c in [70, 50, 49])
-NPYYLI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-NQGVUN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-NQJYMO = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-NQLNMH = "".join(chr(c) for c in [70, 49])
-NRSJMC = 41
-NRXCHW = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-NXNKML = "".join(chr(c) for c in [50, 52, 104])
-NZMJIG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-OAWBSI = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-OIJUGS = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-OJRJHI = 21
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 56])
-ONPYYL = 56
-OOQNRS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-OPHUGT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-OQNRSJ = 25
-OUNBLK = "".join(chr(c) for c in [76, 111])
-OUSPBW = 28
-PFTSIF = 1
-PHUGTY = 72
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 57])
-PICXQI = 14
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-POUYNQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-PQIPOU = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-PYYLIU = 81
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 47
-QFFTTI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-QFYLJU = 68
-QGLRAH = 36
-QGVUNX = 75
-QIEFXQ = 16
-QIPOUY = 27
-QJYMOU = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QLAIID = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QLNMHX = "".join(chr(c) for c in [70, 50])
-QNRSJM = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-QNRXCH = 6
-QRJJJV = 108
-QSNQLN = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-QXPICX = 13
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-RJHIUS = 22
-RJJJVY = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-RKINEJ = 51
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-RXCHWD = 7
-RYXBQF = 35
-SAKQXP = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-SBDJQR = 106
-SELHBQ = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-SIFJBI = "".join(chr(c) for c in [70])
-SIRYXB = 3
-SJMCBF = 42
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SKSOKP = 17
-SNQLNM = 83
-SOKPHU = 18
-SPBWJY = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-SPFTSI = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-SSAKQX = "".join(chr(c) for c in [72, 84, 82, 50])
-SSUHBV = 100
-SUHBVW = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-SXUJUT = 49
-TACCPQ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-TBJEUT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = 116
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-TOPHUG = 82
-TSIFJB = 33
-TTIDUB = 97
-TYEKCW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-TYIYWS = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-UBSSUH = 99
-UBYGDS = 104
-UGSELH = 4
-UGTYIY = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UHBVWV = 101
-UIKFWR = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-UJUTYE = 79
-UNBLKX = "".join(chr(c) for c in [72, 105])
-UNRJZT = 56
-UNXNKM = "".join(chr(c) for c in [65, 109, 80, 109])
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-USOOQN = 24
-USPBWJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UTOPHU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-UXFEFJ = 2
-UYNQJY = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-VDNQGV = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-VDQLAI = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-VUNXNK = 34
-VWVUBY = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-VYFCRT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 86
-WAONPY = 55
-WBSIRY = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-WDAFIK = 111
-WIVDNQ = 73
-WJYKLG = 29
-WMNZMJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WRKINE = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-WSKWIV = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WVUBYG = 103
-XBQFYL = 66
-XCHWDA = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 49]
-)
-XEKVKZ = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-XFEFJT = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-XLSXUJ = 48
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 51])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 53])
-XSJWMN = 59
-XTIACQ = 93
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XWAJVD = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-XYBQSN = 74
-YBQSNQ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-YEKCWA = 80
-YFCRTF = 4
-YGDSBD = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-YIYWSK = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-YKLGQP = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-YLIUXF = "".join(chr(c) for c in [79, 119, 110])
-YLJUIK = 70
-YNQJYM = 57
-YOUSPB = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-YXBQFY = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-YYLIUX = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 84
-ZMJIGY = 62
-ZUQEXL = 46
-AKQXPI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-]
-AOAWBS = [MJMAOA, JMAOAW, MAOAWB]
-BQSNQL = [LGQPLS, YBQSNQ]
-BSIRYX = [AWBSIR, WBSIRY]
-BYGDSB = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, XEKVKZ, EKVKZI, KVKZIL]
-CPQIPO = [JTACCP, TACCPQ, ACCPQI, CCPQIP]
-DNQGVU = [VLASSA, IVDNQG, VDNQGV]
-EUTOPH = [JVHFTH, IPOUYN, JEUTOP]
-FJBIAM = [SIFJBI, IFJBIA]
-FXQGLR = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-GYOUSP = [JVHFTH, IGYOUS, PIPIVL]
-IJUGSE = [LOIJUG, OIJUGS]
-JPUNRJ = [JUTYEK]
-JUIKFW = [LGQPLS, LJUIKF]
-JYKLGQ = [PIPIVL, IGYOUS]
-KJPUNR = [
-    BMJVHF,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    OOQNRS,
-    XUJUTY,
-]
-LHBQNR = [SELHBQ, ELHBQN]
-LIUXFE = [YYLIUX, YLIUXF]
-NBLKXS = [OUNBLK, UNBLKX]
-NEJNIB = [KINEJN, INEJNI]
-OUYNQJ = [IPOUYN, POUYNQ]
-PBWJYK = [USPBWJ, SPBWJY]
-PUNRJZ = []
-QPLSPF = [LGQPLS, GQPLSP]
-SKWIVD = [YWSKWI, WSKWIV]
-SOOQNR = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-UTYEKC = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    JUTYEK,
-]
-VKZILX = [NQLNMH, QLNMHX, LNMHXE, NMHXEK, MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-XNKMLO = [JVHFTH, UNXNKM, NXNKML]
-YMOUNB = [NQJYMO, QJYMOU, JYMOUN]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -675,267 +19,1068 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return UNRJZT
+        return 56
 
     @property
     def output_keys(self):
-        return KJPUNR
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, AKQXPI, None, None, QBMJVH
-            ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, AKQXPI, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, AKQXPI, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, AKQXPI, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                115,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadOptions1": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions1", 110, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 111, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 112, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, AKQXPI, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, FXQGLR, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, AKQXPI, None, None, QBMJVH
-            ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, AKQXPI, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, AKQXPI, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, AKQXPI, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, AKQXPI, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, AKQXPI, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, AKQXPI, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, SOOQNR, None, None, QBMJVH
-            ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, SOOQNR, None, None, QBMJVH
-            ),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, UTYEKC, None, None, None
-            ),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, None),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, IUXFEF, LIUXFE, None, UXFEFJ, QBMJVH
-            ),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, PYYLIU, UXFEFJ, NBLKXS, None, UXFEFJ, QBMJVH
-            ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoEnumStructAccessor(
-                self.struct, MJIGYO, JIGYOU, None, GYOUSP, None, None, QBMJVH
-            ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, PBWJYK, None, None, QBMJVH
-            ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoTempStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, JYKLGQ, None, None, QBMJVH
-            ),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, PYYLIU, SIRYXB, BSIRYX, None, UXFEFJ, QBMJVH
-            ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoTempStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoEnumStructAccessor(
-                self.struct, FYLJUI, YLJUIK, None, JUIKFW, None, None, QBMJVH
-            ),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, QBMJVH),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, NEJNIB, None, None, QBMJVH
-            ),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, BQSNQL, None, None, QBMJVH
-            ),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, VKZILX, None, None, QBMJVH
-            ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, VKZILX, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, VKZILX, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, None, VKZILX, None, None, QBMJVH
-            ),
-            AJVDQL: GeckoEnumStructAccessor(
-                self.struct, AJVDQL, JVDQLA, None, VKZILX, None, None, QBMJVH
-            ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, None, VKZILX, None, None, QBMJVH
-            ),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, LAIIDN, None, VKZILX, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, IIDNIB, None, VKZILX, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, VKZILX, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, VKZILX, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, VKZILX, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, VKZILX, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, VKZILX, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, VKZILX, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, VKZILX, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, BYGDSB, None, None, QBMJVH
-            ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, BYGDSB, None, None, QBMJVH
-            ),
-            DSBDJQ: GeckoEnumStructAccessor(
-                self.struct, DSBDJQ, SBDJQR, None, BYGDSB, None, None, QBMJVH
-            ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DJQRJJ, None, BYGDSB, None, None, QBMJVH
-            ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, BYGDSB, None, None, QBMJVH
-            ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, JJJVYF, None, BYGDSB, None, None, QBMJVH
-            ),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, QBMJVH),
-            VYFCRT: GeckoTimeStructAccessor(self.struct, VYFCRT, YFCRTF, QBMJVH),
-            FCRTFM: GeckoTimeStructAccessor(self.struct, FCRTFM, CRTFMN, QBMJVH),
-            RTFMNH: GeckoTimeStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoTimeStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoTimeStructAccessor(self.struct, NHTBJE, HTBJEU, QBMJVH),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, EUTOPH, None, None, QBMJVH
-            ),
-            UTOPHU: GeckoBoolStructAccessor(
-                self.struct, UTOPHU, TOPHUG, IUXFEF, QBMJVH
-            ),
-            OPHUGT: GeckoBoolStructAccessor(
-                self.struct, OPHUGT, PHUGTY, UXFEFJ, QBMJVH
-            ),
-            HUGTYI: GeckoBoolStructAccessor(
-                self.struct, HUGTYI, PHUGTY, IUXFEF, QBMJVH
-            ),
-            UGTYIY: GeckoBoolStructAccessor(
-                self.struct, UGTYIY, PHUGTY, GTYIYW, QBMJVH
-            ),
-            TYIYWS: GeckoBoolStructAccessor(
-                self.struct, TYIYWS, PHUGTY, SIRYXB, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, SKWIVD, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, DNQGVU, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, QBMJVH),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, XNKMLO, None, None, QBMJVH
-            ),
-            NKMLOI: GeckoWordStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, PYYLIU, GTYIYW, IJUGSE, None, UXFEFJ, QBMJVH
-            ),
-            JUGSEL: GeckoBoolStructAccessor(
-                self.struct, JUGSEL, PYYLIU, UGSELH, QBMJVH
-            ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, PYYLIU, HBQNRX, LHBQNR, None, UXFEFJ, QBMJVH
-            ),
-            BQNRXC: GeckoBoolStructAccessor(
-                self.struct, BQNRXC, PYYLIU, QNRXCH, QBMJVH
-            ),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, PYYLIU, RXCHWD, QBMJVH
-            ),
-            XCHWDA: GeckoByteStructAccessor(self.struct, XCHWDA, CHWDAF, QBMJVH),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, QBMJVH),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, QBMJVH),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-57.py
+++ b/src/geckolib/driver/packs/inyt-cfg-57.py
@@ -12,707 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-ACQFFT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-AFIKJP = 112
-AHEOCT = 38
-AIIDNI = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-AJVDQL = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-AMJMAO = 115
-AONPYY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AWBSIR = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BDJQRJ = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-BFEGZU = 44
-BIAMJM = 31
-BJEUTO = 71
-BLKXSJ = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 54])
-BSSUHB = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-BVWVUB = 102
-BWJYKL = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BXYBQS = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-CHWDAF = 110
-CQBMJV = 0
-CQFFTT = 95
-CRTFMN = 6
-CTHBSK = 40
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-CXQIEF = 15
-DAFIKJ = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 51]
-)
-DJQRJJ = 107
-DNIBXT = 91
-DQLAII = 88
-DSBDJQ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-DUBSSU = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-EFXQGL = 26
-EGZUQE = 45
-EJNIBX = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-EKCWAO = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-EKVKZI = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-ELHBQN = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-EOCTHB = 39
-EXLSXU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-FCRTFM = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-FEFJTA = 118
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-FFTTID = 96
-FIKJPU = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FJTACC = 32
-FMNHTB = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-FWRKIN = 114
-FYLJUI = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-GDSBDJ = 105
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-GQPLSP = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-GSELHB = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-GTYIYW = 1
-GVUNXN = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-HBQNRX = 5
-HBSKSO = 50
-HBVWVU = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 23
-HTBJEU = 10
-HUGTYI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-HUOJRJ = 20
-HWDAFI = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 50]
-)
-HXEKVK = "".join(chr(c) for c in [70, 50, 51])
-IACQFF = 94
-IAMJMA = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-IBXTIA = 92
-IBXYBQ = 53
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 52])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IDUBSS = 98
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-IFJBIA = "".join(chr(c) for c in [67])
-IGYOUS = "".join(chr(c) for c in [80, 49])
-IIDNIB = 90
-IKFWRK = 77
-IKJPUN = 113
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [67, 69])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-IRYXBQ = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-IUSOOQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-IUXFEF = 0
-IVDNQG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 76
-JBIAMJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-JEUTOP = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-JIGYOU = 78
-JJJVYF = 109
-JJVYFC = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JMAOAW = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-JNIBXY = 52
-JPUNRJ = 119
-JQRJJJ = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JTACCP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JUGSEL = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-JUTYEK = "".join(chr(c) for c in [76, 73])
-JVDQLA = 87
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = 3
-JWMNZM = 60
-JYMOUN = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-KCWAON = 54
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-KINEJN = "".join(chr(c) for c in [85, 76])
-KJPUNR = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-KLGQPL = 30
-KMLOIJ = 64
-KPHUOJ = 19
-KQXPIC = "".join(chr(c) for c in [79, 117, 116, 50])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 55])
-KVKZIL = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-KWIVDN = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-KXSJWM = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-KZILXW = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-LAIIDN = 89
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-LJUIKF = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-LKXSJW = 58
-LNMHXE = "".join(chr(c) for c in [70, 51])
-LOIJUG = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-LRAHEO = 37
-LSPFTS = 63
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-LXWAJV = 85
-MAOAWB = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-MCBFEG = 43
-MHXEKV = "".join(chr(c) for c in [70, 50, 50])
-MJIGYO = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-MJMAOA = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-MJVHFT = 12
-MLOIJU = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-MNHTBJ = 8
-MNZMJI = 61
-MOUNBL = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-NHTBJE = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-NIBXYB = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-NKMLOI = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-NMHXEK = "".join(chr(c) for c in [70, 50, 49])
-NPYYLI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-NQGVUN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-NQJYMO = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-NQLNMH = "".join(chr(c) for c in [70, 49])
-NRSJMC = 41
-NRXCHW = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-NXNKML = "".join(chr(c) for c in [50, 52, 104])
-NZMJIG = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-OAWBSI = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-OIJUGS = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-OJRJHI = 21
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 56])
-ONPYYL = 56
-OOQNRS = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-OPHUGT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-OQNRSJ = 25
-OUNBLK = "".join(chr(c) for c in [76, 111])
-OUSPBW = 28
-PFTSIF = 1
-PHUGTY = 72
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 57])
-PICXQI = 14
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-POUYNQ = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-PQIPOU = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-PYYLIU = 81
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 47
-QFFTTI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-QFYLJU = 68
-QGLRAH = 36
-QGVUNX = 75
-QIEFXQ = 16
-QIPOUY = 27
-QJYMOU = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-QLAIID = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QLNMHX = "".join(chr(c) for c in [70, 50])
-QNRSJM = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-QNRXCH = 6
-QRJJJV = 108
-QSNQLN = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-QXPICX = 13
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-RJHIUS = 22
-RJJJVY = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-RJZTAT = 57
-RKINEJ = 51
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-RXCHWD = 7
-RYXBQF = 35
-SAKQXP = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-SBDJQR = 106
-SELHBQ = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-SIFJBI = "".join(chr(c) for c in [70])
-SIRYXB = 3
-SJMCBF = 42
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SKSOKP = 17
-SNQLNM = 83
-SOKPHU = 18
-SPBWJY = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-SPFTSI = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-SSAKQX = "".join(chr(c) for c in [72, 84, 82, 50])
-SSUHBV = 100
-SUHBVW = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-SXUJUT = 49
-TACCPQ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-TBJEUT = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = 116
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-TOPHUG = 82
-TSIFJB = 33
-TTIDUB = 97
-TYEKCW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-TYIYWS = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-UBSSUH = 99
-UBYGDS = 104
-UGSELH = 4
-UGTYIY = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UHBVWV = 101
-UIKFWR = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-UJUTYE = 79
-UNBLKX = "".join(chr(c) for c in [72, 105])
-UNXNKM = "".join(chr(c) for c in [65, 109, 80, 109])
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-USOOQN = 24
-USPBWJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UTOPHU = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-UXFEFJ = 2
-UYNQJY = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-VDNQGV = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-VDQLAI = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VLASSA = "".join(chr(c) for c in [])
-VUBYGD = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-VUNXNK = 34
-VWVUBY = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-VYFCRT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = 86
-WAONPY = 55
-WBSIRY = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-WDAFIK = 111
-WIVDNQ = 73
-WJYKLG = 29
-WMNZMJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WRKINE = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-WSKWIV = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-WVUBYG = 103
-XBQFYL = 66
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-XFEFJT = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-XLSXUJ = 48
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 51])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 53])
-XSJWMN = 59
-XTIACQ = 93
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-XWAJVD = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-XYBQSN = 74
-YBQSNQ = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-YEKCWA = 80
-YFCRTF = 4
-YGDSBD = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-YIYWSK = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-YKLGQP = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-YLIUXF = "".join(chr(c) for c in [79, 119, 110])
-YLJUIK = 70
-YNQJYM = 57
-YOUSPB = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-YXBQFY = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-YYLIUX = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZILXWA = 84
-ZMJIGY = 62
-ZUQEXL = 46
-AKQXPI = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-]
-AOAWBS = [MJMAOA, JMAOAW, MAOAWB]
-BQSNQL = [LGQPLS, YBQSNQ]
-BSIRYX = [AWBSIR, WBSIRY]
-BYGDSB = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, XEKVKZ, EKVKZI, KVKZIL]
-CPQIPO = [JTACCP, TACCPQ, ACCPQI, CCPQIP]
-DNQGVU = [VLASSA, IVDNQG, VDNQGV]
-EUTOPH = [JVHFTH, IPOUYN, JEUTOP]
-FJBIAM = [SIFJBI, IFJBIA]
-FXQGLR = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-GYOUSP = [JVHFTH, IGYOUS, PIPIVL]
-IJUGSE = [LOIJUG, OIJUGS]
-JUIKFW = [LGQPLS, LJUIKF]
-JYKLGQ = [PIPIVL, IGYOUS]
-LHBQNR = [SELHBQ, ELHBQN]
-LIUXFE = [YYLIUX, YLIUXF]
-NBLKXS = [OUNBLK, UNBLKX]
-NEJNIB = [KINEJN, INEJNI]
-NRJZTA = []
-OUYNQJ = [IPOUYN, POUYNQ]
-PBWJYK = [USPBWJ, SPBWJY]
-PUNRJZ = [
-    BMJVHF,
-    KQXPIC,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    OOQNRS,
-    XUJUTY,
-]
-QPLSPF = [LGQPLS, GQPLSP]
-SKWIVD = [YWSKWI, WSKWIV]
-SOOQNR = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-UNRJZT = [JUTYEK]
-UTYEKC = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    JUTYEK,
-]
-VKZILX = [NQLNMH, QLNMHX, LNMHXE, NMHXEK, MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-XNKMLO = [JVHFTH, UNXNKM, NXNKML]
-YMOUNB = [NQJYMO, QJYMOU, JYMOUN]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -720,272 +19,1071 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return RJZTAT
+        return 57
 
     @property
     def output_keys(self):
-        return PUNRJZ
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, AKQXPI, None, None, QBMJVH
-            ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, AKQXPI, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, AKQXPI, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, AKQXPI, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, AKQXPI, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, FXQGLR, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, AKQXPI, None, None, QBMJVH
-            ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, AKQXPI, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, AKQXPI, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, AKQXPI, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, AKQXPI, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, AKQXPI, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, AKQXPI, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, SOOQNR, None, None, QBMJVH
-            ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, OQNRSJ, None, SOOQNR, None, None, QBMJVH
-            ),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, QBMJVH),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, UTYEKC, None, None, None
-            ),
-            TYEKCW: GeckoByteStructAccessor(self.struct, TYEKCW, YEKCWA, None),
-            EKCWAO: GeckoByteStructAccessor(self.struct, EKCWAO, KCWAON, QBMJVH),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, QBMJVH),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, IUXFEF, LIUXFE, None, UXFEFJ, QBMJVH
-            ),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, None, CPQIPO, None, None, QBMJVH
-            ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, PYYLIU, UXFEFJ, NBLKXS, None, UXFEFJ, QBMJVH
-            ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, QBMJVH),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoEnumStructAccessor(
-                self.struct, MJIGYO, JIGYOU, None, GYOUSP, None, None, QBMJVH
-            ),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, None, PBWJYK, None, None, QBMJVH
-            ),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoByteStructAccessor(self.struct, PLSPFT, LSPFTS, QBMJVH),
-            SPFTSI: GeckoTempStructAccessor(self.struct, SPFTSI, PFTSIF, QBMJVH),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, JYKLGQ, None, None, QBMJVH
-            ),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, PYYLIU, SIRYXB, BSIRYX, None, UXFEFJ, QBMJVH
-            ),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoTempStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoEnumStructAccessor(
-                self.struct, FYLJUI, YLJUIK, None, JUIKFW, None, None, QBMJVH
-            ),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, QBMJVH),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, NEJNIB, None, None, QBMJVH
-            ),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, QBMJVH),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, BQSNQL, None, None, QBMJVH
-            ),
-            QSNQLN: GeckoEnumStructAccessor(
-                self.struct, QSNQLN, SNQLNM, None, VKZILX, None, None, QBMJVH
-            ),
-            KZILXW: GeckoEnumStructAccessor(
-                self.struct, KZILXW, ZILXWA, None, VKZILX, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, VKZILX, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, WAJVDQ, None, VKZILX, None, None, QBMJVH
-            ),
-            AJVDQL: GeckoEnumStructAccessor(
-                self.struct, AJVDQL, JVDQLA, None, VKZILX, None, None, QBMJVH
-            ),
-            VDQLAI: GeckoEnumStructAccessor(
-                self.struct, VDQLAI, DQLAII, None, VKZILX, None, None, QBMJVH
-            ),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, LAIIDN, None, VKZILX, None, None, QBMJVH
-            ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, IIDNIB, None, VKZILX, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, VKZILX, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, VKZILX, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, VKZILX, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, VKZILX, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, VKZILX, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, VKZILX, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, VKZILX, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, QBMJVH),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, QBMJVH),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, BYGDSB, None, None, QBMJVH
-            ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, BYGDSB, None, None, QBMJVH
-            ),
-            DSBDJQ: GeckoEnumStructAccessor(
-                self.struct, DSBDJQ, SBDJQR, None, BYGDSB, None, None, QBMJVH
-            ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, DJQRJJ, None, BYGDSB, None, None, QBMJVH
-            ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, BYGDSB, None, None, QBMJVH
-            ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, JJJVYF, None, BYGDSB, None, None, QBMJVH
-            ),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, QBMJVH),
-            VYFCRT: GeckoTimeStructAccessor(self.struct, VYFCRT, YFCRTF, QBMJVH),
-            FCRTFM: GeckoTimeStructAccessor(self.struct, FCRTFM, CRTFMN, QBMJVH),
-            RTFMNH: GeckoTimeStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoTimeStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoTimeStructAccessor(self.struct, NHTBJE, HTBJEU, QBMJVH),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, EUTOPH, None, None, QBMJVH
-            ),
-            UTOPHU: GeckoBoolStructAccessor(
-                self.struct, UTOPHU, TOPHUG, IUXFEF, QBMJVH
-            ),
-            OPHUGT: GeckoBoolStructAccessor(
-                self.struct, OPHUGT, PHUGTY, UXFEFJ, QBMJVH
-            ),
-            HUGTYI: GeckoBoolStructAccessor(
-                self.struct, HUGTYI, PHUGTY, IUXFEF, QBMJVH
-            ),
-            UGTYIY: GeckoBoolStructAccessor(
-                self.struct, UGTYIY, PHUGTY, GTYIYW, QBMJVH
-            ),
-            TYIYWS: GeckoBoolStructAccessor(
-                self.struct, TYIYWS, PHUGTY, SIRYXB, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, SKWIVD, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, DNQGVU, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, QBMJVH),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, XNKMLO, None, None, QBMJVH
-            ),
-            NKMLOI: GeckoWordStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, PYYLIU, GTYIYW, IJUGSE, None, UXFEFJ, QBMJVH
-            ),
-            JUGSEL: GeckoBoolStructAccessor(
-                self.struct, JUGSEL, PYYLIU, UGSELH, QBMJVH
-            ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, PYYLIU, HBQNRX, LHBQNR, None, UXFEFJ, QBMJVH
-            ),
-            BQNRXC: GeckoBoolStructAccessor(
-                self.struct, BQNRXC, PYYLIU, QNRXCH, QBMJVH
-            ),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, PYYLIU, RXCHWD, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, IUXFEF, QBMJVH
-            ),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, QBMJVH),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, QBMJVH),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoBoolStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, IUXFEF, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                115,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "KeypadOptions2": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions2", 111, "ALL"
+            ),
+            "KeypadOptions3": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions3", 112, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-58.py
+++ b/src/geckolib/driver/packs/inyt-cfg-58.py
@@ -12,929 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 32
-ACMCVD = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-ACQFFT = 93
-AFIKJP = 110
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-AIIDNI = 88
-AJVDQL = 85
-AKQXPI = "".join(chr(c) for c in [65, 85, 88])
-AKSTSE = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-AMJMAO = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-AOAWBS = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-AONPYY = 55
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [67, 89, 65, 78])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-AZMKQT = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-BDJQRJ = 105
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-BHZVOA = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-BIAMJM = "".join(chr(c) for c in [67])
-BJEUTO = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-BLKXSJ = "".join(chr(c) for c in [76, 111])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 35
-BQNRXC = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-BQSNQL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BSIRYX = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-BSKSOK = 50
-BSSUHB = 98
-BVWVUB = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-BWJYKL = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-BXIBHZ = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-BXTIAC = 91
-BXYBQS = 52
-BYGDSB = 103
-CBFEGZ = 43
-CCPQIP = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-CGETIX = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-CHWDAF = 6
-CMCVDS = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-CPQIPO = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-CRTFMN = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-CVDSSR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 54
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 52])
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DGKEAK = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-DJQRJJ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-DKHTZB = 119
-DNIBXT = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-DQLAII = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-DUBSSU = 97
-EAKSTS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFJTAC = 118
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-EJNIBX = "".join(chr(c) for c in [85, 76])
-EKCWAO = 80
-EKVKZI = "".join(chr(c) for c in [70, 50, 50])
-EMCGET = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-ETIXQV = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-EUTOPH = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-EXLSXU = 47
-FCRTFM = 3
-FEFJTA = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-FEGZUQ = 44
-FFTTID = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-FJBIAM = 33
-FJTACC = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-FMNHTB = 6
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 63
-FTTIDU = 95
-FWRKIN = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-FXQGLR = 26
-FYLJUI = 66
-FZDGKE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-GDSBDJ = 104
-GETIXQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-GKEAKS = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-GLRAHE = 36
-GQPLSP = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-GSELHB = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-GTYIYW = 72
-GVUNXN = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-GYOUSP = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-GZUQEX = 45
-HBQNRX = 4
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-HBVWVU = 100
-HBXIBH = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 38
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-HTBJEU = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-HUGTYI = 82
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 57])
-HWDAFI = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-HXEKVK = "".join(chr(c) for c in [70, 51])
-HZVOAC = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-IACQFF = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-IBHZVO = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-IBXTIA = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IBXYBQ = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-ICXQIE = 14
-IDNIBX = 89
-IDUBSS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IEFXQG = 16
-IFJBIA = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-IGYOUS = 62
-IHBXIB = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-IIDNIB = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-IJUGSE = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-IKFWRK = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-IKJPUN = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-INEJNI = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IRYXBQ = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-IUSOOQ = 23
-IVDNQG = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IYWSKW = 1
-JBIAMJ = "".join(chr(c) for c in [70])
-JEUTOP = 10
-JHIUSO = 22
-JIGYOU = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JJJVYF = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-JJVYFC = 108
-JMAOAW = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-JMCBFE = 42
-JNIBXY = "".join(chr(c) for c in [67, 69])
-JQRJJJ = 106
-JRJHIU = 21
-JTACCP = 120
-JUGSEL = 64
-JUIKFW = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-JUTYEK = 79
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JWMNZM = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-JYMOUN = 57
-JZTATD = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-KCWAON = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KEAKST = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-KINEJN = 114
-KJPUNR = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-KLGQPL = 29
-KMLOIJ = 34
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 56])
-KQTDKH = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-KSOKPH = 17
-KSTSEM = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-KVKZIL = "".join(chr(c) for c in [70, 50, 51])
-KWIVDN = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-KZILXW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LAIIDN = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LHBQNR = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-LIUXFE = "".join(chr(c) for c in [79, 119, 110])
-LJUIKF = 68
-LKXSJW = "".join(chr(c) for c in [72, 105])
-LNMHXE = 83
-LOIJUG = "".join(chr(c) for c in [50, 52, 104])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-LSPFTS = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-LSXUJU = 48
-LXWAJV = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-MAOAWB = 115
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-MCGETI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-MCVDSS = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-MFZDGK = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-MHXEKV = "".join(chr(c) for c in [70, 50])
-MJIGYO = 61
-MJMAOA = 31
-MJVHFT = 12
-MLOIJU = "".join(chr(c) for c in [65, 109, 80, 109])
-MNHTBJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-MOUNBL = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NBLKXS = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-NEJNIB = 51
-NHTBJE = 116
-NIBXTI = 90
-NKMLOI = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-NMHXEK = "".join(chr(c) for c in [70, 49])
-NPYYLI = 56
-NQGVUN = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-NQTMFZ = 111
-NRJZTA = "".join(chr(c) for c in [82, 69, 68])
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-NRXCHW = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NXNKML = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-NZMJIG = 60
-OACMCV = "".join(chr(c) for c in [73, 100, 111, 108])
-OAWBSI = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-OCTHBS = 39
-OIHBXI = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-OKPHUO = 18
-ONPYYL = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-OQNRSJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-OUNBLK = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-OUSPBW = "".join(chr(c) for c in [80, 49])
-OUYNQJ = 27
-PBWJYK = 28
-PFTSIF = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-PHUGTY = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-PHUOJR = 19
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 51])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-POUYNQ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-PQIPOU = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PUNRJZ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-PYYLIU = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QFFTTI = 94
-QFYLJU = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-QGVUNX = 73
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-QIPOUY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-QJYMOU = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-QLAIID = 87
-QLNMHX = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-QNRSJM = 25
-QNRXCH = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-QPLSPF = 30
-QRJJJV = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-QSNQLN = 74
-QTDKHT = 113
-QTMFZD = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-QVXOIH = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 50])
-RAHEOC = 37
-RAZMKQ = 112
-RJHIUS = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-RJJJVY = 107
-RJZTAT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-RKINEJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-RSJMCB = 41
-RTFMNH = 4
-RURAZM = "".join(chr(c) for c in [65, 108, 108])
-SAKQXP = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-SBDJQR = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-SELHBQ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-SEMCGE = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SIFJBI = 1
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-SJWMNZ = 58
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 54])
-SKWIVD = 5
-SNQLNM = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 55])
-SOOQNR = 24
-SPBWJY = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-SRURAZ = "".join(
-    chr(c)
-    for c in [
-        67,
-        102,
-        103,
-        67,
-        104,
-        97,
-        110,
-        103,
-        101,
-        67,
-        111,
-        100,
-        101,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-SSAKQX = "".join(chr(c) for c in [72, 84, 82, 50])
-SSRURA = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SSUHBV = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-STSEMC = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-SUHBVW = 99
-SXUJUT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-TACCPQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-TATDZX = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-TBJEUT = 8
-TDKHTZ = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-TDZXNQ = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TFMNHT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-THBSKS = 40
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 92
-TIDUBS = 96
-TIXQVX = "".join(chr(c) for c in [76, 65])
-TMFZDG = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-TOPHUG = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-TSEMCG = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-TSIFJB = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-TTIDUB = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-TYIYWS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-UBSSUH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-UBYGDS = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-UGSELH = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UGTYIY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-UHBVWV = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UIKFWR = 70
-UJUTYE = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-UNRJZT = "".join(chr(c) for c in [79, 70, 70])
-UOJRJH = 20
-UQEXLS = 46
-URAZMK = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-USOOQN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-UTOPHU = 71
-UTYEKC = "".join(chr(c) for c in [76, 73])
-UXFEFJ = 0
-UYNQJY = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-VDNQGV = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-VDQLAI = 86
-VDSSRU = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-VUBYGD = 102
-VUNXNK = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-VWVUBY = 101
-VXOIHB = "".join(chr(c) for c in [80, 68, 67])
-VYFCRT = 109
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-WAONPY = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-WDAFIK = 7
-WIVDNQ = 76
-WJYKLG = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-WMNZMJ = 59
-WRKINE = 77
-WSKWIV = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-WVUBYG = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-XBQFYL = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-XCHWDA = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-XEKVKZ = "".join(chr(c) for c in [70, 50, 49])
-XFEFJT = 2
-XIBHZV = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-XLSXUJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-XNKMLO = 75
-XNQTMF = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-XOIHBX = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-XPICXQ = 13
-XQIEFX = 15
-XQVXOI = "".join(chr(c) for c in [77, 65, 65, 88])
-XSJWMN = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-XTIACQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-XUJUTY = 49
-XWAJVD = 84
-XYBQSN = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-YBQSNQ = 53
-YEKCWA = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-YFCRTF = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-YGDSBD = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-YIYWSK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-YKLGQP = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-YLIUXF = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-YLJUIK = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-YMOUNB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-YNQJYM = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-YOUSPB = 78
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-YXBQFY = 3
-YYLIUX = 81
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = 58
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [65, 108, 112, 115])
-ZILXWA = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-ZTATDZ = "".join(chr(c) for c in [66, 76, 85, 69])
-ZUQEXL = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-ZVOACM = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-ZXNQTM = 8
-DNQGVU = [IVDNQG, VDNQGV]
-DSBDJQ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VKZILX, KZILXW, ZILXWA]
-DSSRUR = [
-    QTMFZD,
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    KSTSEM,
-    STSEMC,
-    TSEMCG,
-    SEMCGE,
-    EMCGET,
-    MCGETI,
-    CGETIX,
-    GETIXQ,
-    ETIXQV,
-    TIXQVX,
-    IXQVXO,
-    XQVXOI,
-    QVXOIH,
-    VXOIHB,
-    XOIHBX,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-    BXIBHZ,
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-]
-DZXNQT = [UNRJZT, NRJZTA, RJZTAT, JZTATD, ZTATDZ, TATDZX, ATDZXN, TDZXNQ]
-ELHBQN = [GSELHB, SELHBQ]
-HTZBBE = [UTYEKC]
-IAMJMA = [JBIAMJ, BIAMJM]
-ILXWAJ = [NMHXEK, MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL, VKZILX, KZILXW, ZILXWA]
-IPOUYN = [CCPQIP, CPQIPO, PQIPOU, QIPOUY]
-IUXFEF = [YLIUXF, LIUXFE]
-JPUNRJ = [IKJPUN, KJPUNR]
-JYKLGQ = [BWJYKL, WJYKLG]
-KFWRKI = [PLSPFT, IKFWRK]
-KHTZBB = [
-    BMJVHF,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OQNRSJ,
-    UJUTYE,
-]
-KQXPIC = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-]
-KXSJWM = [BLKXSJ, LKXSJW]
-LGQPLS = [PIPIVL, OUSPBW]
-MKQTDK = [AZMKQT, ZMKQTD, VLASSA, VLASSA]
-NIBXYB = [EJNIBX, JNIBXY]
-NQJYMO = [UYNQJY, YNQJYM]
-NQLNMH = [PLSPFT, SNQLNM]
-OIJUGS = [JVHFTH, MLOIJU, LOIJUG]
-OOQNRS = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-OPHUGT = [JVHFTH, UYNQJY, TOPHUG]
-RXCHWD = [QNRXCH, NRXCHW]
-RYXBQF = [SIRYXB, IRYXBQ]
-SPFTSI = [PLSPFT, LSPFTS]
-TYEKCW = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    UTYEKC,
-]
-TZBBEK = []
-UNBLKX = [YMOUNB, MOUNBL, OUNBLK]
-UNXNKM = [VLASSA, GVUNXN, VUNXNK]
-USPBWJ = [JVHFTH, OUSPBW, PIPIVL]
-WBSIRY = [AOAWBS, OAWBSI, AWBSIR]
-XQGLRA = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -942,289 +19,1119 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return ZBBEKB
+        return 58
 
     @property
     def output_keys(self):
-        return KHTZBB
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, KQXPIC, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, KQXPIC, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, KQXPIC, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, KQXPIC, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, KQXPIC, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XQGLRA, None, None, QBMJVH
-            ),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, KQXPIC, None, None, QBMJVH
-            ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, KQXPIC, None, None, QBMJVH
-            ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, KQXPIC, None, None, QBMJVH
-            ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, KQXPIC, None, None, QBMJVH
-            ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, KQXPIC, None, None, QBMJVH
-            ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, KQXPIC, None, None, QBMJVH
-            ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, IUSOOQ, None, KQXPIC, None, None, QBMJVH
-            ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, SOOQNR, None, OOQNRS, None, None, QBMJVH
-            ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, None, OOQNRS, None, None, QBMJVH
-            ),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, QBMJVH),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, TYEKCW, None, None, None
-            ),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, None),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, QBMJVH),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, QBMJVH),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, YYLIUX, UXFEFJ, IUXFEF, None, XFEFJT, QBMJVH
-            ),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, IPOUYN, None, None, QBMJVH
-            ),
-            POUYNQ: GeckoEnumStructAccessor(
-                self.struct, POUYNQ, OUYNQJ, None, NQJYMO, None, None, QBMJVH
-            ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, UNBLKX, None, None, QBMJVH
-            ),
-            NBLKXS: GeckoEnumStructAccessor(
-                self.struct, NBLKXS, YYLIUX, XFEFJT, KXSJWM, None, XFEFJT, QBMJVH
-            ),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoEnumStructAccessor(
-                self.struct, GYOUSP, YOUSPB, None, USPBWJ, None, None, QBMJVH
-            ),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, LGQPLS, None, None, QBMJVH
-            ),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoByteStructAccessor(self.struct, PFTSIF, FTSIFJ, QBMJVH),
-            TSIFJB: GeckoTempStructAccessor(self.struct, TSIFJB, SIFJBI, QBMJVH),
-            IFJBIA: GeckoEnumStructAccessor(
-                self.struct, IFJBIA, FJBIAM, None, IAMJMA, None, None, QBMJVH
-            ),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, LGQPLS, None, None, QBMJVH
-            ),
-            JMAOAW: GeckoEnumStructAccessor(
-                self.struct, JMAOAW, MAOAWB, None, WBSIRY, None, None, QBMJVH
-            ),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, YYLIUX, YXBQFY, RYXBQF, None, XFEFJT, QBMJVH
-            ),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoTempStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoTempStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, QBMJVH),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, QBMJVH),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, NEJNIB, None, NIBXYB, None, None, QBMJVH
-            ),
-            IBXYBQ: GeckoByteStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, ILXWAJ, None, None, QBMJVH
-            ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, ILXWAJ, None, None, QBMJVH
-            ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, ILXWAJ, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, ILXWAJ, None, None, QBMJVH
-            ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, ILXWAJ, None, None, QBMJVH
-            ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, BXTIAC, None, ILXWAJ, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, ILXWAJ, None, None, QBMJVH
-            ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            FFTTID: GeckoEnumStructAccessor(
-                self.struct, FFTTID, FTTIDU, None, ILXWAJ, None, None, QBMJVH
-            ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, TIDUBS, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IDUBSS: GeckoEnumStructAccessor(
-                self.struct, IDUBSS, DUBSSU, None, ILXWAJ, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, DSBDJQ, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, DSBDJQ, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, DSBDJQ, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoTimeStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoTimeStructAccessor(self.struct, MNHTBJ, NHTBJE, QBMJVH),
-            HTBJEU: GeckoTimeStructAccessor(self.struct, HTBJEU, TBJEUT, QBMJVH),
-            BJEUTO: GeckoTimeStructAccessor(self.struct, BJEUTO, JEUTOP, QBMJVH),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, OPHUGT, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoBoolStructAccessor(
-                self.struct, PHUGTY, HUGTYI, UXFEFJ, QBMJVH
-            ),
-            UGTYIY: GeckoBoolStructAccessor(
-                self.struct, UGTYIY, GTYIYW, XFEFJT, QBMJVH
-            ),
-            TYIYWS: GeckoBoolStructAccessor(
-                self.struct, TYIYWS, GTYIYW, UXFEFJ, QBMJVH
-            ),
-            YIYWSK: GeckoBoolStructAccessor(
-                self.struct, YIYWSK, GTYIYW, IYWSKW, QBMJVH
-            ),
-            YWSKWI: GeckoBoolStructAccessor(
-                self.struct, YWSKWI, GTYIYW, YXBQFY, QBMJVH
-            ),
-            WSKWIV: GeckoBoolStructAccessor(
-                self.struct, WSKWIV, GTYIYW, SKWIVD, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, DNQGVU, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, UNXNKM, None, None, QBMJVH
-            ),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, QBMJVH),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoWordStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, YYLIUX, IYWSKW, ELHBQN, None, XFEFJT, QBMJVH
-            ),
-            LHBQNR: GeckoBoolStructAccessor(
-                self.struct, LHBQNR, YYLIUX, HBQNRX, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, YYLIUX, SKWIVD, RXCHWD, None, XFEFJT, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, YYLIUX, CHWDAF, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, YYLIUX, WDAFIK, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, UXFEFJ, QBMJVH
-            ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, AFIKJP, WDAFIK, JPUNRJ, None, XFEFJT, QBMJVH
-            ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, AFIKJP, HBQNRX, DZXNQT, None, ZXNQTM, QBMJVH
-            ),
-            SSRURA: GeckoBoolStructAccessor(
-                self.struct, SSRURA, AFIKJP, IYWSKW, QBMJVH
-            ),
-            SRURAZ: GeckoBoolStructAccessor(
-                self.struct, SRURAZ, AFIKJP, XFEFJT, RURAZM
-            ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, RAZMKQ, XFEFJT, MKQTDK, None, HBQNRX, QBMJVH
-            ),
-            KQTDKH: GeckoByteStructAccessor(self.struct, KQTDKH, QTDKHT, QBMJVH),
-            TDKHTZ: GeckoBoolStructAccessor(
-                self.struct, TDKHTZ, DKHTZB, UXFEFJ, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                115,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "CfgChangeCodeEnable": GeckoBoolStructAccessor(
+                self.struct, "CfgChangeCodeEnable", 110, 2, "All"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-60.py
+++ b/src/geckolib/driver/packs/inyt-cfg-60.py
@@ -12,1041 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 120
-ACMCVD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-ACQFFT = 93
-AFIKJP = 110
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-AIIDNI = 88
-AIVEMV = 60
-AJVDQL = 85
-AKQXPI = "".join(chr(c) for c in [65, 85, 88])
-AKSTSE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-AMJMAO = 33
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-AONPYY = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [66, 76, 85, 69])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-BBEKBD = 121
-BDJQRJ = 105
-BEKBDF = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-BHZVOA = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-BIAMJM = 1
-BJEUTO = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-BJLOIN = 127
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 66
-BQNRXC = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-BQSNQL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-BSKSOK = 50
-BSSUHB = 98
-BVWVUB = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-BWJYKL = "".join(chr(c) for c in [80, 49])
-BXIBHZ = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-BXTIAC = 91
-BXYBQS = 53
-BYGDSB = 103
-CBFEGZ = 43
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CGETIX = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-CHWDAF = 6
-CMCVDS = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-CPQIPO = 32
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-CRTFMN = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-CVDSSR = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 52])
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DDPMXF = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-DFSROG = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-DGKEAK = 111
-DJQRJJ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-DNIBXT = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-DNQGVU = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-DPMXFU = 125
-DQLAII = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-DSSRUR = "".join(chr(c) for c in [73, 100, 111, 108])
-DUBSSU = 97
-DZXNQT = "".join(chr(c) for c in [67, 89, 65, 78])
-EAKSTS = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-EFJTAC = 0
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-EKBDFS = 123
-EKCWAO = "".join(chr(c) for c in [76, 73])
-EKVKZI = "".join(chr(c) for c in [70, 50, 50])
-ELHBQN = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-ELWUEU = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-EMCGET = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-ETDRXA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-ETIXQV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-EUHNNX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-EUTOPH = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-EXLSXU = 47
-EZFETD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-FCRTFM = 3
-FEGZUQ = 44
-FETDRX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-FFTTID = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-FIKJPU = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-FJBIAM = 63
-FJTACC = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-FMNHTB = 6
-FSROGM = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-FTTIDU = 95
-FUBJLO = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-FWRKIN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-FXQGLR = 26
-FYLJUI = 68
-GDSBDJ = 104
-GETIXQ = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-GKEAKS = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-GLRAHE = 36
-GMDDPM = 124
-GSELHB = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-GTYIYW = 72
-GVUNXN = 73
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-GZUQEX = 45
-HBQNRX = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-HBVWVU = 100
-HBXIBH = "".join(chr(c) for c in [77, 65, 65, 88])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 38
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-HNNXWE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-HTBJEU = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-HTZBBE = 113
-HUGTYI = 82
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 57])
-HWDAFI = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-HXEKVK = "".join(chr(c) for c in [70, 51])
-HZVOAC = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-IACQFF = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-IAMJMA = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-IBHZVO = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-IBXTIA = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IBXYBQ = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-ICXQIE = 14
-IDNIBX = 89
-IDUBSS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IEFXQG = 16
-IFJBIA = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-IGYOUS = 60
-IHBXIB = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IIDNIB = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-IKFWRK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IKJPUN = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-INEJNI = "".join(chr(c) for c in [85, 76])
-INELWU = "".join(chr(c) for c in [52])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-IRYXBQ = 3
-IUSOOQ = 23
-IUXFEF = 81
-IVDNQG = 76
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-IYWSKW = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-JBIAMJ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-JEUTOP = 10
-JHIUSO = 22
-JIGYOU = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-JJJVYF = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-JJVYFC = 108
-JLOINE = "".join(chr(c) for c in [49])
-JMAOAW = "".join(chr(c) for c in [67])
-JMCBFE = 42
-JNIBXY = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-JPUNRJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JQRJJJ = 106
-JRJHIU = 21
-JTACCP = 118
-JUGSEL = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-JUIKFW = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-JUTYEK = 119
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JWMNZM = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-JYKLGQ = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-JZTATD = "".join(chr(c) for c in [82, 69, 68])
-KBDFSR = "".join(chr(c) for c in [82, 71, 66])
-KEAKST = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-KFWRKI = 77
-KHTZBB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-KINEJN = 51
-KJPUNR = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-KLGQPL = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-KMLOIJ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 56])
-KQTDKH = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-KSOKPH = 17
-KSTSEM = "".join(chr(c) for c in [65, 108, 112, 115])
-KVKZIL = "".join(chr(c) for c in [70, 50, 51])
-KWIVDN = 5
-KXSJWM = "".join(chr(c) for c in [76, 111])
-KZILXW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LAIIDN = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-LIUXFE = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-LJUIKF = 70
-LKXSJW = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LNMHXE = 83
-LOIJUG = "".join(chr(c) for c in [65, 109, 80, 109])
-LOINEL = "".join(chr(c) for c in [50])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-LSXUJU = 48
-LWUEUH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-LXWAJV = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-MCGETI = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-MCVDSS = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-MDDPMX = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-MFZDGK = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-MHXEKV = "".join(chr(c) for c in [70, 50])
-MJIGYO = 59
-MJMAOA = "".join(chr(c) for c in [70])
-MJVHFT = 12
-MKQTDK = 112
-MLOIJU = 34
-MNHTBJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-MNZMJI = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-MOUNBL = 57
-MXFUBJ = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-NBLKXS = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-NEJNIB = "".join(chr(c) for c in [67, 69])
-NHTBJE = 116
-NIBXTI = 90
-NIBXYB = 52
-NKMLOI = 75
-NMHXEK = "".join(chr(c) for c in [70, 49])
-NNXWEE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-NPYYLI = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-NQJYMO = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-NQTMFZ = 8
-NRJZTA = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-NRXCHW = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NXWEEZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-NZMJIG = 58
-OACMCV = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-OAWBSI = 31
-OCTHBS = 39
-OGMDDP = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-OIHBXI = "".join(chr(c) for c in [76, 65])
-OIJUGS = "".join(chr(c) for c in [50, 52, 104])
-OINELW = "".join(chr(c) for c in [51])
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-OKPHUO = 18
-ONPYYL = 54
-OQNRSJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-OUNBLK = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-OUSPBW = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-PBWJYK = 78
-PFTSIF = 30
-PHUGTY = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-PHUOJR = 19
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 51])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 29
-PMXFUB = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-POUYNQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PQIPOU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-PYYLIU = 55
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QFFTTI = 94
-QFYLJU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-QIPOUY = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-QJYMOU = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-QLAIID = 87
-QLNMHX = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-QNRSJM = 25
-QNRXCH = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-QPLSPF = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-QRJJJV = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-QSNQLN = 74
-QTDKHT = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-QTMFZD = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-QVXOIH = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 50])
-RAHEOC = 37
-RAZMKQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-RJHIUS = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-RJJJVY = 107
-RJZTAT = "".join(chr(c) for c in [79, 70, 70])
-RKINEJ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-RSJMCB = 41
-RTFMNH = 4
-RURAZM = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-RYXBQF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-SBDJQR = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-SELHBQ = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-SEMCGE = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 54])
-SKWIVD = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-SNQLNM = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 55])
-SOOQNR = 24
-SPBWJY = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-SPFTSI = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-SROGMD = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-SRURAZ = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-SSAKQX = "".join(chr(c) for c in [72, 84, 82, 50])
-SSRURA = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-SSUHBV = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-STSEMC = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-SUHBVW = 99
-SXUJUT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-TACCPQ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-TATDZX = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-TBJEUT = 8
-TDKHTZ = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-TDRXAI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-TDZXNQ = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-TFMNHT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-THBSKS = 40
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 92
-TIDUBS = 96
-TIXQVX = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-TMFZDG = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-TOPHUG = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-TSEMCG = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-TSIFJB = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-TTIDUB = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-TYIYWS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-TZBBEK = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UBJLOI = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-UBSSUH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-UBYGDS = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-UEUHNN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-UGSELH = 64
-UGTYIY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-UHBVWV = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UHNNXW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-UJUTYE = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-UNBLKX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-UNRJZT = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-UNXNKM = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-UOJRJH = 20
-UQEXLS = 46
-URAZMK = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-USOOQN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-USPBWJ = 62
-UTOPHU = 71
-UTYEKC = 2
-UXFEFJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UYNQJY = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-VDNQGV = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-VDQLAI = 86
-VDSSRU = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-VUBYGD = 102
-VUNXNK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-VWVUBY = 101
-VXOIHB = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VYFCRT = 109
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-WAONPY = 80
-WBSIRY = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-WDAFIK = 7
-WEEZFE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-WIVDNQ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-WMNZMJ = 1
-WRKINE = 114
-WSKWIV = 4
-WUEUHN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-WVUBYG = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-XBQFYL = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-XCHWDA = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-XEKVKZ = "".join(chr(c) for c in [70, 50, 49])
-XFEFJT = "".join(chr(c) for c in [79, 119, 110])
-XFUBJL = 126
-XIBHZV = "".join(chr(c) for c in [80, 68, 67])
-XLSXUJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-XNKMLO = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-XOIHBX = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-XPICXQ = 13
-XQIEFX = 15
-XQVXOI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-XSJWMN = "".join(chr(c) for c in [72, 105])
-XTIACQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-XUJUTY = 49
-XWAJVD = 84
-XWEEZF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YBQSNQ = 122
-YEKCWA = 79
-YFCRTF = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-YGDSBD = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-YIYWSK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-YKLGQP = 28
-YLIUXF = 56
-YLJUIK = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YMOUNB = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-YNQJYM = 27
-YOUSPB = 61
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-YXBQFY = 35
-YYLIUX = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-ZFETDR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-ZILXWA = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-ZMKQTD = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-ZTATDZ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-ZUQEXL = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-ZVOACM = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-ZXNQTM = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-AZMKQT = [
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    KSTSEM,
-    STSEMC,
-    TSEMCG,
-    SEMCGE,
-    EMCGET,
-    MCGETI,
-    CGETIX,
-    GETIXQ,
-    ETIXQV,
-    TIXQVX,
-    IXQVXO,
-    XQVXOI,
-    QVXOIH,
-    VXOIHB,
-    XOIHBX,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-    BXIBHZ,
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-]
-BDFSRO = [KBDFSR, ZXNQTM]
-BLKXSJ = [OUNBLK, UNBLKX, NBLKXS]
-DKHTZB = [QTDKHT, TDKHTZ, VLASSA, VLASSA]
-DRXAIV = [
-    BMJVHF,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OQNRSJ,
-    TYEKCW,
-]
-DSBDJQ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VKZILX, KZILXW, ZILXWA]
-EJNIBX = [INEJNI, NEJNIB]
-FEFJTA = [UXFEFJ, XFEFJT]
-FZDGKE = [TMFZDG, MFZDGK]
-GQPLSP = [KLGQPL, LGQPLS]
-IJUGSE = [JVHFTH, LOIJUG, OIJUGS]
-ILXWAJ = [NMHXEK, MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL, VKZILX, KZILXW, ZILXWA]
-JYMOUN = [NQJYMO, QJYMOU]
-KCWAON = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    EKCWAO,
-]
-KQXPIC = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-]
-LHBQNR = [SELHBQ, ELHBQN]
-LSPFTS = [PIPIVL, BWJYKL]
-MAOAWB = [MJMAOA, JMAOAW]
-NELWUE = [VLASSA, JLOINE, LOINEL, OINELW, INELWU]
-NQGVUN = [VDNQGV, DNQGVU]
-NQLNMH = [FTSIFJ, SNQLNM]
-NXNKML = [VLASSA, VUNXNK, UNXNKM]
-OOQNRS = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-OPHUGT = [JVHFTH, NQJYMO, TOPHUG]
-OUYNQJ = [PQIPOU, QIPOUY, IPOUYN, POUYNQ]
-PUNRJZ = [KJPUNR, JPUNRJ]
-ROGMDD = [FSROGM, SROGMD]
-RXAIVE = [EKCWAO]
-RXCHWD = [QNRXCH, NRXCHW]
-SIFJBI = [FTSIFJ, TSIFJB]
-SIRYXB = [WBSIRY, BSIRYX]
-SJWMNZ = [KXSJWM, XSJWMN]
-UIKFWR = [FTSIFJ, JUIKFW]
-WJYKLG = [JVHFTH, BWJYKL, PIPIVL]
-XAIVEM = []
-XNQTMF = [RJZTAT, JZTATD, ZTATDZ, TATDZX, ATDZXN, TDZXNQ, DZXNQT, ZXNQTM]
-XQGLRA = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1054,347 +19,1229 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return AIVEMV
+        return 60
 
     @property
     def output_keys(self):
-        return DRXAIV
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, KQXPIC, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, KQXPIC, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, KQXPIC, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, KQXPIC, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, KQXPIC, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XQGLRA, None, None, QBMJVH
-            ),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, KQXPIC, None, None, QBMJVH
-            ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, KQXPIC, None, None, QBMJVH
-            ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, KQXPIC, None, None, QBMJVH
-            ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, KQXPIC, None, None, QBMJVH
-            ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, KQXPIC, None, None, QBMJVH
-            ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, KQXPIC, None, None, QBMJVH
-            ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, IUSOOQ, None, KQXPIC, None, None, QBMJVH
-            ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, SOOQNR, None, OOQNRS, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 112, 0, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, None, OOQNRS, None, None, QBMJVH
-            ),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, QBMJVH),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
-            UJUTYE: GeckoBoolStructAccessor(
-                self.struct, UJUTYE, JUTYEK, UTYEKC, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, KCWAON, None, None, None
-            ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, None),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, EFJTAC, FEFJTA, None, UTYEKC, QBMJVH
-            ),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
-            ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, BLKXSJ, None, None, QBMJVH
-            ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, IUXFEF, UTYEKC, SJWMNZ, None, UTYEKC, QBMJVH
-            ),
-            JWMNZM: GeckoBoolStructAccessor(
-                self.struct, JWMNZM, JUTYEK, WMNZMJ, QBMJVH
-            ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, WJYKLG, None, None, QBMJVH
-            ),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, LSPFTS, None, None, QBMJVH
-            ),
-            SPFTSI: GeckoEnumStructAccessor(
-                self.struct, SPFTSI, PFTSIF, None, SIFJBI, None, None, QBMJVH
-            ),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, LSPFTS, None, None, QBMJVH
-            ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, IUXFEF, IRYXBQ, SIRYXB, None, UTYEKC, QBMJVH
-            ),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoTempStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoTempStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, UIKFWR, None, None, QBMJVH
-            ),
-            IKFWRK: GeckoByteStructAccessor(self.struct, IKFWRK, KFWRKI, QBMJVH),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, QBMJVH),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoByteStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, ILXWAJ, None, None, QBMJVH
-            ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, ILXWAJ, None, None, QBMJVH
-            ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, ILXWAJ, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, ILXWAJ, None, None, QBMJVH
-            ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, ILXWAJ, None, None, QBMJVH
-            ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, BXTIAC, None, ILXWAJ, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, ILXWAJ, None, None, QBMJVH
-            ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            FFTTID: GeckoEnumStructAccessor(
-                self.struct, FFTTID, FTTIDU, None, ILXWAJ, None, None, QBMJVH
-            ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, TIDUBS, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IDUBSS: GeckoEnumStructAccessor(
-                self.struct, IDUBSS, DUBSSU, None, ILXWAJ, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, DSBDJQ, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, DSBDJQ, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, DSBDJQ, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoTimeStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoTimeStructAccessor(self.struct, MNHTBJ, NHTBJE, QBMJVH),
-            HTBJEU: GeckoTimeStructAccessor(self.struct, HTBJEU, TBJEUT, QBMJVH),
-            BJEUTO: GeckoTimeStructAccessor(self.struct, BJEUTO, JEUTOP, QBMJVH),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, OPHUGT, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoBoolStructAccessor(
-                self.struct, PHUGTY, HUGTYI, EFJTAC, QBMJVH
-            ),
-            UGTYIY: GeckoBoolStructAccessor(
-                self.struct, UGTYIY, GTYIYW, UTYEKC, QBMJVH
-            ),
-            TYIYWS: GeckoBoolStructAccessor(
-                self.struct, TYIYWS, GTYIYW, EFJTAC, QBMJVH
-            ),
-            YIYWSK: GeckoBoolStructAccessor(
-                self.struct, YIYWSK, GTYIYW, WMNZMJ, QBMJVH
-            ),
-            IYWSKW: GeckoBoolStructAccessor(
-                self.struct, IYWSKW, GTYIYW, IRYXBQ, QBMJVH
-            ),
-            YWSKWI: GeckoBoolStructAccessor(
-                self.struct, YWSKWI, GTYIYW, WSKWIV, QBMJVH
-            ),
-            SKWIVD: GeckoBoolStructAccessor(
-                self.struct, SKWIVD, GTYIYW, KWIVDN, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, NQGVUN, None, None, QBMJVH
-            ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, NXNKML, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, IJUGSE, None, None, QBMJVH
-            ),
-            JUGSEL: GeckoWordStructAccessor(self.struct, JUGSEL, UGSELH, QBMJVH),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, IUXFEF, WMNZMJ, LHBQNR, None, UTYEKC, QBMJVH
-            ),
-            HBQNRX: GeckoBoolStructAccessor(
-                self.struct, HBQNRX, IUXFEF, WSKWIV, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, IUXFEF, KWIVDN, RXCHWD, None, UTYEKC, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, IUXFEF, CHWDAF, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, IUXFEF, WDAFIK, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, EFJTAC, QBMJVH
-            ),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, AFIKJP, WMNZMJ, QBMJVH
-            ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, AFIKJP, UTYEKC, PUNRJZ, None, UTYEKC, QBMJVH
-            ),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, AFIKJP, IRYXBQ, PUNRJZ, None, UTYEKC, QBMJVH
-            ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, AFIKJP, WSKWIV, XNQTMF, None, NQTMFZ, QBMJVH
-            ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, AFIKJP, WDAFIK, FZDGKE, None, UTYEKC, QBMJVH
-            ),
-            ZMKQTD: GeckoBoolStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, EFJTAC, QBMJVH
-            ),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, MKQTDK, UTYEKC, DKHTZB, None, WSKWIV, QBMJVH
-            ),
-            KHTZBB: GeckoByteStructAccessor(self.struct, KHTZBB, HTZBBE, QBMJVH),
-            TZBBEK: GeckoBoolStructAccessor(
-                self.struct, TZBBEK, JUTYEK, EFJTAC, QBMJVH
-            ),
-            ZBBEKB: GeckoByteStructAccessor(self.struct, ZBBEKB, BBEKBD, QBMJVH),
-            BEKBDF: GeckoEnumStructAccessor(
-                self.struct, BEKBDF, EKBDFS, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            DFSROG: GeckoEnumStructAccessor(
-                self.struct, DFSROG, EKBDFS, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            OGMDDP: GeckoEnumStructAccessor(
-                self.struct, OGMDDP, GMDDPM, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            MDDPMX: GeckoEnumStructAccessor(
-                self.struct, MDDPMX, GMDDPM, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            DDPMXF: GeckoEnumStructAccessor(
-                self.struct, DDPMXF, DPMXFU, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            PMXFUB: GeckoEnumStructAccessor(
-                self.struct, PMXFUB, DPMXFU, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            MXFUBJ: GeckoEnumStructAccessor(
-                self.struct, MXFUBJ, XFUBJL, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            FUBJLO: GeckoEnumStructAccessor(
-                self.struct, FUBJLO, XFUBJL, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            UBJLOI: GeckoEnumStructAccessor(
-                self.struct, UBJLOI, BJLOIN, EFJTAC, NELWUE, None, NQTMFZ, None
-            ),
-            ELWUEU: GeckoBoolStructAccessor(self.struct, ELWUEU, BJLOIN, WDAFIK, None),
-            LWUEUH: GeckoBoolStructAccessor(self.struct, LWUEUH, EKBDFS, WSKWIV, None),
-            WUEUHN: GeckoBoolStructAccessor(self.struct, WUEUHN, EKBDFS, KWIVDN, None),
-            UEUHNN: GeckoBoolStructAccessor(self.struct, UEUHNN, EKBDFS, CHWDAF, None),
-            EUHNNX: GeckoBoolStructAccessor(self.struct, EUHNNX, EKBDFS, WDAFIK, None),
-            UHNNXW: GeckoBoolStructAccessor(self.struct, UHNNXW, GMDDPM, WSKWIV, None),
-            HNNXWE: GeckoBoolStructAccessor(self.struct, HNNXWE, GMDDPM, KWIVDN, None),
-            NNXWEE: GeckoBoolStructAccessor(self.struct, NNXWEE, GMDDPM, CHWDAF, None),
-            NXWEEZ: GeckoBoolStructAccessor(self.struct, NXWEEZ, GMDDPM, WDAFIK, None),
-            XWEEZF: GeckoBoolStructAccessor(self.struct, XWEEZF, DPMXFU, WSKWIV, None),
-            WEEZFE: GeckoBoolStructAccessor(self.struct, WEEZFE, DPMXFU, KWIVDN, None),
-            EEZFET: GeckoBoolStructAccessor(self.struct, EEZFET, DPMXFU, CHWDAF, None),
-            EZFETD: GeckoBoolStructAccessor(self.struct, EZFETD, DPMXFU, WDAFIK, None),
-            ZFETDR: GeckoBoolStructAccessor(self.struct, ZFETDR, XFUBJL, WSKWIV, None),
-            FETDRX: GeckoBoolStructAccessor(self.struct, FETDRX, XFUBJL, KWIVDN, None),
-            ETDRXA: GeckoBoolStructAccessor(self.struct, ETDRXA, XFUBJL, CHWDAF, None),
-            TDRXAI: GeckoBoolStructAccessor(self.struct, TDRXAI, XFUBJL, WDAFIK, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-61.py
+++ b/src/geckolib/driver/packs/inyt-cfg-61.py
@@ -12,1090 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AONPYY = 80
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-AWBSIR = 31
-AZMKQT = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-BBEKBD = "".join(chr(c) for c in [73, 100, 111, 108])
-BDFSRO = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-BFEGZU = 43
-BHZVOA = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BJLOIN = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 128
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVWVUB = 95
-BWJYKL = 78
-BXIBHZ = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = 8
-CHWDAF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CMCVDS = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRTFMN = 105
-CTHBSK = 39
-CVDSSR = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYWONF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-CZOLSI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-DAFIKJ = "".join(chr(c) for c in [50, 52, 104])
-DFSROG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-DGKEAK = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DZXNQT = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-EAKSTS = "".join(chr(c) for c in [82, 69, 68])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-ELWUEU = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-EMCGET = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-EMVCYW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-EOCTHB = 38
-ETDRXA = "".join(chr(c) for c in [51])
-ETIXQV = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-EUHNNX = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EZFETD = 127
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = "".join(chr(c) for c in [50])
-FFTTID = 89
-FIKJPU = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-FZDGKE = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-GKEAKS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [65, 108, 112, 115])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = 125
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = 34
-HXEKVK = 53
-HZVOAC = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IHBXIB = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = 64
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-INELWU = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = 61
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVEMVC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = 123
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JPUNRJ = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JZTATD = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-KBDFSR = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KEAKST = "".join(chr(c) for c in [79, 70, 70])
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = "".join(chr(c) for c in [82, 71, 66])
-LRAHEO = 36
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCVDSS = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-MDDPMX = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-MFZDGK = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MVCYWO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-MXFUBJ = 113
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-NFZCZO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NNXWEE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = 110
-NRJZTA = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-NRSJMC = 25
-NRXCHW = 130
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NXWEEZ = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OGMDDP = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-OIHBXI = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-ONFZCZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMXFUB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PUNRJZ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QNRXCH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-QTMFZD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-QVXOIH = 111
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAZMKQ = "".join(chr(c) for c in [80, 68, 67])
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-RKINEJ = 115
-ROGMDD = 112
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [77, 65, 65, 88])
-RXAIVE = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-RXCHWD = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SEMCGE = "".join(chr(c) for c in [67, 89, 65, 78])
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-SRURAZ = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSRURA = "".join(chr(c) for c in [76, 65])
-SSUHBV = 93
-STSEMC = "".join(chr(c) for c in [66, 76, 85, 69])
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SXUJUT = 48
-TACCPQ = 118
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-TDRXAI = "".join(chr(c) for c in [52])
-TDZXNQ = 6
-TFMNHT = 106
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-TMFZDG = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-TOPHUG = 4
-TSEMCG = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-UBJLOI = 121
-UBSSUH = 92
-UBYGDS = 97
-UEUHNN = 124
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UHBVWV = 94
-UHNNXW = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VEMVCY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = "".join(chr(c) for c in [65, 109, 80, 109])
-WEEZFE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WONFZC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-WVUBYG = 96
-XAIVEM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-XBQFYL = 35
-XCHWDA = 132
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XIBHZV = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-XLSXUJ = 47
-XNKMLO = 5
-XNQTMF = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XOIHBX = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XQVXOI = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = 126
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWONFZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-ZFETDR = "".join(chr(c) for c in [49])
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-ZOLSIP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-ZTATDZ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZUQEXL = 45
-ZVOACM = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-ZXNQTM = 7
-AFIKJP = [JVHFTH, WDAFIK, DAFIKJ]
-AOAWBS = [JMAOAW, MAOAWB]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DDPMXF = [GMDDPM, MDDPMX, VLASSA, VLASSA]
-DRXAIV = [VLASSA, ZFETDR, FETDRX, ETDRXA, TDRXAI]
-EFJTAC = [XFEFJT, FEFJTA]
-FSROGM = [
-    VXOIHB,
-    XOIHBX,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-    BXIBHZ,
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-]
-IFJBIA = [TSIFJB, SIFJBI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-IRYXBQ = [BSIRYX, SIRYXB]
-IXQVXO = [ETIXQV, TIXQVX]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-LSIPMD = [KCWAON]
-LWUEUH = [NELWUE, ELWUEU]
-MCGETI = [KEAKST, EAKSTS, AKSTSE, KSTSEM, STSEMC, TSEMCG, SEMCGE, EMCGET]
-OIJUGS = [MLOIJU, LOIJUG]
-OINELW = [LOINEL, EMCGET]
-OLSIPM = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SIPMDM = []
-SPFTSI = [PIPIVL, WJYKLG]
-TATDZX = [JZTATD, ZTATDZ]
-UNRJZT = [JPUNRJ, PUNRJZ]
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-ZDGKEA = [MFZDGK, FZDGKE]
-ZILXWA = [TSIFJB, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1103,356 +19,1255 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return IPMDMP
+        return 61
 
     @property
     def output_keys(self):
-        return OLSIPM
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "OnzenStart": GeckoTimeStructAccessor(
+                self.struct, "OnzenStart", 128, "ALL"
+            ),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 130, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 132, "ALL"),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoTimeStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoTimeStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, AFIKJP, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoWordStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, UXFEFJ, MNZMJI, UNRJZT, None, TYEKCW, QBMJVH
-            ),
-            NRJZTA: GeckoBoolStructAccessor(
-                self.struct, NRJZTA, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, UXFEFJ, XNKMLO, TATDZX, None, TYEKCW, QBMJVH
-            ),
-            ATDZXN: GeckoBoolStructAccessor(
-                self.struct, ATDZXN, UXFEFJ, TDZXNQ, QBMJVH
-            ),
-            DZXNQT: GeckoBoolStructAccessor(
-                self.struct, DZXNQT, UXFEFJ, ZXNQTM, QBMJVH
-            ),
-            XNQTMF: GeckoBoolStructAccessor(
-                self.struct, XNQTMF, NQTMFZ, FJTACC, QBMJVH
-            ),
-            QTMFZD: GeckoBoolStructAccessor(
-                self.struct, QTMFZD, NQTMFZ, MNZMJI, QBMJVH
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, NQTMFZ, TYEKCW, ZDGKEA, None, TYEKCW, QBMJVH
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, NQTMFZ, RYXBQF, ZDGKEA, None, TYEKCW, QBMJVH
-            ),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, NQTMFZ, UNXNKM, MCGETI, None, CGETIX, QBMJVH
-            ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, NQTMFZ, ZXNQTM, IXQVXO, None, TYEKCW, QBMJVH
-            ),
-            SROGMD: GeckoBoolStructAccessor(
-                self.struct, SROGMD, ROGMDD, MNZMJI, QBMJVH
-            ),
-            OGMDDP: GeckoEnumStructAccessor(
-                self.struct, OGMDDP, ROGMDD, TYEKCW, DDPMXF, None, UNXNKM, QBMJVH
-            ),
-            DPMXFU: GeckoBoolStructAccessor(
-                self.struct, DPMXFU, ROGMDD, UNXNKM, QBMJVH
-            ),
-            PMXFUB: GeckoByteStructAccessor(self.struct, PMXFUB, MXFUBJ, QBMJVH),
-            XFUBJL: GeckoBoolStructAccessor(
-                self.struct, XFUBJL, UTYEKC, FJTACC, QBMJVH
-            ),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, QBMJVH),
-            BJLOIN: GeckoEnumStructAccessor(
-                self.struct, BJLOIN, JLOINE, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            INELWU: GeckoEnumStructAccessor(
-                self.struct, INELWU, JLOINE, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            WUEUHN: GeckoEnumStructAccessor(
-                self.struct, WUEUHN, UEUHNN, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            EUHNNX: GeckoEnumStructAccessor(
-                self.struct, EUHNNX, UEUHNN, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            UHNNXW: GeckoEnumStructAccessor(
-                self.struct, UHNNXW, HNNXWE, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            NNXWEE: GeckoEnumStructAccessor(
-                self.struct, NNXWEE, HNNXWE, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            NXWEEZ: GeckoEnumStructAccessor(
-                self.struct, NXWEEZ, XWEEZF, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            WEEZFE: GeckoEnumStructAccessor(
-                self.struct, WEEZFE, XWEEZF, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            EEZFET: GeckoEnumStructAccessor(
-                self.struct, EEZFET, EZFETD, FJTACC, DRXAIV, None, CGETIX, None
-            ),
-            RXAIVE: GeckoBoolStructAccessor(self.struct, RXAIVE, EZFETD, ZXNQTM, None),
-            XAIVEM: GeckoBoolStructAccessor(self.struct, XAIVEM, JLOINE, UNXNKM, None),
-            AIVEMV: GeckoBoolStructAccessor(self.struct, AIVEMV, JLOINE, XNKMLO, None),
-            IVEMVC: GeckoBoolStructAccessor(self.struct, IVEMVC, JLOINE, TDZXNQ, None),
-            VEMVCY: GeckoBoolStructAccessor(self.struct, VEMVCY, JLOINE, ZXNQTM, None),
-            EMVCYW: GeckoBoolStructAccessor(self.struct, EMVCYW, UEUHNN, UNXNKM, None),
-            MVCYWO: GeckoBoolStructAccessor(self.struct, MVCYWO, UEUHNN, XNKMLO, None),
-            VCYWON: GeckoBoolStructAccessor(self.struct, VCYWON, UEUHNN, TDZXNQ, None),
-            CYWONF: GeckoBoolStructAccessor(self.struct, CYWONF, UEUHNN, ZXNQTM, None),
-            YWONFZ: GeckoBoolStructAccessor(self.struct, YWONFZ, HNNXWE, UNXNKM, None),
-            WONFZC: GeckoBoolStructAccessor(self.struct, WONFZC, HNNXWE, XNKMLO, None),
-            ONFZCZ: GeckoBoolStructAccessor(self.struct, ONFZCZ, HNNXWE, TDZXNQ, None),
-            NFZCZO: GeckoBoolStructAccessor(self.struct, NFZCZO, HNNXWE, ZXNQTM, None),
-            FZCZOL: GeckoBoolStructAccessor(self.struct, FZCZOL, XWEEZF, UNXNKM, None),
-            ZCZOLS: GeckoBoolStructAccessor(self.struct, ZCZOLS, XWEEZF, XNKMLO, None),
-            CZOLSI: GeckoBoolStructAccessor(self.struct, CZOLSI, XWEEZF, TDZXNQ, None),
-            ZOLSIP: GeckoBoolStructAccessor(self.struct, ZOLSIP, XWEEZF, ZXNQTM, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-62.py
+++ b/src/geckolib/driver/packs/inyt-cfg-62.py
@@ -12,1104 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AONPYY = 80
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-AWBSIR = 31
-AZMKQT = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-BBEKBD = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-BDFSRO = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-BFEGZU = 43
-BHZVOA = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BJLOIN = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 128
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVWVUB = 95
-BWJYKL = 78
-BXIBHZ = 111
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-CHWDAF = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-CMCVDS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRTFMN = 105
-CTHBSK = 39
-CVDSSR = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYWONF = "".join(chr(c) for c in [52])
-CZOLSI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-DFSROG = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-DMPSCT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DRXAIV = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DZXNQT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EAKSTS = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-ELWUEU = 113
-EMCGET = "".join(chr(c) for c in [82, 69, 68])
-EMVCYW = "".join(chr(c) for c in [49])
-EOCTHB = 38
-ETDRXA = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-ETIXQV = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-EUHNNX = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EZFETD = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-FFTTID = 89
-FIKJPU = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FSROGM = "".join(chr(c) for c in [73, 100, 111, 108])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-FZDGKE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-GCRHYU = 62
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(chr(c) for c in [66, 76, 85, 69])
-GKEAKS = 110
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = "".join(chr(c) for c in [82, 71, 66])
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = 157
-HXEKVK = 53
-HZVOAC = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = 158
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVEMVC = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JPUNRJ = 34
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JZTATD = 64
-KBDFSR = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KEAKST = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [77, 65, 65, 88])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-LRAHEO = 36
-LSIPMD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCGETI = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-MCVDSS = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-MDDPMX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-MDMPSC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-MFZDGK = 6
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MPSCTT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-MVCYWO = "".join(chr(c) for c in [50])
-MXFUBJ = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-NFZCZO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NRSJMC = 25
-NRXCHW = 130
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NXWEEZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OGMDDP = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-OIHBXI = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-OINELW = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-OLSIPM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-ONFZCZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMDMPS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-PMXFUB = 112
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PSCTTG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-PUNRJZ = "".join(chr(c) for c in [65, 109, 80, 109])
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QNRXCH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QVXOIH = 8
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAZMKQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RKINEJ = 115
-ROGMDD = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-RXAIVE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-RXCHWD = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SCTTGC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIPMDM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-SRURAZ = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSRURA = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SSUHBV = 93
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SXUJUT = 48
-TACCPQ = 118
-TATDZX = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(chr(c) for c in [80, 68, 67])
-TDRXAI = 125
-TFMNHT = 106
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(chr(c) for c in [67, 89, 65, 78])
-TMFZDG = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-TOPHUG = 4
-TSEMCG = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UBSSUH = 92
-UBYGDS = 97
-UEUHNN = 121
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UHBVWV = 94
-UHNNXW = 123
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNRJZT = "".join(chr(c) for c in [50, 52, 104])
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(chr(c) for c in [51])
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-VEMVCY = 127
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = "".join(chr(c) for c in [79, 70, 70])
-WEEZFE = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WONFZC = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-WVUBYG = 96
-XAIVEM = 126
-XBQFYL = 35
-XCHWDA = 132
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-XIBHZV = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-XLSXUJ = 47
-XNKMLO = 5
-XNQTMF = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-XOIHBX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-ZDGKEA = 7
-ZFETDR = 124
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [76, 65])
-ZOLSIP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-ZTATDZ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ZUQEXL = 45
-ZVOACM = "".join(chr(c) for c in [65, 108, 112, 115])
-ZXNQTM = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AFIKJP = [JVHFTH, WDAFIK, VLASSA, DAFIKJ]
-AOAWBS = [JMAOAW, MAOAWB]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CTTGCR = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DDPMXF = [
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-]
-EEZFET = [XWEEZF, WEEZFE]
-EFJTAC = [XFEFJT, FEFJTA]
-IFJBIA = [TSIFJB, SIFJBI]
-IHBXIB = [XOIHBX, OIHBXI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-INELWU = [JVHFTH, LOINEL, OINELW, VLASSA]
-IRYXBQ = [BSIRYX, SIRYXB]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-NNXWEE = [HNNXWE, IXQVXO]
-NRJZTA = [JVHFTH, PUNRJZ, UNRJZT]
-OIJUGS = [MLOIJU, LOIJUG]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QTMFZD = [XNQTMF, NQTMFZ]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SPFTSI = [PIPIVL, WJYKLG]
-STSEMC = [AKSTSE, KSTSEM]
-TDZXNQ = [TATDZX, ATDZXN]
-TGCRHY = []
-TTGCRH = [KCWAON]
-UBJLOI = [XFUBJL, FUBJLO, VLASSA, VLASSA]
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-XQVXOI = [WDAFIK, EMCGET, MCGETI, CGETIX, GETIXQ, ETIXQV, TIXQVX, IXQVXO]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-YWONFZ = [VLASSA, EMVCYW, MVCYWO, VCYWON, CYWONF]
-ZILXWA = [TSIFJB, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1117,363 +19,1278 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GCRHYU
+        return 62
 
     @property
     def output_keys(self):
-        return CTTGCR
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "OnzenStart": GeckoTimeStructAccessor(
+                self.struct, "OnzenStart", 128, "ALL"
+            ),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 130, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 132, "ALL"),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoTimeStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoTimeStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, AFIKJP, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoTimeStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoWordStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, UXFEFJ, MNZMJI, TDZXNQ, None, TYEKCW, QBMJVH
-            ),
-            DZXNQT: GeckoBoolStructAccessor(
-                self.struct, DZXNQT, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, UXFEFJ, XNKMLO, QTMFZD, None, TYEKCW, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, UXFEFJ, MFZDGK, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, UXFEFJ, ZDGKEA, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, GKEAKS, FJTACC, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, GKEAKS, MNZMJI, QBMJVH
-            ),
-            EAKSTS: GeckoEnumStructAccessor(
-                self.struct, EAKSTS, GKEAKS, TYEKCW, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, GKEAKS, RYXBQF, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, GKEAKS, UNXNKM, XQVXOI, None, QVXOIH, QBMJVH
-            ),
-            VXOIHB: GeckoEnumStructAccessor(
-                self.struct, VXOIHB, GKEAKS, ZDGKEA, IHBXIB, None, TYEKCW, QBMJVH
-            ),
-            DPMXFU: GeckoBoolStructAccessor(
-                self.struct, DPMXFU, PMXFUB, MNZMJI, QBMJVH
-            ),
-            MXFUBJ: GeckoEnumStructAccessor(
-                self.struct, MXFUBJ, PMXFUB, TYEKCW, UBJLOI, None, UNXNKM, QBMJVH
-            ),
-            BJLOIN: GeckoBoolStructAccessor(
-                self.struct, BJLOIN, PMXFUB, UNXNKM, QBMJVH
-            ),
-            JLOINE: GeckoEnumStructAccessor(
-                self.struct, JLOINE, PMXFUB, MFZDGK, INELWU, None, UNXNKM, QBMJVH
-            ),
-            NELWUE: GeckoByteStructAccessor(self.struct, NELWUE, ELWUEU, QBMJVH),
-            LWUEUH: GeckoBoolStructAccessor(
-                self.struct, LWUEUH, UTYEKC, FJTACC, QBMJVH
-            ),
-            WUEUHN: GeckoByteStructAccessor(self.struct, WUEUHN, UEUHNN, QBMJVH),
-            EUHNNX: GeckoEnumStructAccessor(
-                self.struct, EUHNNX, UHNNXW, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            NXWEEZ: GeckoEnumStructAccessor(
-                self.struct, NXWEEZ, UHNNXW, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            EZFETD: GeckoEnumStructAccessor(
-                self.struct, EZFETD, ZFETDR, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            FETDRX: GeckoEnumStructAccessor(
-                self.struct, FETDRX, ZFETDR, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            ETDRXA: GeckoEnumStructAccessor(
-                self.struct, ETDRXA, TDRXAI, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            DRXAIV: GeckoEnumStructAccessor(
-                self.struct, DRXAIV, TDRXAI, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            RXAIVE: GeckoEnumStructAccessor(
-                self.struct, RXAIVE, XAIVEM, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            AIVEMV: GeckoEnumStructAccessor(
-                self.struct, AIVEMV, XAIVEM, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            IVEMVC: GeckoEnumStructAccessor(
-                self.struct, IVEMVC, VEMVCY, FJTACC, YWONFZ, None, QVXOIH, None
-            ),
-            WONFZC: GeckoBoolStructAccessor(self.struct, WONFZC, VEMVCY, ZDGKEA, None),
-            ONFZCZ: GeckoBoolStructAccessor(self.struct, ONFZCZ, UHNNXW, UNXNKM, None),
-            NFZCZO: GeckoBoolStructAccessor(self.struct, NFZCZO, UHNNXW, XNKMLO, None),
-            FZCZOL: GeckoBoolStructAccessor(self.struct, FZCZOL, UHNNXW, MFZDGK, None),
-            ZCZOLS: GeckoBoolStructAccessor(self.struct, ZCZOLS, UHNNXW, ZDGKEA, None),
-            CZOLSI: GeckoBoolStructAccessor(self.struct, CZOLSI, ZFETDR, UNXNKM, None),
-            ZOLSIP: GeckoBoolStructAccessor(self.struct, ZOLSIP, ZFETDR, XNKMLO, None),
-            OLSIPM: GeckoBoolStructAccessor(self.struct, OLSIPM, ZFETDR, MFZDGK, None),
-            LSIPMD: GeckoBoolStructAccessor(self.struct, LSIPMD, ZFETDR, ZDGKEA, None),
-            SIPMDM: GeckoBoolStructAccessor(self.struct, SIPMDM, TDRXAI, UNXNKM, None),
-            IPMDMP: GeckoBoolStructAccessor(self.struct, IPMDMP, TDRXAI, XNKMLO, None),
-            PMDMPS: GeckoBoolStructAccessor(self.struct, PMDMPS, TDRXAI, MFZDGK, None),
-            MDMPSC: GeckoBoolStructAccessor(self.struct, MDMPSC, TDRXAI, ZDGKEA, None),
-            DMPSCT: GeckoBoolStructAccessor(self.struct, DMPSCT, XAIVEM, UNXNKM, None),
-            MPSCTT: GeckoBoolStructAccessor(self.struct, MPSCTT, XAIVEM, XNKMLO, None),
-            PSCTTG: GeckoBoolStructAccessor(self.struct, PSCTTG, XAIVEM, MFZDGK, None),
-            SCTTGC: GeckoBoolStructAccessor(self.struct, SCTTGC, XAIVEM, ZDGKEA, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-63.py
+++ b/src/geckolib/driver/packs/inyt-cfg-63.py
@@ -12,1510 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-ADXLUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AOESVZ = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-AONPYY = 80
-APUMEA = "".join(chr(c) for c in [49])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-AWBSIR = 31
-AXADXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-AXNCUG = 124
-AZMKQT = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-BBEKBD = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-BDFSRO = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-BFEGZU = 43
-BHZVOA = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BJLOIN = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 128
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVNAXA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-BVWVUB = 95
-BWJYKL = 78
-BXIBHZ = 111
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-CHWDAF = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-CMCVDS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRHYUA = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-CRTFMN = 105
-CTHBSK = 39
-CTTGCR = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-CUGUCY = 125
-CVDSSR = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYRAPU = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-CYWONF = 137
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-DFSROG = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-DMPSCT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DRXAIV = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DXLUBG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-DZXNQT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EAKSTS = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-ELWUEU = 113
-EMCGET = "".join(chr(c) for c in [82, 69, 68])
-EMVCYW = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-EOCTHB = 38
-ESVZSS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-ETDRXA = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-ETIXQV = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-EUHNNX = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = 135
-FFTTID = 89
-FIKJPU = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FSROGM = "".join(chr(c) for c in [73, 100, 111, 108])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-FZDGKE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(chr(c) for c in [66, 76, 85, 69])
-GKEAKS = 110
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GUCYRA = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = 157
-HXEKVK = 53
-HYUAXN = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-HZVOAC = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = 158
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = 149
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JFJNTT = 63
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JPUNRJ = 34
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JZTATD = 64
-KBDFSR = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KEAKST = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [77, 65, 65, 88])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-LRAHEO = 36
-LSIPMD = 147
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LUBGJF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCGETI = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-MCVDSS = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-MDDPMX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-MDMPSC = 151
-MEAOES = "".join(chr(c) for c in [52])
-MFZDGK = 6
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MPSCTT = 153
-MVCYWO = 136
-MXFUBJ = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-NAXADX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NCUGUC = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-NFZCZO = 141
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NNXWEE = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NRSJMC = 25
-NRXCHW = 130
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-OGMDDP = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-OIHBXI = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-OINELW = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-OLSIPM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-ONFZCZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMDMPS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-PMXFUB = 112
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PSCTTG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-PUMEAO = "".join(chr(c) for c in [50])
-PUNRJZ = "".join(chr(c) for c in [65, 109, 80, 109])
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QNRXCH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QVXOIH = 8
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = 127
-RAZMKQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-RHYUAX = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RKINEJ = 115
-ROGMDD = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-RXAIVE = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-RXCHWD = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SBVNAX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-SCTTGC = 155
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIPMDM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-SRURAZ = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-SSRURA = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SSUHBV = 93
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SVZSSB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-SXUJUT = 48
-TACCPQ = 118
-TATDZX = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(chr(c) for c in [80, 68, 67])
-TDRXAI = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-TFMNHT = 106
-TGCRHY = "".join(chr(c) for c in [82, 71, 66])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(chr(c) for c in [67, 89, 65, 78])
-TMFZDG = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-TOPHUG = 4
-TSEMCG = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTGCRH = 123
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UAXNCU = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-UBSSUH = 92
-UBYGDS = 97
-UCYRAP = 126
-UEUHNN = 121
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UGUCYR = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-UHBVWV = 94
-UHNNXW = 133
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UMEAOE = "".join(chr(c) for c in [51])
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNRJZT = "".join(chr(c) for c in [50, 52, 104])
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-VEMVCY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-VOACMC = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = "".join(chr(c) for c in [79, 70, 70])
-WEEZFE = 134
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WONFZC = 139
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-WVUBYG = 96
-XADXLU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-XAIVEM = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-XBQFYL = 35
-XCHWDA = 132
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-XIBHZV = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-XLSXUJ = 47
-XLUBGJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-XNCUGU = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-XNKMLO = 5
-XNQTMF = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-XOIHBX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-YWONFZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = 143
-ZDGKEA = 7
-ZFETDR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [76, 65])
-ZOLSIP = 145
-ZSSBVN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-ZTATDZ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ZUQEXL = 45
-ZVOACM = "".join(chr(c) for c in [65, 108, 112, 115])
-ZXNQTM = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AFIKJP = [JVHFTH, WDAFIK, VLASSA, DAFIKJ]
-AOAWBS = [JMAOAW, MAOAWB]
-BGJFJN = [KCWAON]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DDPMXF = [
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-]
-EAOESV = [VLASSA, APUMEA, PUMEAO, UMEAOE, MEAOES]
-EFJTAC = [XFEFJT, FEFJTA]
-EZFETD = [EEZFET]
-GCRHYU = [TGCRHY, IXQVXO]
-GJFJNT = []
-IFJBIA = [TSIFJB, SIFJBI]
-IHBXIB = [XOIHBX, OIHBXI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-INELWU = [JVHFTH, LOINEL, OINELW, VLASSA]
-IRYXBQ = [BSIRYX, SIRYXB]
-IVEMVC = [ETDRXA, TDRXAI, DRXAIV, RXAIVE, XAIVEM, AIVEMV, VLASSA, VLASSA]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-NRJZTA = [JVHFTH, PUNRJZ, UNRJZT]
-NXWEEZ = [HNNXWE, NNXWEE]
-OIJUGS = [MLOIJU, LOIJUG]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QTMFZD = [XNQTMF, NQTMFZ]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SPFTSI = [PIPIVL, WJYKLG]
-STSEMC = [AKSTSE, KSTSEM]
-TDZXNQ = [TATDZX, ATDZXN]
-UBGJFJ = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-UBJLOI = [XFUBJL, FUBJLO, VLASSA, VLASSA]
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-XQVXOI = [WDAFIK, EMCGET, MCGETI, CGETIX, GETIXQ, ETIXQV, TIXQVX, IXQVXO]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-YUAXNC = [RHYUAX, HYUAXN]
-ZILXWA = [TSIFJB, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1523,386 +19,1353 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JFJNTT
+        return 63
 
     @property
     def output_keys(self):
-        return UBGJFJ
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "OnzenStart": GeckoTimeStructAccessor(
+                self.struct, "OnzenStart", 128, "ALL"
+            ),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 130, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 132, "ALL"),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoTimeStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoTimeStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, AFIKJP, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoTimeStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoWordStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, UXFEFJ, MNZMJI, TDZXNQ, None, TYEKCW, QBMJVH
-            ),
-            DZXNQT: GeckoBoolStructAccessor(
-                self.struct, DZXNQT, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, UXFEFJ, XNKMLO, QTMFZD, None, TYEKCW, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, UXFEFJ, MFZDGK, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, UXFEFJ, ZDGKEA, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, GKEAKS, FJTACC, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, GKEAKS, MNZMJI, QBMJVH
-            ),
-            EAKSTS: GeckoEnumStructAccessor(
-                self.struct, EAKSTS, GKEAKS, TYEKCW, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, GKEAKS, RYXBQF, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, GKEAKS, UNXNKM, XQVXOI, None, QVXOIH, QBMJVH
-            ),
-            VXOIHB: GeckoEnumStructAccessor(
-                self.struct, VXOIHB, GKEAKS, ZDGKEA, IHBXIB, None, TYEKCW, QBMJVH
-            ),
-            DPMXFU: GeckoBoolStructAccessor(
-                self.struct, DPMXFU, PMXFUB, MNZMJI, QBMJVH
-            ),
-            MXFUBJ: GeckoEnumStructAccessor(
-                self.struct, MXFUBJ, PMXFUB, TYEKCW, UBJLOI, None, UNXNKM, QBMJVH
-            ),
-            BJLOIN: GeckoBoolStructAccessor(
-                self.struct, BJLOIN, PMXFUB, UNXNKM, QBMJVH
-            ),
-            JLOINE: GeckoEnumStructAccessor(
-                self.struct, JLOINE, PMXFUB, MFZDGK, INELWU, None, UNXNKM, QBMJVH
-            ),
-            NELWUE: GeckoByteStructAccessor(self.struct, NELWUE, ELWUEU, QBMJVH),
-            LWUEUH: GeckoBoolStructAccessor(
-                self.struct, LWUEUH, UTYEKC, FJTACC, QBMJVH
-            ),
-            WUEUHN: GeckoByteStructAccessor(self.struct, WUEUHN, UEUHNN, QBMJVH),
-            EUHNNX: GeckoEnumStructAccessor(
-                self.struct, EUHNNX, UHNNXW, None, NXWEEZ, None, None, QBMJVH
-            ),
-            XWEEZF: GeckoEnumStructAccessor(
-                self.struct, XWEEZF, WEEZFE, None, EZFETD, None, None, QBMJVH
-            ),
-            ZFETDR: GeckoEnumStructAccessor(
-                self.struct, ZFETDR, FETDRX, FJTACC, IVEMVC, None, QVXOIH, QBMJVH
-            ),
-            VEMVCY: GeckoBoolStructAccessor(
-                self.struct, VEMVCY, FETDRX, ZDGKEA, QBMJVH
-            ),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, QBMJVH),
-            VCYWON: GeckoWordStructAccessor(self.struct, VCYWON, CYWONF, QBMJVH),
-            YWONFZ: GeckoWordStructAccessor(self.struct, YWONFZ, WONFZC, QBMJVH),
-            ONFZCZ: GeckoWordStructAccessor(self.struct, ONFZCZ, NFZCZO, QBMJVH),
-            FZCZOL: GeckoWordStructAccessor(self.struct, FZCZOL, ZCZOLS, QBMJVH),
-            CZOLSI: GeckoWordStructAccessor(self.struct, CZOLSI, ZOLSIP, QBMJVH),
-            OLSIPM: GeckoWordStructAccessor(self.struct, OLSIPM, LSIPMD, QBMJVH),
-            SIPMDM: GeckoWordStructAccessor(self.struct, SIPMDM, IPMDMP, QBMJVH),
-            PMDMPS: GeckoWordStructAccessor(self.struct, PMDMPS, MDMPSC, QBMJVH),
-            DMPSCT: GeckoWordStructAccessor(self.struct, DMPSCT, MPSCTT, QBMJVH),
-            PSCTTG: GeckoWordStructAccessor(self.struct, PSCTTG, SCTTGC, QBMJVH),
-            CTTGCR: GeckoEnumStructAccessor(
-                self.struct, CTTGCR, TTGCRH, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            CRHYUA: GeckoEnumStructAccessor(
-                self.struct, CRHYUA, TTGCRH, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            UAXNCU: GeckoEnumStructAccessor(
-                self.struct, UAXNCU, AXNCUG, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            XNCUGU: GeckoEnumStructAccessor(
-                self.struct, XNCUGU, AXNCUG, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            NCUGUC: GeckoEnumStructAccessor(
-                self.struct, NCUGUC, CUGUCY, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            UGUCYR: GeckoEnumStructAccessor(
-                self.struct, UGUCYR, CUGUCY, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            GUCYRA: GeckoEnumStructAccessor(
-                self.struct, GUCYRA, UCYRAP, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            CYRAPU: GeckoEnumStructAccessor(
-                self.struct, CYRAPU, UCYRAP, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, RAPUME, FJTACC, EAOESV, None, QVXOIH, None
-            ),
-            AOESVZ: GeckoBoolStructAccessor(self.struct, AOESVZ, RAPUME, ZDGKEA, None),
-            OESVZS: GeckoBoolStructAccessor(self.struct, OESVZS, TTGCRH, UNXNKM, None),
-            ESVZSS: GeckoBoolStructAccessor(self.struct, ESVZSS, TTGCRH, XNKMLO, None),
-            SVZSSB: GeckoBoolStructAccessor(self.struct, SVZSSB, TTGCRH, MFZDGK, None),
-            VZSSBV: GeckoBoolStructAccessor(self.struct, VZSSBV, TTGCRH, ZDGKEA, None),
-            ZSSBVN: GeckoBoolStructAccessor(self.struct, ZSSBVN, AXNCUG, UNXNKM, None),
-            SSBVNA: GeckoBoolStructAccessor(self.struct, SSBVNA, AXNCUG, XNKMLO, None),
-            SBVNAX: GeckoBoolStructAccessor(self.struct, SBVNAX, AXNCUG, MFZDGK, None),
-            BVNAXA: GeckoBoolStructAccessor(self.struct, BVNAXA, AXNCUG, ZDGKEA, None),
-            VNAXAD: GeckoBoolStructAccessor(self.struct, VNAXAD, CUGUCY, UNXNKM, None),
-            NAXADX: GeckoBoolStructAccessor(self.struct, NAXADX, CUGUCY, XNKMLO, None),
-            AXADXL: GeckoBoolStructAccessor(self.struct, AXADXL, CUGUCY, MFZDGK, None),
-            XADXLU: GeckoBoolStructAccessor(self.struct, XADXLU, CUGUCY, ZDGKEA, None),
-            ADXLUB: GeckoBoolStructAccessor(self.struct, ADXLUB, UCYRAP, UNXNKM, None),
-            DXLUBG: GeckoBoolStructAccessor(self.struct, DXLUBG, UCYRAP, XNKMLO, None),
-            XLUBGJ: GeckoBoolStructAccessor(self.struct, XLUBGJ, UCYRAP, MFZDGK, None),
-            LUBGJF: GeckoBoolStructAccessor(self.struct, LUBGJF, UCYRAP, ZDGKEA, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-64.py
+++ b/src/geckolib/driver/packs/inyt-cfg-64.py
@@ -12,1578 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-ADXLUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-AFIKJP = 157
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = 6
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AOESVZ = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-AONPYY = 80
-APUMEA = 125
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [65, 109, 80, 109])
-AWBSIR = 31
-AXADXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-AXNCUG = "".join(chr(c) for c in [82, 71, 66])
-AZMKQT = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-BBEKBD = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-BDFSRO = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [80, 68, 67])
-BFEGZU = 43
-BGJFJN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-BHZVOA = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 160
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVNAXA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-BVWVUB = 95
-BWJYKL = 78
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-CHWDAF = 130
-CMCVDS = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRHYUA = 153
-CRTFMN = 105
-CTHBSK = 39
-CTTGCR = 149
-CUGUCY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-CVDSSR = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYRAPU = 124
-CYWONF = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-CZOLSI = 137
-DAFIKJ = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-DDPMXF = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-DFSROG = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DGKEAK = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-DMPSCT = 145
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(chr(c) for c in [73, 100, 111, 108])
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DRXAIV = 134
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DXLUBG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-EAKSTS = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-EAOESV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-EMCGET = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-EMVCYW = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-EOCTHB = 38
-ESVZSS = "".join(chr(c) for c in [49])
-EUHNNX = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EZFETD = 133
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-FFTTID = 89
-FIKJPU = "".join(chr(c) for c in [79, 70, 70])
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJNTTU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FSROGM = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = 136
-FZDGKE = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-GCRHYU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GJFJNT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-GKEAKS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [76, 65])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-HXEKVK = 53
-HYUAXN = 155
-HZVOAC = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IHBXIB = "".join(chr(c) for c in [67, 89, 65, 78])
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-INELWU = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVEMVC = 135
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JFJNTT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JNTTUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-JPUNRJ = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-KBDFSR = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = 112
-LRAHEO = 36
-LSIPMD = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LUBGJF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCGETI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-MCVDSS = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-MDDPMX = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-MDMPSC = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-MEAOES = 126
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MPSCTT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-MVCYWO = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-MXFUBJ = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-NAXADX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NCUGUC = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-NFZCZO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NNXWEE = 113
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NRJZTA = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-NRSJMC = 25
-NRXCHW = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-NTTUVR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NXWEEZ = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = 111
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = 127
-OGMDDP = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-OIHBXI = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-OINELW = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-OLSIPM = 139
-ONFZCZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMDMPS = 143
-PMXFUB = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PSCTTG = 147
-PUMEAO = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-PUNRJZ = 158
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-QTMFZD = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-QVXOIH = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-RAZMKQ = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-RHYUAX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-RKINEJ = 115
-ROGMDD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-RXAIVE = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-RXCHWD = 128
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SBVNAX = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-SCTTGC = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-SEMCGE = 110
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIPMDM = 141
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-SRURAZ = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSRURA = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-SSUHBV = 93
-STSEMC = 7
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SVZSSB = "".join(chr(c) for c in [50])
-SXUJUT = 48
-TACCPQ = 118
-TATDZX = 34
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-TDRXAI = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-TDZXNQ = "".join(chr(c) for c in [50, 52, 104])
-TFMNHT = 106
-TGCRHY = 151
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-TMFZDG = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TOPHUG = 4
-TSEMCG = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTGCRH = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-UAXNCU = 123
-UBGJFJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-UBJLOI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-UBSSUH = 92
-UBYGDS = 97
-UCYRAP = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-UEUHNN = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UGUCYR = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-UHBVWV = 94
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UMEAOE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNRJZT = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [65, 108, 112, 115])
-VEMVCY = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-VOACMC = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-VRFLSI = 64
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(chr(c) for c in [51])
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = 132
-WEEZFE = 121
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-WVUBYG = 96
-XADXLU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-XBQFYL = 35
-XCHWDA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-XIBHZV = 8
-XLSXUJ = 47
-XLUBGJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-XNKMLO = 5
-XNQTMF = 64
-XOIHBX = "".join(chr(c) for c in [66, 76, 85, 69])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XQVXOI = "".join(chr(c) for c in [82, 69, 68])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-YUAXNC = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-YWONFZ = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [77, 65, 65, 88])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-ZDGKEA = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-ZFETDR = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-ZOLSIP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-ZSSBVN = "".join(chr(c) for c in [52])
-ZTATDZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-ZUQEXL = 45
-ZXNQTM = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-AOAWBS = [JMAOAW, MAOAWB]
-BJLOIN = [
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-    DDPMXF,
-    DPMXFU,
-    PMXFUB,
-    MXFUBJ,
-    XFUBJL,
-    FUBJLO,
-    UBJLOI,
-]
-BXIBHZ = [FIKJPU, XQVXOI, QVXOIH, VXOIHB, XOIHBX, OIHBXI, IHBXIB, HBXIBH]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DZXNQT = [JVHFTH, ATDZXN, TDZXNQ]
-EFJTAC = [XFEFJT, FEFJTA]
-ELWUEU = [INELWU, NELWUE, VLASSA, VLASSA]
-ETDRXA = [ZFETDR, FETDRX]
-ETIXQV = [CGETIX, GETIXQ]
-GUCYRA = [CUGUCY, UGUCYR]
-IFJBIA = [TSIFJB, SIFJBI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-IRYXBQ = [BSIRYX, SIRYXB]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-JZTATD = [NRJZTA, RJZTAT]
-KEAKST = [DGKEAK, GKEAKS]
-KJPUNR = [JVHFTH, FIKJPU, VLASSA, IKJPUN]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-MFZDGK = [QTMFZD, TMFZDG]
-OIJUGS = [MLOIJU, LOIJUG]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QNRXCH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KQXPIC,
-]
-QPLSPF = [LGQPLS, GQPLSP]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SPFTSI = [PIPIVL, WJYKLG]
-SSBVNA = [VLASSA, ESVZSS, SVZSSB, VZSSBV, ZSSBVN]
-TTUVRF = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-TUVRFL = [KCWAON]
-UHNNXW = [JVHFTH, UEUHNN, EUHNNX, VLASSA]
-UVRFLS = []
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-WONFZC = [VEMVCY, EMVCYW, MVCYWO, VCYWON, CYWONF, YWONFZ, VLASSA, VLASSA]
-XAIVEM = [RXAIVE]
-XNCUGU = [AXNCUG, HBXIBH]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-ZILXWA = [TSIFJB, KZILXW]
-ZVOACM = [BHZVOA, HZVOAC]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1591,392 +19,1406 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return VRFLSI
+        return 64
 
     @property
     def output_keys(self):
-        return TTUVRF
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, QNRXCH, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoTimeStructAccessor(self.struct, NRXCHW, RXCHWD, QBMJVH),
-            XCHWDA: GeckoTimeStructAccessor(self.struct, XCHWDA, CHWDAF, QBMJVH),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, QBMJVH),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, KJPUNR, None, None, QBMJVH
-            ),
-            JPUNRJ: GeckoTimeStructAccessor(self.struct, JPUNRJ, PUNRJZ, QBMJVH),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, UTYEKC, RYXBQF, JZTATD, None, TYEKCW, QBMJVH
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, TATDZX, None, DZXNQT, None, None, QBMJVH
-            ),
-            ZXNQTM: GeckoWordStructAccessor(self.struct, ZXNQTM, XNQTMF, QBMJVH),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, UXFEFJ, MNZMJI, MFZDGK, None, TYEKCW, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, UXFEFJ, XNKMLO, KEAKST, None, TYEKCW, QBMJVH
-            ),
-            EAKSTS: GeckoBoolStructAccessor(
-                self.struct, EAKSTS, UXFEFJ, AKSTSE, QBMJVH
-            ),
-            KSTSEM: GeckoBoolStructAccessor(
-                self.struct, KSTSEM, UXFEFJ, STSEMC, QBMJVH
-            ),
-            TSEMCG: GeckoBoolStructAccessor(
-                self.struct, TSEMCG, SEMCGE, FJTACC, QBMJVH
-            ),
-            EMCGET: GeckoBoolStructAccessor(
-                self.struct, EMCGET, SEMCGE, MNZMJI, QBMJVH
-            ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, SEMCGE, TYEKCW, ETIXQV, None, TYEKCW, QBMJVH
-            ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, SEMCGE, RYXBQF, ETIXQV, None, TYEKCW, QBMJVH
-            ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, SEMCGE, UNXNKM, BXIBHZ, None, XIBHZV, QBMJVH
-            ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, SEMCGE, STSEMC, ZVOACM, None, TYEKCW, QBMJVH
-            ),
-            JLOINE: GeckoBoolStructAccessor(
-                self.struct, JLOINE, LOINEL, MNZMJI, QBMJVH
-            ),
-            OINELW: GeckoEnumStructAccessor(
-                self.struct, OINELW, LOINEL, TYEKCW, ELWUEU, None, UNXNKM, QBMJVH
-            ),
-            LWUEUH: GeckoBoolStructAccessor(
-                self.struct, LWUEUH, LOINEL, UNXNKM, QBMJVH
-            ),
-            WUEUHN: GeckoEnumStructAccessor(
-                self.struct, WUEUHN, LOINEL, AKSTSE, UHNNXW, None, UNXNKM, QBMJVH
-            ),
-            HNNXWE: GeckoByteStructAccessor(self.struct, HNNXWE, NNXWEE, QBMJVH),
-            NXWEEZ: GeckoBoolStructAccessor(
-                self.struct, NXWEEZ, UTYEKC, FJTACC, QBMJVH
-            ),
-            XWEEZF: GeckoByteStructAccessor(self.struct, XWEEZF, WEEZFE, QBMJVH),
-            EEZFET: GeckoEnumStructAccessor(
-                self.struct, EEZFET, EZFETD, None, ETDRXA, None, None, QBMJVH
-            ),
-            TDRXAI: GeckoEnumStructAccessor(
-                self.struct, TDRXAI, DRXAIV, None, XAIVEM, None, None, QBMJVH
-            ),
-            AIVEMV: GeckoEnumStructAccessor(
-                self.struct, AIVEMV, IVEMVC, FJTACC, WONFZC, None, XIBHZV, QBMJVH
-            ),
-            ONFZCZ: GeckoBoolStructAccessor(
-                self.struct, ONFZCZ, IVEMVC, STSEMC, QBMJVH
-            ),
-            NFZCZO: GeckoByteStructAccessor(self.struct, NFZCZO, FZCZOL, QBMJVH),
-            ZCZOLS: GeckoWordStructAccessor(self.struct, ZCZOLS, CZOLSI, QBMJVH),
-            ZOLSIP: GeckoWordStructAccessor(self.struct, ZOLSIP, OLSIPM, QBMJVH),
-            LSIPMD: GeckoWordStructAccessor(self.struct, LSIPMD, SIPMDM, QBMJVH),
-            IPMDMP: GeckoWordStructAccessor(self.struct, IPMDMP, PMDMPS, QBMJVH),
-            MDMPSC: GeckoWordStructAccessor(self.struct, MDMPSC, DMPSCT, QBMJVH),
-            MPSCTT: GeckoWordStructAccessor(self.struct, MPSCTT, PSCTTG, QBMJVH),
-            SCTTGC: GeckoWordStructAccessor(self.struct, SCTTGC, CTTGCR, QBMJVH),
-            TTGCRH: GeckoWordStructAccessor(self.struct, TTGCRH, TGCRHY, QBMJVH),
-            GCRHYU: GeckoWordStructAccessor(self.struct, GCRHYU, CRHYUA, QBMJVH),
-            RHYUAX: GeckoWordStructAccessor(self.struct, RHYUAX, HYUAXN, QBMJVH),
-            YUAXNC: GeckoEnumStructAccessor(
-                self.struct, YUAXNC, UAXNCU, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            NCUGUC: GeckoEnumStructAccessor(
-                self.struct, NCUGUC, UAXNCU, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            UCYRAP: GeckoEnumStructAccessor(
-                self.struct, UCYRAP, CYRAPU, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, CYRAPU, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            RAPUME: GeckoEnumStructAccessor(
-                self.struct, RAPUME, APUMEA, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            PUMEAO: GeckoEnumStructAccessor(
-                self.struct, PUMEAO, APUMEA, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            UMEAOE: GeckoEnumStructAccessor(
-                self.struct, UMEAOE, MEAOES, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            EAOESV: GeckoEnumStructAccessor(
-                self.struct, EAOESV, MEAOES, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            AOESVZ: GeckoEnumStructAccessor(
-                self.struct, AOESVZ, OESVZS, FJTACC, SSBVNA, None, XIBHZV, None
-            ),
-            SBVNAX: GeckoBoolStructAccessor(self.struct, SBVNAX, OESVZS, STSEMC, None),
-            BVNAXA: GeckoBoolStructAccessor(self.struct, BVNAXA, UAXNCU, UNXNKM, None),
-            VNAXAD: GeckoBoolStructAccessor(self.struct, VNAXAD, UAXNCU, XNKMLO, None),
-            NAXADX: GeckoBoolStructAccessor(self.struct, NAXADX, UAXNCU, AKSTSE, None),
-            AXADXL: GeckoBoolStructAccessor(self.struct, AXADXL, UAXNCU, STSEMC, None),
-            XADXLU: GeckoBoolStructAccessor(self.struct, XADXLU, CYRAPU, UNXNKM, None),
-            ADXLUB: GeckoBoolStructAccessor(self.struct, ADXLUB, CYRAPU, XNKMLO, None),
-            DXLUBG: GeckoBoolStructAccessor(self.struct, DXLUBG, CYRAPU, AKSTSE, None),
-            XLUBGJ: GeckoBoolStructAccessor(self.struct, XLUBGJ, CYRAPU, STSEMC, None),
-            LUBGJF: GeckoBoolStructAccessor(self.struct, LUBGJF, APUMEA, UNXNKM, None),
-            UBGJFJ: GeckoBoolStructAccessor(self.struct, UBGJFJ, APUMEA, XNKMLO, None),
-            BGJFJN: GeckoBoolStructAccessor(self.struct, BGJFJN, APUMEA, AKSTSE, None),
-            GJFJNT: GeckoBoolStructAccessor(self.struct, GJFJNT, APUMEA, STSEMC, None),
-            JFJNTT: GeckoBoolStructAccessor(self.struct, JFJNTT, MEAOES, UNXNKM, None),
-            FJNTTU: GeckoBoolStructAccessor(self.struct, FJNTTU, MEAOES, XNKMLO, None),
-            JNTTUV: GeckoBoolStructAccessor(self.struct, JNTTUV, MEAOES, AKSTSE, None),
-            NTTUVR: GeckoBoolStructAccessor(self.struct, NTTUVR, MEAOES, STSEMC, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-65.py
+++ b/src/geckolib/driver/packs/inyt-cfg-65.py
@@ -12,1671 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 45
-ACMCVD = 7
-ACQFFT = 114
-ADXLUB = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-AFIKJP = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-AOAWBS = 58
-AOESVZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-AONPYY = 23
-APUMEA = 143
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AWBSIR = 59
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-BDFSRO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-BDJQRJ = 87
-BEKBDF = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BFEGZU = "".join(chr(c) for c in [70, 51])
-BGJFJN = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-BHZVOA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BIAMJM = "".join(chr(c) for c in [76, 111])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-BLKXSJ = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BMIKGN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 78
-BQNRXC = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-BQSNQL = "".join(chr(c) for c in [70])
-BSIRYX = 60
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BVNAXA = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BWJYKL = 32
-BXIBHZ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BXYBQS = 1
-BYGDSB = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-CBFEGZ = "".join(chr(c) for c in [70, 50])
-CCPQIP = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CHWDAF = 72
-CMCVDS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CPOUBM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-CPQIPO = 46
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-CRHYUA = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-CRTFMN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-CTHBSK = 39
-CTTGCR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-CUGUCY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 22
-CXQIEF = 14
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-CYWONF = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DDPMXF = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-DFSROG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-DGKEAK = 132
-DJQRJJ = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-DMPSCT = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-DNIBXT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-DNQGVU = 106
-DPMXFU = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-DRXAIV = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-DSBDJQ = 86
-DSSRUR = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DUBSSU = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-DXLUBG = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-DZXNQT = 75
-EAKSTS = "".join(chr(c) for c in [79, 70, 70])
-EAOESV = 147
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-EFJTAC = 43
-EFXQGL = 16
-EGZUQE = "".join(chr(c) for c in [70, 50, 50])
-EKBDFS = 111
-EKCWAO = 21
-EKVKZI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-ELHBQN = 10
-ELWUEU = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-EMCGET = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-EMVCYW = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-EOCTHB = 38
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-ETIXQV = 34
-EUHNNX = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-EUTOPH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-EZFETD = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-FCPOUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-FCRTFM = 92
-FEFJTA = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-FEGZUQ = "".join(chr(c) for c in [70, 50, 49])
-FETDRX = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-FFTTID = "".join(chr(c) for c in [85, 76])
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-FJNTTU = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-FJTACC = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FLSIJU = "".join(chr(c) for c in [51])
-FMNHTB = 94
-FOUURI = 65
-FSROGM = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 57
-FTTIDU = "".join(chr(c) for c in [67, 69])
-FUBJLO = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-FWRKIN = 29
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FZCZOL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FZDGKE = 130
-GCRHYU = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-GDSBDJ = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-GETIXQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-GJFJNT = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-GKEAKS = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GQPLSP = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-GSELHB = 8
-GTYIYW = 101
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-GVUNXN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-GYOUSP = 0
-GZUQEX = "".join(chr(c) for c in [70, 50, 51])
-HBQNRX = 71
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [56, 65])
-HNNXWE = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-HTBJEU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-HUGTYI = 100
-HUOJRJ = "".join(chr(c) for c in [50, 65])
-HWDAFI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-HYUAXN = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [72, 105])
-IBHZVO = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-IBXTIA = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IBXYBQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IDUBSS = 52
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IFJBIA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-IHBXIB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IIDNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-IJUGSE = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-IJUZMR = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-IKGNVF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-IKJPUN = 5
-ILXWAJ = 68
-INEJNI = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-INELWU = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-IPOUYN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-IRYXBQ = 61
-IUSOOQ = "".join(chr(c) for c in [57, 65])
-IUXFEF = 41
-IVDNQG = 105
-IVEMVC = 112
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [50, 52, 104])
-IYWSKW = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JBIAMJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JEUTOP = 97
-JFJNTT = 125
-JHIUSO = "".join(chr(c) for c in [55, 65])
-JIGYOU = "".join(chr(c) for c in [79, 119, 110])
-JJJVYF = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-JJVYFC = 90
-JLOINE = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-JMAOAW = 1
-JMCBFE = 163
-JNIBXY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JNTTUV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-JPUNRJ = 76
-JQRJJJ = 88
-JRJHIU = "".join(chr(c) for c in [53, 65])
-JTACCP = 44
-JUGSEL = 116
-JUIKFW = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-JUTYEK = 19
-JUZMRK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-JVDQLA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JWMNZM = 55
-JYKLGQ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-JZTATD = 73
-KBDFSR = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-KCWAON = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-KEAKST = 157
-KFWRKI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-KGNVFO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-KHTZBB = 8
-KINEJN = 30
-KJPUNR = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-KLGQPL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-KMLOIJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KPHUOJ = "".join(chr(c) for c in [48, 65])
-KQTDKH = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-KVFCPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-KVKZIL = 35
-KXSJWM = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KZILXW = 66
-LAIIDN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LHBQNR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LIUXFE = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-LJUIKF = 28
-LKXSJW = 80
-LNMHXE = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-LOIJUG = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LOINEL = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-LRAHEO = 36
-LSIJUZ = "".join(chr(c) for c in [52])
-LSIPMD = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-LSPFTS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-LSXUJU = 17
-LUBGJF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-LWUEUH = "".join(chr(c) for c in [80, 68, 67])
-LXWAJV = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-MAOAWB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-MCBFEG = "".join(chr(c) for c in [70, 49])
-MCGETI = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-MCVDSS = 110
-MDDPMX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-MEAOES = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-MFZDGK = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-MHXEKV = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-MIKGNV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-MJIGYO = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-MJMAOA = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [66, 76, 85, 69])
-MLOIJU = 4
-MNHTBJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-MNZMJI = 56
-MOUNBL = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-MPSCTT = 134
-MRKVFC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-MVCYWO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-MXFUBJ = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-NAXADX = "".join(chr(c) for c in [82, 71, 66])
-NCUGUC = 136
-NEJNIB = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-NELWUE = "".join(chr(c) for c in [77, 65, 65, 88])
-NHTBJE = 95
-NIBXTI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NIBXYB = 63
-NKMLOI = 3
-NMHXEK = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-NNXWEE = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-NPYYLI = 24
-NQGVUN = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-NQJYMO = 119
-NQLNMH = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NRSJMC = "".join(chr(c) for c in [49, 53, 65])
-NRXCHW = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NTTUVR = 126
-NXNKML = 109
-NXWEEZ = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-NZMJIG = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-OACMCV = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-OAWBSI = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = 149
-OGMDDP = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OIHBXI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-OIJUGS = 6
-OINELW = "".join(chr(c) for c in [76, 65])
-OJRJHI = "".join(chr(c) for c in [52, 65])
-OKPHUO = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-OLSIPM = 121
-ONFZCZ = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-ONPYYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-OOQNRS = "".join(chr(c) for c in [49, 50, 65])
-OPHUGT = 99
-OQNRSJ = "".join(chr(c) for c in [49, 51, 65])
-OUBMIK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-OUNBLK = 79
-OUSPBW = 118
-OUYNQJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-PBWJYK = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-PFTSIF = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-PHUGTY = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-PHUOJR = "".join(chr(c) for c in [49, 65])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-PMDMPS = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-PMXFUB = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-POUBMI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-POUYNQ = 48
-PQIPOU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-PSCTTG = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-PUMEAO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-PUNRJZ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-QFFTTI = 51
-QFYLJU = "".join(chr(c) for c in [80, 49])
-QGVUNX = 107
-QIEFXQ = 15
-QIPOUY = 47
-QJYMOU = 2
-QLAIID = 115
-QLNMHX = 31
-QNRSJM = "".join(chr(c) for c in [49, 52, 65])
-QPLSPF = 27
-QRJJJV = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QSNQLN = "".join(chr(c) for c in [67])
-QTDKHT = "".join(chr(c) for c in [67, 89, 65, 78])
-QTMFZD = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-QVXOIH = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-RAZMKQ = "".join(chr(c) for c in [82, 69, 68])
-RFLSIJ = "".join(chr(c) for c in [50])
-RHYUAX = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-RJHIUS = "".join(chr(c) for c in [54, 65])
-RJJJVY = 89
-RJZTAT = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-RKINEJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-RKVFCP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-ROGMDD = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-RTFMNH = 93
-RURAZM = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RXAIVE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-RXCHWD = 82
-RYXBQF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-SBVNAX = 155
-SELHBQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-SIFJBI = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-SIPMDM = 133
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SJMCBF = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-SJWMNZ = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SKSOKP = 50
-SKWIVD = 104
-SOKPHU = 161
-SOOQNR = "".join(chr(c) for c in [49, 49, 65])
-SPBWJY = 120
-SROGMD = "".join(chr(c) for c in [65, 108, 112, 115])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-SSRURA = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-SSUHBV = 122
-STSEMC = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SUHBVW = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-SVZSSB = 151
-SXUJUT = "".join(chr(c) for c in [79, 117, 116, 55])
-TACCPQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-TATDZX = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-TBJEUT = 96
-TDKHTZ = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TDRXAI = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-TDZXNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TFMNHT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-TGCRHY = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 162
-TIDUBS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-TIXQVX = "".join(chr(c) for c in [65, 109, 80, 109])
-TMFZDG = 128
-TOPHUG = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-TSEMCG = 158
-TSIFJB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TTGCRH = 135
-TTUVRF = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-TUVRFL = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-TYEKCW = 20
-TYIYWS = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-TZBBEK = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-UBGJFJ = 124
-UBJLOI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-UBMIKG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-UBSSUH = 53
-UBYGDS = 84
-UCYRAP = 139
-UEUHNN = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-UGSELH = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-UGTYIY = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-UGUCYR = 137
-UHBVWV = 74
-UHNNXW = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UIKFWR = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-UJUTYE = "".join(chr(c) for c in [79, 117, 116, 56])
-UMEAOE = 145
-UNBLKX = "".join(chr(c) for c in [76, 73])
-UNRJZT = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-UNXNKM = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-UOJRJH = "".join(chr(c) for c in [51, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-URAZMK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-USOOQN = "".join(chr(c) for c in [49, 48, 65])
-USPBWJ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-UTOPHU = 98
-UTYEKC = "".join(chr(c) for c in [79, 117, 116, 57])
-UVRFLS = 127
-UXFEFJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-UYNQJY = 49
-UZMRKV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-VDNQGV = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-VDQLAI = 77
-VDSSRU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-VEMVCY = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-VFCPOU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = 123
-VOACMC = 6
-VRFLSI = "".join(chr(c) for c in [49])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-VUNXNK = 108
-VWVUBY = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-VXOIHB = 64
-VYFCRT = 91
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-WAJVDQ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-WAONPY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WDAFIK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-WEEZFE = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-WIVDNQ = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-WJYKLG = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-WMNZMJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-WONFZC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-WSKWIV = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-WUEUHN = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WVUBYG = 83
-XADXLU = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-XBQFYL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-XEKVKZ = 3
-XFEFJT = 42
-XFUBJL = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XIBHZV = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 54])
-XNCUGU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-XNQTMF = 160
-XOIHBX = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = 54
-XTIACQ = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-XUJUTY = 18
-XWAJVD = 70
-XWEEZF = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-XYBQSN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YBQSNQ = 33
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-YFCRTF = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-YGDSBD = 85
-YIYWSK = 102
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-YLIUXF = 25
-YLJUIK = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YMOUNB = 4
-YNQJYM = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = 141
-YUAXNC = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-YWONFZ = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-YWSKWI = 103
-YXBQFY = 62
-YYLIUX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = 113
-ZDGKEA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZFETDR = "".join(chr(c) for c in [73, 100, 111, 108])
-ZILXWA = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZMJIGY = 81
-ZMKQTD = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-ZMRKVF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-ZOLSIP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-ZSSBVN = 153
-ZTATDZ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-ZUQEXL = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-ZVOACM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-ZXNQTM = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-AJVDQL = [INEJNI, WAJVDQ]
-AMJMAO = [BIAMJM, IAMJMA]
-ATDZXN = [VLASSA, ZTATDZ, TATDZX]
-AXADXL = [NAXADX, TDKHTZ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BVWVUB = [INEJNI, HBVWVU]
-BXTIAC = [LAIIDN, AIIDNI, IIDNIB, IDNIBX, DNIBXT, NIBXTI, IBXTIA]
-CGETIX = [EMCGET, MCGETI]
-DKHTZB = [EAKSTS, RAZMKQ, AZMKQT, ZMKQTD, MKQTDK, KQTDKH, QTDKHT, TDKHTZ]
-EJNIBX = [INEJNI, NEJNIB]
-EXLSXU = [MCBFEG, CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX]
-FJBIAM = [TSIFJB, SIFJBI, IFJBIA]
-FYLJUI = [JVHFTH, QFYLJU, PIPIVL]
-GNVFOU = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    SJMCBF,
-    XLSXUJ,
-    SXUJUT,
-    UJUTYE,
-    UTYEKC,
-    YEKCWA,
-    KCWAON,
-    WAONPY,
-    ONPYYL,
-    YYLIUX,
-    MOUNBL,
-]
-HBXIBH = [OIHBXI, IHBXIB]
-HXEKVK = [NMHXEK, MHXEKV]
-HZVOAC = [IBHZVO, BHZVOA]
-IGYOUS = [MJIGYO, JIGYOU]
-IKFWRK = [JUIKFW, UIKFWR]
-KSTSEM = [JVHFTH, EAKSTS, VLASSA, AKSTSE]
-KWIVDN = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, ZUQEXL, UQEXLS, QEXLSX]
-LGQPLS = [WJYKLG, JYKLGQ, YKLGQP, KLGQPL]
-MDMPSC = [IPMDMP, PMDMPS]
-NBLKXS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    UNBLKX,
-]
-NFZCZO = [JVHFTH, WONFZC, ONFZCZ, VLASSA]
-NQTMFZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KQXPIC,
-]
-NRJZTA = [PUNRJZ, UNRJZT]
-NVFOUU = [UNBLKX]
-PYYLIU = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QNRXCH = [JVHFTH, PLSPFT, BQNRXC]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-RSJMCB = [
-    OKPHUO,
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-]
-SCTTGC = [PSCTTG]
-SIJUZM = [VLASSA, VRFLSI, RFLSIJ, FLSIJU, LSIJUZ]
-SNQLNM = [BQSNQL, QSNQLN]
-SPFTSI = [PLSPFT, LSPFTS]
-SRURAZ = [DSSRUR, SSRURA]
-TTIDUB = [FFTTID, FTTIDU]
-UAXNCU = [TGCRHY, GCRHYU, CRHYUA, RHYUAX, HYUAXN, YUAXNC, VLASSA, VLASSA]
-VCYWON = [EMVCYW, MVCYWO, VLASSA, VLASSA]
-VFOUUR = []
-WRKINE = [PIPIVL, QFYLJU]
-XAIVEM = [
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-    DDPMXF,
-    DPMXFU,
-    PMXFUB,
-    MXFUBJ,
-    XFUBJL,
-    FUBJLO,
-    UBJLOI,
-    BJLOIN,
-    JLOINE,
-    LOINEL,
-    OINELW,
-    INELWU,
-    NELWUE,
-    ELWUEU,
-    LWUEUH,
-    WUEUHN,
-    UEUHNN,
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-]
-XLUBGJ = [ADXLUB, DXLUBG]
-XQVXOI = [JVHFTH, TIXQVX, IXQVXO]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1684,402 +19,1452 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return FOUURI
+        return 65
 
     @property
     def output_keys(self):
-        return GNVFOU
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, RSJMCB, None, None, QBMJVH
-            ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, QXPICX, None, None, QBMJVH
-            ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, QXPICX, None, None, QBMJVH
-            ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, QXPICX, None, None, QBMJVH
-            ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, TYEKCW, None, QXPICX, None, None, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, QXPICX, None, None, QBMJVH
-            ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, QXPICX, None, None, QBMJVH
-            ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, QXPICX, None, None, QBMJVH
-            ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, PYYLIU, None, None, QBMJVH
-            ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, None, PYYLIU, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoBoolStructAccessor(
-                self.struct, YNQJYM, NQJYMO, QJYMOU, QBMJVH
-            ),
-            JYMOUN: GeckoBoolStructAccessor(
-                self.struct, JYMOUN, NQJYMO, YMOUNB, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, NBLKXS, None, None, None
-            ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, GYOUSP, IGYOUS, None, QJYMOU, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, LGQPLS, None, None, QBMJVH
-            ),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, ZMJIGY, QJYMOU, AMJMAO, None, QJYMOU, QBMJVH
-            ),
-            MJMAOA: GeckoBoolStructAccessor(
-                self.struct, MJMAOA, NQJYMO, JMAOAW, QBMJVH
-            ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoByteStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoByteStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FYLJUI, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, WRKINE, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTempStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, SNQLNM, None, None, QBMJVH
-            ),
-            NQLNMH: GeckoEnumStructAccessor(
-                self.struct, NQLNMH, QLNMHX, None, WRKINE, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, ZMJIGY, XEKVKZ, HXEKVK, None, QJYMOU, QBMJVH
-            ),
-            EKVKZI: GeckoByteStructAccessor(self.struct, EKVKZI, KVKZIL, QBMJVH),
-            VKZILX: GeckoTempStructAccessor(self.struct, VKZILX, KZILXW, QBMJVH),
-            ZILXWA: GeckoTempStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, EXLSXU, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, EXLSXU, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, EXLSXU, None, None, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, EXLSXU, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, EXLSXU, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, EXLSXU, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, EXLSXU, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoEnumStructAccessor(
-                self.struct, YFCRTF, FCRTFM, None, EXLSXU, None, None, QBMJVH
-            ),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, EXLSXU, None, None, QBMJVH
-            ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, EXLSXU, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, EXLSXU, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, EXLSXU, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, EXLSXU, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoByteStructAccessor(self.struct, EUTOPH, UTOPHU, QBMJVH),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, QBMJVH),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, QBMJVH),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, QBMJVH),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, QBMJVH),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, QBMJVH),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, KWIVDN, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, KWIVDN, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, KWIVDN, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, KWIVDN, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, KWIVDN, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoTimeStructAccessor(self.struct, KMLOIJ, MLOIJU, QBMJVH),
-            LOIJUG: GeckoTimeStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoTimeStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoTimeStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoTimeStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, QNRXCH, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, RXCHWD, GYOUSP, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, QJYMOU, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, CHWDAF, GYOUSP, QBMJVH
-            ),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, CHWDAF, JMAOAW, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, CHWDAF, XEKVKZ, QBMJVH
-            ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, CHWDAF, YMOUNB, QBMJVH
-            ),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, CHWDAF, IKJPUN, QBMJVH
-            ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, None, ATDZXN, None, None, QBMJVH
-            ),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, QBMJVH),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, XNQTMF, None, NQTMFZ, None, None, QBMJVH
-            ),
-            QTMFZD: GeckoTimeStructAccessor(self.struct, QTMFZD, TMFZDG, QBMJVH),
-            MFZDGK: GeckoTimeStructAccessor(self.struct, MFZDGK, FZDGKE, QBMJVH),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, QBMJVH),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, KEAKST, None, KSTSEM, None, None, QBMJVH
-            ),
-            STSEMC: GeckoTimeStructAccessor(self.struct, STSEMC, TSEMCG, QBMJVH),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, NQJYMO, XEKVKZ, CGETIX, None, QJYMOU, QBMJVH
-            ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, XQVXOI, None, None, QBMJVH
-            ),
-            QVXOIH: GeckoWordStructAccessor(self.struct, QVXOIH, VXOIHB, QBMJVH),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, ZMJIGY, JMAOAW, HBXIBH, None, QJYMOU, QBMJVH
-            ),
-            BXIBHZ: GeckoBoolStructAccessor(
-                self.struct, BXIBHZ, ZMJIGY, YMOUNB, QBMJVH
-            ),
-            XIBHZV: GeckoEnumStructAccessor(
-                self.struct, XIBHZV, ZMJIGY, IKJPUN, HZVOAC, None, QJYMOU, QBMJVH
-            ),
-            ZVOACM: GeckoBoolStructAccessor(
-                self.struct, ZVOACM, ZMJIGY, VOACMC, QBMJVH
-            ),
-            OACMCV: GeckoBoolStructAccessor(
-                self.struct, OACMCV, ZMJIGY, ACMCVD, QBMJVH
-            ),
-            CMCVDS: GeckoBoolStructAccessor(
-                self.struct, CMCVDS, MCVDSS, GYOUSP, QBMJVH
-            ),
-            CVDSSR: GeckoBoolStructAccessor(
-                self.struct, CVDSSR, MCVDSS, JMAOAW, QBMJVH
-            ),
-            VDSSRU: GeckoEnumStructAccessor(
-                self.struct, VDSSRU, MCVDSS, QJYMOU, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, MCVDSS, XEKVKZ, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, MCVDSS, YMOUNB, DKHTZB, None, KHTZBB, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MCVDSS, ACMCVD, BBEKBD, None, QJYMOU, QBMJVH
-            ),
-            AIVEMV: GeckoBoolStructAccessor(
-                self.struct, AIVEMV, IVEMVC, JMAOAW, QBMJVH
-            ),
-            VEMVCY: GeckoEnumStructAccessor(
-                self.struct, VEMVCY, IVEMVC, QJYMOU, VCYWON, None, YMOUNB, QBMJVH
-            ),
-            CYWONF: GeckoBoolStructAccessor(
-                self.struct, CYWONF, IVEMVC, YMOUNB, QBMJVH
-            ),
-            YWONFZ: GeckoEnumStructAccessor(
-                self.struct, YWONFZ, IVEMVC, VOACMC, NFZCZO, None, YMOUNB, QBMJVH
-            ),
-            FZCZOL: GeckoByteStructAccessor(self.struct, FZCZOL, ZCZOLS, QBMJVH),
-            CZOLSI: GeckoBoolStructAccessor(
-                self.struct, CZOLSI, NQJYMO, GYOUSP, QBMJVH
-            ),
-            ZOLSIP: GeckoByteStructAccessor(self.struct, ZOLSIP, OLSIPM, QBMJVH),
-            LSIPMD: GeckoEnumStructAccessor(
-                self.struct, LSIPMD, SIPMDM, None, MDMPSC, None, None, QBMJVH
-            ),
-            DMPSCT: GeckoEnumStructAccessor(
-                self.struct, DMPSCT, MPSCTT, None, SCTTGC, None, None, QBMJVH
-            ),
-            CTTGCR: GeckoEnumStructAccessor(
-                self.struct, CTTGCR, TTGCRH, GYOUSP, UAXNCU, None, KHTZBB, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, TTGCRH, ACMCVD, QBMJVH
-            ),
-            XNCUGU: GeckoByteStructAccessor(self.struct, XNCUGU, NCUGUC, QBMJVH),
-            CUGUCY: GeckoWordStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoWordStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoWordStructAccessor(self.struct, CYRAPU, YRAPUM, QBMJVH),
-            RAPUME: GeckoWordStructAccessor(self.struct, RAPUME, APUMEA, QBMJVH),
-            PUMEAO: GeckoWordStructAccessor(self.struct, PUMEAO, UMEAOE, QBMJVH),
-            MEAOES: GeckoWordStructAccessor(self.struct, MEAOES, EAOESV, QBMJVH),
-            AOESVZ: GeckoWordStructAccessor(self.struct, AOESVZ, OESVZS, QBMJVH),
-            ESVZSS: GeckoWordStructAccessor(self.struct, ESVZSS, SVZSSB, QBMJVH),
-            VZSSBV: GeckoWordStructAccessor(self.struct, VZSSBV, ZSSBVN, QBMJVH),
-            SSBVNA: GeckoWordStructAccessor(self.struct, SSBVNA, SBVNAX, QBMJVH),
-            BVNAXA: GeckoEnumStructAccessor(
-                self.struct, BVNAXA, VNAXAD, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, VNAXAD, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            LUBGJF: GeckoEnumStructAccessor(
-                self.struct, LUBGJF, UBGJFJ, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            BGJFJN: GeckoEnumStructAccessor(
-                self.struct, BGJFJN, UBGJFJ, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            GJFJNT: GeckoEnumStructAccessor(
-                self.struct, GJFJNT, JFJNTT, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            FJNTTU: GeckoEnumStructAccessor(
-                self.struct, FJNTTU, JFJNTT, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            JNTTUV: GeckoEnumStructAccessor(
-                self.struct, JNTTUV, NTTUVR, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            TTUVRF: GeckoEnumStructAccessor(
-                self.struct, TTUVRF, NTTUVR, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            TUVRFL: GeckoEnumStructAccessor(
-                self.struct, TUVRFL, UVRFLS, GYOUSP, SIJUZM, None, KHTZBB, None
-            ),
-            IJUZMR: GeckoBoolStructAccessor(self.struct, IJUZMR, UVRFLS, ACMCVD, None),
-            JUZMRK: GeckoBoolStructAccessor(self.struct, JUZMRK, VNAXAD, YMOUNB, None),
-            UZMRKV: GeckoBoolStructAccessor(self.struct, UZMRKV, VNAXAD, IKJPUN, None),
-            ZMRKVF: GeckoBoolStructAccessor(self.struct, ZMRKVF, VNAXAD, VOACMC, None),
-            MRKVFC: GeckoBoolStructAccessor(self.struct, MRKVFC, VNAXAD, ACMCVD, None),
-            RKVFCP: GeckoBoolStructAccessor(self.struct, RKVFCP, UBGJFJ, YMOUNB, None),
-            KVFCPO: GeckoBoolStructAccessor(self.struct, KVFCPO, UBGJFJ, IKJPUN, None),
-            VFCPOU: GeckoBoolStructAccessor(self.struct, VFCPOU, UBGJFJ, VOACMC, None),
-            FCPOUB: GeckoBoolStructAccessor(self.struct, FCPOUB, UBGJFJ, ACMCVD, None),
-            CPOUBM: GeckoBoolStructAccessor(self.struct, CPOUBM, JFJNTT, YMOUNB, None),
-            POUBMI: GeckoBoolStructAccessor(self.struct, POUBMI, JFJNTT, IKJPUN, None),
-            OUBMIK: GeckoBoolStructAccessor(self.struct, OUBMIK, JFJNTT, VOACMC, None),
-            UBMIKG: GeckoBoolStructAccessor(self.struct, UBMIKG, JFJNTT, ACMCVD, None),
-            BMIKGN: GeckoBoolStructAccessor(self.struct, BMIKGN, NTTUVR, YMOUNB, None),
-            MIKGNV: GeckoBoolStructAccessor(self.struct, MIKGNV, NTTUVR, IKJPUN, None),
-            IKGNVF: GeckoBoolStructAccessor(self.struct, IKGNVF, NTTUVR, VOACMC, None),
-            KGNVFO: GeckoBoolStructAccessor(self.struct, KGNVFO, NTTUVR, ACMCVD, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-66.py
+++ b/src/geckolib/driver/packs/inyt-cfg-66.py
@@ -12,1764 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 45
-ACMCVD = 7
-ACQFFT = 114
-ADXLUB = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-AFIKJP = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-AOAWBS = 58
-AOESVZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-AONPYY = 23
-APUMEA = 143
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AWBSIR = 59
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-BDFSRO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-BDJQRJ = 87
-BEKBDF = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BFEGZU = "".join(chr(c) for c in [70, 51])
-BGJFJN = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-BHZVOA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BIAMJM = "".join(chr(c) for c in [76, 111])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-BLKXSJ = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BMIKGN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 78
-BQNRXC = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-BQSNQL = "".join(chr(c) for c in [70])
-BSIRYX = 60
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BVNAXA = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BWJYKL = 32
-BXIBHZ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BXYBQS = 1
-BYGDSB = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-CBFEGZ = "".join(chr(c) for c in [70, 50])
-CCPQIP = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CHWDAF = 72
-CMCVDS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CPOUBM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-CPQIPO = 46
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-CRHYUA = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-CRTFMN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-CTHBSK = 39
-CTTGCR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-CUGUCY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 22
-CXQIEF = 14
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-CYWONF = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DDPMXF = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-DFSROG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-DGKEAK = 132
-DJQRJJ = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-DMPSCT = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-DNIBXT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-DNQGVU = 106
-DPMXFU = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-DRXAIV = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-DSBDJQ = 86
-DSSRUR = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DUBSSU = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-DXLUBG = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-DZXNQT = 75
-EAKSTS = "".join(chr(c) for c in [79, 70, 70])
-EAOESV = 147
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-EFJTAC = 43
-EFXQGL = 16
-EGZUQE = "".join(chr(c) for c in [70, 50, 50])
-EKBDFS = 111
-EKCWAO = 21
-EKVKZI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-ELHBQN = 10
-ELWUEU = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-EMCGET = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-EMVCYW = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-EOCTHB = 38
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-ETIXQV = 34
-EUHNNX = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-EUTOPH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-EZFETD = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-FCPOUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-FCRTFM = 92
-FEFJTA = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-FEGZUQ = "".join(chr(c) for c in [70, 50, 49])
-FETDRX = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-FFTTID = "".join(chr(c) for c in [85, 76])
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-FJNTTU = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-FJTACC = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FLSIJU = "".join(chr(c) for c in [51])
-FMNHTB = 94
-FOUURI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-FSROGM = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 57
-FTTIDU = "".join(chr(c) for c in [67, 69])
-FUBJLO = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-FWRKIN = 29
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FZCZOL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FZDGKE = 130
-GCRHYU = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-GDSBDJ = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-GETIXQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-GJFJNT = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-GKEAKS = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GNVFOU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-GQPLSP = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-GSELHB = 8
-GTYIYW = 101
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-GVUNXN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-GYOUSP = 0
-GZUQEX = "".join(chr(c) for c in [70, 50, 51])
-HBQNRX = 71
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [56, 65])
-HNNXWE = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-HTBJEU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-HUGTYI = 100
-HUOJRJ = "".join(chr(c) for c in [50, 65])
-HWDAFI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-HYUAXN = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [72, 105])
-IBHZVO = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-IBXTIA = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IBXYBQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IDUBSS = 52
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IEVBVH = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-IFJBIA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-IHBXIB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IIDNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-IJUGSE = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-IJUZMR = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-IKGNVF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-IKJPUN = 5
-ILXWAJ = 68
-INEJNI = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-INELWU = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-IPOUYN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-IRYXBQ = 61
-IUSOOQ = "".join(chr(c) for c in [57, 65])
-IUXFEF = 41
-IVDNQG = 105
-IVEMVC = 112
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [50, 52, 104])
-IYWSKW = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JBIAMJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JEUTOP = 97
-JFJNTT = 125
-JHIUSO = "".join(chr(c) for c in [55, 65])
-JIGYOU = "".join(chr(c) for c in [79, 119, 110])
-JJJVYF = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-JJVYFC = 90
-JLOINE = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-JMAOAW = 1
-JMCBFE = 163
-JNIBXY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JNTTUV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-JPUNRJ = 76
-JQRJJJ = 88
-JRJHIU = "".join(chr(c) for c in [53, 65])
-JTACCP = 44
-JUGSEL = 116
-JUIKFW = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-JUTYEK = 19
-JUZMRK = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-JVDQLA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JWMNZM = 55
-JYKLGQ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-JZTATD = 73
-KBDFSR = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-KCWAON = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-KEAKST = 157
-KFWRKI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-KGNVFO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-KHTZBB = 8
-KINEJN = 30
-KJPUNR = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-KLGQPL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-KMLOIJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KPHUOJ = "".join(chr(c) for c in [48, 65])
-KQTDKH = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-KVFCPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-KVKZIL = 35
-KXSJWM = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KZILXW = 66
-LAIIDN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LHBQNR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LIUXFE = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-LJUIKF = 28
-LKXSJW = 80
-LNMHXE = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-LOIJUG = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LOINEL = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-LRAHEO = 36
-LSIJUZ = "".join(chr(c) for c in [52])
-LSIPMD = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-LSPFTS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-LSXUJU = 17
-LUBGJF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-LWUEUH = "".join(chr(c) for c in [80, 68, 67])
-LXWAJV = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-MAOAWB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-MCBFEG = "".join(chr(c) for c in [70, 49])
-MCGETI = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-MCVDSS = 110
-MDDPMX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-MEAOES = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-MFZDGK = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-MHXEKV = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-MIKGNV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-MJIGYO = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-MJMAOA = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [66, 76, 85, 69])
-MLOIJU = 4
-MNHTBJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-MNZMJI = 56
-MOUNBL = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-MPSCTT = 134
-MRKVFC = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-MVCYWO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-MXFUBJ = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-NAXADX = "".join(chr(c) for c in [82, 71, 66])
-NCUGUC = 136
-NEJNIB = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-NELWUE = "".join(chr(c) for c in [77, 65, 65, 88])
-NHTBJE = 95
-NIBXTI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NIBXYB = 63
-NKMLOI = 3
-NMHXEK = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-NNXWEE = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-NPYYLI = 24
-NQGVUN = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-NQJYMO = 119
-NQLNMH = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NRSJMC = "".join(chr(c) for c in [49, 53, 65])
-NRXCHW = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NTTUVR = 126
-NVFOUU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-NXNKML = 109
-NXWEEZ = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-NZMJIG = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-OACMCV = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-OAWBSI = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = 149
-OGMDDP = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OIHBXI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-OIJUGS = 6
-OINELW = "".join(chr(c) for c in [76, 65])
-OJRJHI = "".join(chr(c) for c in [52, 65])
-OKPHUO = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-OLSIPM = 121
-ONFZCZ = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-ONPYYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-OOQNRS = "".join(chr(c) for c in [49, 50, 65])
-OPHUGT = 99
-OQNRSJ = "".join(chr(c) for c in [49, 51, 65])
-OUBMIK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-OUNBLK = 79
-OUSPBW = 118
-OUURIE = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-PBWJYK = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-PFTSIF = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-PHUGTY = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-PHUOJR = "".join(chr(c) for c in [49, 65])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-PMDMPS = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-PMXFUB = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-POUBMI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-POUYNQ = 48
-PQIPOU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-PSCTTG = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-PUMEAO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-PUNRJZ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-QFFTTI = 51
-QFYLJU = "".join(chr(c) for c in [80, 49])
-QGVUNX = 107
-QIEFXQ = 15
-QIPOUY = 47
-QJYMOU = 2
-QLAIID = 115
-QLNMHX = 31
-QNRSJM = "".join(chr(c) for c in [49, 52, 65])
-QPLSPF = 27
-QRJJJV = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QSNQLN = "".join(chr(c) for c in [67])
-QTDKHT = "".join(chr(c) for c in [67, 89, 65, 78])
-QTMFZD = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-QVXOIH = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-RAZMKQ = "".join(chr(c) for c in [82, 69, 68])
-RFLSIJ = "".join(chr(c) for c in [50])
-RHYUAX = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-RJHIUS = "".join(chr(c) for c in [54, 65])
-RJJJVY = 89
-RJZTAT = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-RKINEJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-RKVFCP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-ROGMDD = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-RTFMNH = 93
-RURAZM = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RXAIVE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-RXCHWD = 82
-RYXBQF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-SBVNAX = 155
-SELHBQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-SIFJBI = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-SIPMDM = 133
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SJMCBF = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-SJWMNZ = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SKSOKP = 50
-SKWIVD = 104
-SOKPHU = 161
-SOOQNR = "".join(chr(c) for c in [49, 49, 65])
-SPBWJY = 120
-SROGMD = "".join(chr(c) for c in [65, 108, 112, 115])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-SSRURA = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-SSUHBV = 122
-STSEMC = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SUHBVW = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-SVZSSB = 151
-SXUJUT = "".join(chr(c) for c in [79, 117, 116, 55])
-TACCPQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-TATDZX = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-TBJEUT = 96
-TDKHTZ = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TDRXAI = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-TDZXNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TFMNHT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-TGCRHY = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 162
-TIDUBS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-TIXQVX = "".join(chr(c) for c in [65, 109, 80, 109])
-TMFZDG = 128
-TOPHUG = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-TSEMCG = 158
-TSIFJB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TTGCRH = 135
-TTUVRF = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-TUVRFL = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-TYEKCW = 20
-TYIYWS = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-TZBBEK = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-UBGJFJ = 124
-UBJLOI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-UBMIKG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-UBSSUH = 53
-UBYGDS = 84
-UCYRAP = 139
-UEUHNN = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-UGSELH = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-UGTYIY = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-UGUCYR = 137
-UHBVWV = 74
-UHNNXW = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UIKFWR = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-UJUTYE = "".join(chr(c) for c in [79, 117, 116, 56])
-UMEAOE = 145
-UNBLKX = "".join(chr(c) for c in [76, 73])
-UNRJZT = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-UNXNKM = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-UOJRJH = "".join(chr(c) for c in [51, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-URAZMK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-URIEVB = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-USOOQN = "".join(chr(c) for c in [49, 48, 65])
-USPBWJ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-UTOPHU = 98
-UTYEKC = "".join(chr(c) for c in [79, 117, 116, 57])
-UURIEV = 164
-UVRFLS = 127
-UXFEFJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-UYNQJY = 49
-UZMRKV = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-VDNQGV = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-VDQLAI = 77
-VDSSRU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-VEMVCY = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-VFCPOU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-VFOUUR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-VHDVRI = 66
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = 123
-VOACMC = 6
-VRFLSI = "".join(chr(c) for c in [49])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-VUNXNK = 108
-VWVUBY = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-VXOIHB = 64
-VYFCRT = 91
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-WAJVDQ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-WAONPY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WDAFIK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-WEEZFE = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-WIVDNQ = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-WJYKLG = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-WMNZMJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-WONFZC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-WSKWIV = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-WUEUHN = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WVUBYG = 83
-XADXLU = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-XBQFYL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-XEKVKZ = 3
-XFEFJT = 42
-XFUBJL = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XIBHZV = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 54])
-XNCUGU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-XNQTMF = 160
-XOIHBX = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = 54
-XTIACQ = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-XUJUTY = 18
-XWAJVD = 70
-XWEEZF = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-XYBQSN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YBQSNQ = 33
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-YFCRTF = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-YGDSBD = 85
-YIYWSK = 102
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-YLIUXF = 25
-YLJUIK = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YMOUNB = 4
-YNQJYM = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = 141
-YUAXNC = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-YWONFZ = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-YWSKWI = 103
-YXBQFY = 62
-YYLIUX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = 113
-ZDGKEA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZFETDR = "".join(chr(c) for c in [73, 100, 111, 108])
-ZILXWA = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZMJIGY = 81
-ZMKQTD = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-ZOLSIP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-ZSSBVN = 153
-ZTATDZ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-ZUQEXL = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-ZVOACM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-ZXNQTM = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-AJVDQL = [INEJNI, WAJVDQ]
-AMJMAO = [BIAMJM, IAMJMA]
-ATDZXN = [VLASSA, ZTATDZ, TATDZX]
-AXADXL = [NAXADX, TDKHTZ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BVHDVR = []
-BVWVUB = [INEJNI, HBVWVU]
-BXTIAC = [LAIIDN, AIIDNI, IIDNIB, IDNIBX, DNIBXT, NIBXTI, IBXTIA]
-CGETIX = [EMCGET, MCGETI]
-DKHTZB = [EAKSTS, RAZMKQ, AZMKQT, ZMKQTD, MKQTDK, KQTDKH, QTDKHT, TDKHTZ]
-EJNIBX = [INEJNI, NEJNIB]
-EVBVHD = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    SJMCBF,
-    XLSXUJ,
-    SXUJUT,
-    UJUTYE,
-    UTYEKC,
-    YEKCWA,
-    KCWAON,
-    WAONPY,
-    ONPYYL,
-    YYLIUX,
-    MOUNBL,
-]
-EXLSXU = [MCBFEG, CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX]
-FJBIAM = [TSIFJB, SIFJBI, IFJBIA]
-FYLJUI = [JVHFTH, QFYLJU, PIPIVL]
-HBXIBH = [OIHBXI, IHBXIB]
-HXEKVK = [NMHXEK, MHXEKV]
-HZVOAC = [IBHZVO, BHZVOA]
-IGYOUS = [MJIGYO, JIGYOU]
-IKFWRK = [JUIKFW, UIKFWR]
-KSTSEM = [JVHFTH, EAKSTS, VLASSA, AKSTSE]
-KWIVDN = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, ZUQEXL, UQEXLS, QEXLSX]
-LGQPLS = [WJYKLG, JYKLGQ, YKLGQP, KLGQPL]
-MDMPSC = [IPMDMP, PMDMPS]
-NBLKXS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    UNBLKX,
-]
-NFZCZO = [JVHFTH, WONFZC, ONFZCZ, VLASSA]
-NQTMFZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KQXPIC,
-]
-NRJZTA = [PUNRJZ, UNRJZT]
-PYYLIU = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QNRXCH = [JVHFTH, PLSPFT, BQNRXC]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-RIEVBV = [URIEVB, TDKHTZ, AZMKQT, JUZMRK, ZMKQTD, QTDKHT, UZMRKV, EAKSTS]
-RSJMCB = [
-    OKPHUO,
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-]
-SCTTGC = [PSCTTG]
-SIJUZM = [VLASSA, VRFLSI, RFLSIJ, FLSIJU, LSIJUZ]
-SNQLNM = [BQSNQL, QSNQLN]
-SPFTSI = [PLSPFT, LSPFTS]
-SRURAZ = [DSSRUR, SSRURA]
-TTIDUB = [FFTTID, FTTIDU]
-UAXNCU = [TGCRHY, GCRHYU, CRHYUA, RHYUAX, HYUAXN, YUAXNC, VLASSA, VLASSA]
-VBVHDV = [UNBLKX]
-VCYWON = [EMVCYW, MVCYWO, VLASSA, VLASSA]
-WRKINE = [PIPIVL, QFYLJU]
-XAIVEM = [
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-    DDPMXF,
-    DPMXFU,
-    PMXFUB,
-    MXFUBJ,
-    XFUBJL,
-    FUBJLO,
-    UBJLOI,
-    BJLOIN,
-    JLOINE,
-    LOINEL,
-    OINELW,
-    INELWU,
-    NELWUE,
-    ELWUEU,
-    LWUEUH,
-    WUEUHN,
-    UEUHNN,
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-]
-XLUBGJ = [ADXLUB, DXLUBG]
-XQVXOI = [JVHFTH, TIXQVX, IXQVXO]
-ZMRKVF = [MKQTDK, TDKHTZ, AZMKQT, JUZMRK, ZMKQTD, QTDKHT, UZMRKV, EAKSTS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1777,409 +19,1484 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return VHDVRI
+        return 66
 
     @property
     def output_keys(self):
-        return EVBVHD
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                164,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 164, 7, None
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, RSJMCB, None, None, QBMJVH
-            ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, QXPICX, None, None, QBMJVH
-            ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, QXPICX, None, None, QBMJVH
-            ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, QXPICX, None, None, QBMJVH
-            ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, TYEKCW, None, QXPICX, None, None, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, QXPICX, None, None, QBMJVH
-            ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, QXPICX, None, None, QBMJVH
-            ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, QXPICX, None, None, QBMJVH
-            ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, PYYLIU, None, None, QBMJVH
-            ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, None, PYYLIU, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoBoolStructAccessor(
-                self.struct, YNQJYM, NQJYMO, QJYMOU, QBMJVH
-            ),
-            JYMOUN: GeckoBoolStructAccessor(
-                self.struct, JYMOUN, NQJYMO, YMOUNB, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, NBLKXS, None, None, None
-            ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, GYOUSP, IGYOUS, None, QJYMOU, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, LGQPLS, None, None, QBMJVH
-            ),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, ZMJIGY, QJYMOU, AMJMAO, None, QJYMOU, QBMJVH
-            ),
-            MJMAOA: GeckoBoolStructAccessor(
-                self.struct, MJMAOA, NQJYMO, JMAOAW, QBMJVH
-            ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoByteStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoByteStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FYLJUI, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, WRKINE, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTempStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, SNQLNM, None, None, QBMJVH
-            ),
-            NQLNMH: GeckoEnumStructAccessor(
-                self.struct, NQLNMH, QLNMHX, None, WRKINE, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, ZMJIGY, XEKVKZ, HXEKVK, None, QJYMOU, QBMJVH
-            ),
-            EKVKZI: GeckoByteStructAccessor(self.struct, EKVKZI, KVKZIL, QBMJVH),
-            VKZILX: GeckoTempStructAccessor(self.struct, VKZILX, KZILXW, QBMJVH),
-            ZILXWA: GeckoTempStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, EXLSXU, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, EXLSXU, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, EXLSXU, None, None, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, EXLSXU, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, EXLSXU, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, EXLSXU, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, EXLSXU, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoEnumStructAccessor(
-                self.struct, YFCRTF, FCRTFM, None, EXLSXU, None, None, QBMJVH
-            ),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, EXLSXU, None, None, QBMJVH
-            ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, EXLSXU, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, EXLSXU, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, EXLSXU, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, EXLSXU, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoByteStructAccessor(self.struct, EUTOPH, UTOPHU, QBMJVH),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, QBMJVH),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, QBMJVH),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, QBMJVH),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, QBMJVH),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, QBMJVH),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, KWIVDN, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, KWIVDN, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, KWIVDN, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, KWIVDN, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, KWIVDN, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoTimeStructAccessor(self.struct, KMLOIJ, MLOIJU, QBMJVH),
-            LOIJUG: GeckoTimeStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoTimeStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoTimeStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoTimeStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, QNRXCH, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, RXCHWD, GYOUSP, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, QJYMOU, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, CHWDAF, GYOUSP, QBMJVH
-            ),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, CHWDAF, JMAOAW, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, CHWDAF, XEKVKZ, QBMJVH
-            ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, CHWDAF, YMOUNB, QBMJVH
-            ),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, CHWDAF, IKJPUN, QBMJVH
-            ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, None, ATDZXN, None, None, QBMJVH
-            ),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, QBMJVH),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, XNQTMF, None, NQTMFZ, None, None, QBMJVH
-            ),
-            QTMFZD: GeckoTimeStructAccessor(self.struct, QTMFZD, TMFZDG, QBMJVH),
-            MFZDGK: GeckoTimeStructAccessor(self.struct, MFZDGK, FZDGKE, QBMJVH),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, QBMJVH),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, KEAKST, None, KSTSEM, None, None, QBMJVH
-            ),
-            STSEMC: GeckoTimeStructAccessor(self.struct, STSEMC, TSEMCG, QBMJVH),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, NQJYMO, XEKVKZ, CGETIX, None, QJYMOU, QBMJVH
-            ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, XQVXOI, None, None, QBMJVH
-            ),
-            QVXOIH: GeckoWordStructAccessor(self.struct, QVXOIH, VXOIHB, QBMJVH),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, ZMJIGY, JMAOAW, HBXIBH, None, QJYMOU, QBMJVH
-            ),
-            BXIBHZ: GeckoBoolStructAccessor(
-                self.struct, BXIBHZ, ZMJIGY, YMOUNB, QBMJVH
-            ),
-            XIBHZV: GeckoEnumStructAccessor(
-                self.struct, XIBHZV, ZMJIGY, IKJPUN, HZVOAC, None, QJYMOU, QBMJVH
-            ),
-            ZVOACM: GeckoBoolStructAccessor(
-                self.struct, ZVOACM, ZMJIGY, VOACMC, QBMJVH
-            ),
-            OACMCV: GeckoBoolStructAccessor(
-                self.struct, OACMCV, ZMJIGY, ACMCVD, QBMJVH
-            ),
-            CMCVDS: GeckoBoolStructAccessor(
-                self.struct, CMCVDS, MCVDSS, GYOUSP, QBMJVH
-            ),
-            CVDSSR: GeckoBoolStructAccessor(
-                self.struct, CVDSSR, MCVDSS, JMAOAW, QBMJVH
-            ),
-            VDSSRU: GeckoEnumStructAccessor(
-                self.struct, VDSSRU, MCVDSS, QJYMOU, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, MCVDSS, XEKVKZ, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, MCVDSS, YMOUNB, DKHTZB, None, KHTZBB, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MCVDSS, ACMCVD, BBEKBD, None, QJYMOU, QBMJVH
-            ),
-            AIVEMV: GeckoBoolStructAccessor(
-                self.struct, AIVEMV, IVEMVC, JMAOAW, QBMJVH
-            ),
-            VEMVCY: GeckoEnumStructAccessor(
-                self.struct, VEMVCY, IVEMVC, QJYMOU, VCYWON, None, YMOUNB, QBMJVH
-            ),
-            CYWONF: GeckoBoolStructAccessor(
-                self.struct, CYWONF, IVEMVC, YMOUNB, QBMJVH
-            ),
-            YWONFZ: GeckoEnumStructAccessor(
-                self.struct, YWONFZ, IVEMVC, VOACMC, NFZCZO, None, YMOUNB, QBMJVH
-            ),
-            FZCZOL: GeckoByteStructAccessor(self.struct, FZCZOL, ZCZOLS, QBMJVH),
-            CZOLSI: GeckoBoolStructAccessor(
-                self.struct, CZOLSI, NQJYMO, GYOUSP, QBMJVH
-            ),
-            ZOLSIP: GeckoByteStructAccessor(self.struct, ZOLSIP, OLSIPM, QBMJVH),
-            LSIPMD: GeckoEnumStructAccessor(
-                self.struct, LSIPMD, SIPMDM, None, MDMPSC, None, None, QBMJVH
-            ),
-            DMPSCT: GeckoEnumStructAccessor(
-                self.struct, DMPSCT, MPSCTT, None, SCTTGC, None, None, QBMJVH
-            ),
-            CTTGCR: GeckoEnumStructAccessor(
-                self.struct, CTTGCR, TTGCRH, GYOUSP, UAXNCU, None, KHTZBB, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, TTGCRH, ACMCVD, QBMJVH
-            ),
-            XNCUGU: GeckoByteStructAccessor(self.struct, XNCUGU, NCUGUC, QBMJVH),
-            CUGUCY: GeckoWordStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoWordStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoWordStructAccessor(self.struct, CYRAPU, YRAPUM, QBMJVH),
-            RAPUME: GeckoWordStructAccessor(self.struct, RAPUME, APUMEA, QBMJVH),
-            PUMEAO: GeckoWordStructAccessor(self.struct, PUMEAO, UMEAOE, QBMJVH),
-            MEAOES: GeckoWordStructAccessor(self.struct, MEAOES, EAOESV, QBMJVH),
-            AOESVZ: GeckoWordStructAccessor(self.struct, AOESVZ, OESVZS, QBMJVH),
-            ESVZSS: GeckoWordStructAccessor(self.struct, ESVZSS, SVZSSB, QBMJVH),
-            VZSSBV: GeckoWordStructAccessor(self.struct, VZSSBV, ZSSBVN, QBMJVH),
-            SSBVNA: GeckoWordStructAccessor(self.struct, SSBVNA, SBVNAX, QBMJVH),
-            BVNAXA: GeckoEnumStructAccessor(
-                self.struct, BVNAXA, VNAXAD, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, VNAXAD, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            LUBGJF: GeckoEnumStructAccessor(
-                self.struct, LUBGJF, UBGJFJ, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            BGJFJN: GeckoEnumStructAccessor(
-                self.struct, BGJFJN, UBGJFJ, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            GJFJNT: GeckoEnumStructAccessor(
-                self.struct, GJFJNT, JFJNTT, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            FJNTTU: GeckoEnumStructAccessor(
-                self.struct, FJNTTU, JFJNTT, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            JNTTUV: GeckoEnumStructAccessor(
-                self.struct, JNTTUV, NTTUVR, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            TTUVRF: GeckoEnumStructAccessor(
-                self.struct, TTUVRF, NTTUVR, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            TUVRFL: GeckoEnumStructAccessor(
-                self.struct, TUVRFL, UVRFLS, GYOUSP, SIJUZM, None, KHTZBB, None
-            ),
-            IJUZMR: GeckoEnumStructAccessor(
-                self.struct, IJUZMR, UVRFLS, XEKVKZ, ZMRKVF, None, KHTZBB, QBMJVH
-            ),
-            MRKVFC: GeckoBoolStructAccessor(self.struct, MRKVFC, UVRFLS, ACMCVD, None),
-            RKVFCP: GeckoBoolStructAccessor(self.struct, RKVFCP, VNAXAD, YMOUNB, None),
-            KVFCPO: GeckoBoolStructAccessor(self.struct, KVFCPO, VNAXAD, IKJPUN, None),
-            VFCPOU: GeckoBoolStructAccessor(self.struct, VFCPOU, VNAXAD, VOACMC, None),
-            FCPOUB: GeckoBoolStructAccessor(self.struct, FCPOUB, VNAXAD, ACMCVD, None),
-            CPOUBM: GeckoBoolStructAccessor(self.struct, CPOUBM, UBGJFJ, YMOUNB, None),
-            POUBMI: GeckoBoolStructAccessor(self.struct, POUBMI, UBGJFJ, IKJPUN, None),
-            OUBMIK: GeckoBoolStructAccessor(self.struct, OUBMIK, UBGJFJ, VOACMC, None),
-            UBMIKG: GeckoBoolStructAccessor(self.struct, UBMIKG, UBGJFJ, ACMCVD, None),
-            BMIKGN: GeckoBoolStructAccessor(self.struct, BMIKGN, JFJNTT, YMOUNB, None),
-            MIKGNV: GeckoBoolStructAccessor(self.struct, MIKGNV, JFJNTT, IKJPUN, None),
-            IKGNVF: GeckoBoolStructAccessor(self.struct, IKGNVF, JFJNTT, VOACMC, None),
-            KGNVFO: GeckoBoolStructAccessor(self.struct, KGNVFO, JFJNTT, ACMCVD, None),
-            GNVFOU: GeckoBoolStructAccessor(self.struct, GNVFOU, NTTUVR, YMOUNB, None),
-            NVFOUU: GeckoBoolStructAccessor(self.struct, NVFOUU, NTTUVR, IKJPUN, None),
-            VFOUUR: GeckoBoolStructAccessor(self.struct, VFOUUR, NTTUVR, VOACMC, None),
-            FOUURI: GeckoBoolStructAccessor(self.struct, FOUURI, NTTUVR, ACMCVD, None),
-            OUURIE: GeckoEnumStructAccessor(
-                self.struct, OUURIE, UURIEV, YMOUNB, RIEVBV, None, KHTZBB, QBMJVH
-            ),
-            IEVBVH: GeckoBoolStructAccessor(self.struct, IEVBVH, UURIEV, ACMCVD, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-80.py
+++ b/src/geckolib/driver/packs/inyt-cfg-80.py
@@ -12,1920 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACQFFT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-ADXLUB = 136
-AFIKJP = 109
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-AIVEMV = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-AJVDQL = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AMJMAO = "".join(chr(c) for c in [72, 105])
-AOAWBS = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-AOESVZ = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = 10
-AWBSIR = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-AXADXL = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-AXNCUG = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-BDFSRO = 7
-BDJQRJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BEKBDF = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BEXLTP = 80
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BGJFJN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-BHZVOA = 157
-BIAMJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [67, 89, 65, 78])
-BMIKGN = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-BQNRXC = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-BQSNQL = 33
-BSIRYX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BSKSOK = 40
-BVHDVR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-BVNAXA = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-BVWVUB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BWJYKL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-BXIBHZ = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-BXTIAC = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-BXYBQS = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BYGDSB = 167
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-CHWDAF = 107
-CMCVDS = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-CRHYUA = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-CRTFMN = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CUGUCY = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = 121
-CYWONF = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-CZOLSI = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-DAFIKJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-DDPMXF = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DFSROG = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DJQRJJ = 170
-DKEYGG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-DMPSCT = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-DNIBXT = 77
-DNQGVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-DQLAII = 68
-DRXAIV = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-DSBDJQ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DSSRUR = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-DUBSSU = "".join(chr(c) for c in [85, 76])
-DVRIDK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-DXLUBG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-DZXNQT = 71
-EAKSTS = 5
-EAOESV = 134
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-EKBDFS = 6
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-ELHBQN = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-ELWUEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-EMCGET = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-EMVCYW = "".join(chr(c) for c in [76, 65])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-EUHNNX = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-EUTOPH = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-EVBVHD = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EYGGVY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-EZFETD = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FCPOUB = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-FCRTFM = 122
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-FIKJPU = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-FJBIAM = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FJNTTU = 143
-FJTACC = 43
-FLSIJU = 151
-FOUURI = 127
-FSROGM = 110
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-FUBJLO = "".join(chr(c) for c in [66, 76, 85, 69])
-FWRKIN = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-FXQGLR = 16
-FYLJUI = "".join(chr(c) for c in [80, 49])
-FZCZOL = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-FZDGKE = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GCRHYU = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-GDSBDJ = 168
-GETIXQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GGVYKL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-GJFJNT = 141
-GKEAKS = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GNVFOU = 126
-GSELHB = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-GTYIYW = 89
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GVUNXN = 96
-GVYKLT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = 52
-HBXIBH = 130
-HDVRID = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-HSVSIB = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-HTBJEU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HUGTYI = 88
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-HXEKVK = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-HZVOAC = "".join(chr(c) for c in [79, 70, 70])
-IACQFF = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IAMJMA = "".join(chr(c) for c in [76, 111])
-IBHZVO = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IBXTIA = 115
-IBXYBQ = 63
-ICXQIE = 13
-IDKEYG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-IDNIBX = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IDUBSS = 51
-IEFXQG = 15
-IFJBIA = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IGYOUS = "".join(chr(c) for c in [79, 119, 110])
-IHBXIB = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-IJUGSE = 101
-IJUZMR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-IKFWRK = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-IKGNVF = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-IKJPUN = 3
-INEJNI = 30
-INELWU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-IPOUYN = 47
-IRYXBQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-IVEMVC = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 75
-IYWSKW = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JEUTOP = 85
-JFJNTT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JJJVYF = "".join(chr(c) for c in [105, 110, 89, 74])
-JLOINE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-JMAOAW = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JNTTUV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-JPUNRJ = 4
-JQRJJJ = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-JUIKFW = 28
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = 155
-JVDQLA = 66
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-JWMNZM = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JYMOUN = 2
-JZTATD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-KBDFSR = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-KCWAON = 21
-KEAKST = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KEYGGV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-KGNVFO = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-KHTZBB = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-KINEJN = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-KJPUNR = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KLGQPL = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-KLTQLV = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-KMLOIJ = 99
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = 76
-KVFCPO = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-KWIVDN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-KXSJWM = 80
-KZILXW = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-LAIIDN = 70
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-LHBQNR = 104
-LIUXFE = 25
-LJUIKF = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 31
-LOIJUG = 100
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-LSIPMD = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-LSPFTS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTQLVH = 172
-LUBGJF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-LVHSVS = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-LXWAJV = 3
-MAOAWB = 1
-MCBFEG = 163
-MCGETI = 73
-MCVDSS = 158
-MDMPSC = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MEAOES = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-MFZDGK = 72
-MHXEKV = 164
-MIKGNV = 125
-MJIGYO = 81
-MJVHFT = 12
-MKQTDK = 64
-MLOIJU = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-MNHTBJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-MNZMJI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-MRKVFC = "".join(chr(c) for c in [82, 71, 66])
-MVCYWO = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MXFUBJ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NEJNIB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-NELWUE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NFZCZO = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NHTBJE = 83
-NIBXTI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-NIBXYB = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NKMLOI = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-NMHXEK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-NNXWEE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = 95
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQTMFZ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NRJZTA = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-NTTUVR = 145
-NVFOUU = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-NXNKML = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-NXWEEZ = "".join(chr(c) for c in [65, 108, 112, 115])
-NZMJIG = 56
-OACMCV = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-OAWBSI = 58
-OCTHBS = 38
-OGMDDP = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-OIHBXI = 128
-OIJUGS = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-OINELW = 8
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-ONFZCZ = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = 87
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = 124
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-OUURIE = "".join(chr(c) for c in [49])
-OUYNQJ = 48
-PBWJYK = 120
-PHUGTY = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 27
-PMDMPS = "".join(chr(c) for c in [73, 100, 111, 108])
-PMXFUB = "".join(chr(c) for c in [82, 69, 68])
-POUBMI = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-PUMEAO = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-PUNRJZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-QFYLJU = 78
-QGLRAH = 26
-QGVUNX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-QLNMHX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QLVHSV = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 105
-QPLSPF = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-QRJJJV = 171
-QSNQLN = "".join(chr(c) for c in [70])
-QTDKHT = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-QTMFZD = 82
-QVXOIH = 160
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 133
-RAZMKQ = "".join(chr(c) for c in [50, 52, 104])
-RFLSIJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-RHYUAX = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-RIDKEY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-RIEVBV = "".join(chr(c) for c in [52])
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = "".join(chr(c) for c in [105, 110, 89, 84])
-RJZTAT = 116
-ROGMDD = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = 74
-RURAZM = 34
-RXAIVE = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-RXCHWD = 106
-RYXBQF = 61
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = 169
-SBVNAX = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-SCTTGC = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-SELHBQ = 103
-SIFJBI = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-SIJUZM = 153
-SIPMDM = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-SIRYXB = 60
-SJWMNZ = 54
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = 92
-SNQLNM = "".join(chr(c) for c in [67])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-SPFTSI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-SROGMD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SRURAZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-SSUHBV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-STSEMC = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-SUHBVW = 114
-SVZSSB = 135
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-TBJEUT = 84
-TDKHTZ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TDRXAI = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-TDZXNQ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TGCRHY = 112
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-TIDUBS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-TIXQVX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TMFZDG = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-TOPHUG = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TQLVHS = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-TSEMCG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-TSIFJB = 57
-TTGCRH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-TTIDUB = 162
-TTUVRF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-TUVRFL = 147
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-TZBBEK = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-UAXNCU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-UBGJFJ = 139
-UBJLOI = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-UBMIKG = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-UBSSUH = "".join(chr(c) for c in [67, 69])
-UBYGDS = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-UCYRAP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-UEUHNN = 111
-UGSELH = 102
-UGTYIY = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-UGUCYR = 113
-UHBVWV = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-UHNNXW = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UIKFWR = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UJUTYE = 18
-UNBLKX = 79
-UNRJZT = 6
-UNXNKM = 97
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [65, 109, 80, 109])
-URIEVB = "".join(chr(c) for c in [51])
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = 118
-UTOPHU = 86
-UTYEKC = 19
-UURIEV = "".join(chr(c) for c in [50])
-UVRFLS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-VBVHDV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-VCYWON = "".join(chr(c) for c in [77, 65, 65, 88])
-VDNQGV = 94
-VDQLAI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VDSSRU = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-VEMVCY = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-VFCPOU = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VFOUUR = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-VHDVRI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VHSVSI = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-VKZILX = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-VOACMC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-VRFLSI = 149
-VRIDKE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-VUBYGD = 166
-VUNXNK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VWVUBY = 165
-VYFCRT = 53
-VYKLTQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-WAJVDQ = 35
-WAONPY = 22
-WBSIRY = 59
-WDAFIK = 108
-WEEZFE = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-WIVDNQ = 93
-WJYKLG = 32
-WMNZMJ = 55
-WONFZC = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WRKINE = 29
-WSKWIV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-WUEUHN = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XADXLU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-XAIVEM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-XBQFYL = 62
-XCHWDA = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-XEKVKZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XFUBJL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-XIBHZV = 132
-XLUBGJ = 137
-XNCUGU = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-XNKMLO = 98
-XOIHBX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-XSJWMN = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-XTIACQ = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-XWEEZF = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-XYBQSN = 1
-YBQSNQ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YEKCWA = 20
-YFCRTF = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGDSBD = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGGVYK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-YIYWSK = 90
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-YKLTQL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOUSPB = 0
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-YUAXNC = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-YWONFZ = "".join(chr(c) for c in [80, 68, 67])
-YWSKWI = 91
-YXBQFY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZDGKEA = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ZFETDR = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-ZILXWA = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-ZMJIGY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-ZMKQTD = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ZMRKVF = 123
-ZOLSIP = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-ZSSBVN = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-ZTATDZ = 8
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-ZXNQTM = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-ACMCVD = [JVHFTH, HZVOAC, ZVOACM, VOACMC, OACMCV]
-AZMKQT = [JVHFTH, URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BSSUHB = [DUBSSU, UBSSUH]
-CPOUBM = [VFCPOU, FCPOUB]
-CTTGCR = [
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-]
-DKHTZB = [QTDKHT, TDKHTZ]
-ETIXQV = [VLASSA, CGETIX, GETIXQ]
-FFTTID = [BXTIAC, XTIACQ, TIACQF, IACQFF, ACQFFT, CQFFTT, QFFTTI]
-FMNHTB = [NEJNIB, TFMNHT]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-GQPLSP = [JYKLGQ, YKLGQP, KLGQPL, LGQPLS]
-GYOUSP = [JIGYOU, IGYOUS]
-HBQNRX = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-HYUAXN = [CRHYUA, RHYUAX, VLASSA, VLASSA]
-IBEXLT = []
-IEVBVH = [VLASSA, OUURIE, UURIEV, URIEVB, RIEVBV]
-IIDNIB = [NEJNIB, AIIDNI]
-ILXWAJ = [KZILXW, ZILXWA]
-JBIAMJ = [SIFJBI, IFJBIA, FJBIAM]
-JJVYFC = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    RJJJVY,
-    VLASSA,
-    JJJVYF,
-]
-JNIBXY = [NEJNIB, EJNIBX]
-KFWRKI = [UIKFWR, IKFWRK]
-KVKZIL = [HXEKVK, XEKVKZ, EKVKZI]
-LOINEL = [HZVOAC, PMXFUB, MXFUBJ, XFUBJL, FUBJLO, UBJLOI, BJLOIN, JLOINE]
-LWUEUH = [NELWUE, ELWUEU]
-MDDPMX = [OGMDDP, GMDDPM]
-MJMAOA = [IAMJMA, AMJMAO]
-NAXADX = [VZSSBV, ZSSBVN, SSBVNA, SBVNAX, BVNAXA, VNAXAD, VLASSA, VLASSA]
-NCUGUC = [JVHFTH, AXNCUG, XNCUGU, VLASSA]
-NQLNMH = [QSNQLN, SNQLNM]
-OESVZS = [AOESVZ]
-PFTSIF = [LSPFTS, SPFTSI]
-RKINEJ = [PIPIVL, FYLJUI]
-RKVFCP = [MRKVFC, JLOINE]
-SEMCGE = [STSEMC, TSEMCG]
-SIBEXL = [NBLKXS]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-SSRURA = [VDSSRU, DSSRUR]
-SVSIBE = [TQLVHS, QLVHSV, LVHSVS, VHSVSI, HSVSIB]
-UMEAOE = [APUMEA, PUMEAO]
-VSIBEX = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-]
-VXOIHB = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XNQTMF = [JVHFTH, LSPFTS, ZXNQTM]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-YLJUIK = [JVHFTH, FYLJUI, PIPIVL]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1933,417 +19,1500 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return BEXLTP
+        return 80
 
     @property
     def output_keys(self):
-        return VSIBEX
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, YOUSPB, GYOUSP, None, JYMOUN, QBMJVH
-            ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, JBIAMJ, None, None, QBMJVH
-            ),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, MJIGYO, JYMOUN, MJMAOA, None, JYMOUN, QBMJVH
-            ),
-            JMAOAW: GeckoBoolStructAccessor(
-                self.struct, JMAOAW, QJYMOU, MAOAWB, QBMJVH
-            ),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, QBMJVH),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, QBMJVH),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTempStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, RKINEJ, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, KVKZIL, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, MJIGYO, LXWAJV, ILXWAJ, None, JYMOUN, QBMJVH
-            ),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, QBMJVH),
-            AJVDQL: GeckoTempStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoTempStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, LAIIDN, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, FFTTID, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, BSSUHB, None, None, QBMJVH
-            ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, QBMJVH),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, QBMJVH),
-            BDJQRJ: GeckoByteStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, JJVYFC, None, None, None
-            ),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, FMNHTB, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, XLSXUJ, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, OPHUGT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, QBMJVH),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, QBMJVH),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, QBMJVH),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, QBMJVH),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, QBMJVH),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, HBQNRX, None, None, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, HBQNRX, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, HBQNRX, None, None, QBMJVH
-            ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, CHWDAF, None, HBQNRX, None, None, QBMJVH
-            ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, WDAFIK, None, HBQNRX, None, None, QBMJVH
-            ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, HBQNRX, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoTimeStructAccessor(self.struct, KJPUNR, JPUNRJ, QBMJVH),
-            PUNRJZ: GeckoTimeStructAccessor(self.struct, PUNRJZ, UNRJZT, QBMJVH),
-            NRJZTA: GeckoTimeStructAccessor(self.struct, NRJZTA, RJZTAT, QBMJVH),
-            JZTATD: GeckoTimeStructAccessor(self.struct, JZTATD, ZTATDZ, QBMJVH),
-            TATDZX: GeckoTimeStructAccessor(self.struct, TATDZX, ATDZXN, QBMJVH),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, None, XNQTMF, None, None, QBMJVH
-            ),
-            NQTMFZ: GeckoBoolStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, YOUSPB, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, MFZDGK, JYMOUN, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, MFZDGK, YOUSPB, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, MFZDGK, MAOAWB, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, MFZDGK, LXWAJV, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, MFZDGK, MOUNBL, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, MFZDGK, EAKSTS, QBMJVH
-            ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, SEMCGE, None, None, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, QBMJVH),
-            XQVXOI: GeckoEnumStructAccessor(
-                self.struct, XQVXOI, QVXOIH, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoTimeStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoTimeStructAccessor(self.struct, IHBXIB, HBXIBH, QBMJVH),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, QBMJVH),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, BHZVOA, None, ACMCVD, None, None, QBMJVH
-            ),
-            CMCVDS: GeckoTimeStructAccessor(self.struct, CMCVDS, MCVDSS, QBMJVH),
-            CVDSSR: GeckoEnumStructAccessor(
-                self.struct, CVDSSR, QJYMOU, LXWAJV, SSRURA, None, JYMOUN, QBMJVH
-            ),
-            SRURAZ: GeckoEnumStructAccessor(
-                self.struct, SRURAZ, RURAZM, None, AZMKQT, None, None, QBMJVH
-            ),
-            ZMKQTD: GeckoWordStructAccessor(self.struct, ZMKQTD, MKQTDK, QBMJVH),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, MJIGYO, MAOAWB, DKHTZB, None, JYMOUN, QBMJVH
-            ),
-            KHTZBB: GeckoBoolStructAccessor(
-                self.struct, KHTZBB, MJIGYO, MOUNBL, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MJIGYO, EAKSTS, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, MJIGYO, EKBDFS, QBMJVH
-            ),
-            KBDFSR: GeckoBoolStructAccessor(
-                self.struct, KBDFSR, MJIGYO, BDFSRO, QBMJVH
-            ),
-            DFSROG: GeckoBoolStructAccessor(
-                self.struct, DFSROG, FSROGM, YOUSPB, QBMJVH
-            ),
-            SROGMD: GeckoBoolStructAccessor(
-                self.struct, SROGMD, FSROGM, MAOAWB, QBMJVH
-            ),
-            ROGMDD: GeckoEnumStructAccessor(
-                self.struct, ROGMDD, FSROGM, JYMOUN, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DDPMXF: GeckoEnumStructAccessor(
-                self.struct, DDPMXF, FSROGM, LXWAJV, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, FSROGM, MOUNBL, LOINEL, None, OINELW, QBMJVH
-            ),
-            INELWU: GeckoEnumStructAccessor(
-                self.struct, INELWU, FSROGM, BDFSRO, LWUEUH, None, JYMOUN, QBMJVH
-            ),
-            TTGCRH: GeckoBoolStructAccessor(
-                self.struct, TTGCRH, TGCRHY, MAOAWB, QBMJVH
-            ),
-            GCRHYU: GeckoEnumStructAccessor(
-                self.struct, GCRHYU, TGCRHY, JYMOUN, HYUAXN, None, MOUNBL, QBMJVH
-            ),
-            YUAXNC: GeckoBoolStructAccessor(
-                self.struct, YUAXNC, TGCRHY, MOUNBL, QBMJVH
-            ),
-            UAXNCU: GeckoEnumStructAccessor(
-                self.struct, UAXNCU, TGCRHY, EKBDFS, NCUGUC, None, MOUNBL, QBMJVH
-            ),
-            CUGUCY: GeckoByteStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoBoolStructAccessor(
-                self.struct, GUCYRA, QJYMOU, YOUSPB, QBMJVH
-            ),
-            UCYRAP: GeckoByteStructAccessor(self.struct, UCYRAP, CYRAPU, QBMJVH),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, RAPUME, None, UMEAOE, None, None, QBMJVH
-            ),
-            MEAOES: GeckoEnumStructAccessor(
-                self.struct, MEAOES, EAOESV, None, OESVZS, None, None, QBMJVH
-            ),
-            ESVZSS: GeckoEnumStructAccessor(
-                self.struct, ESVZSS, SVZSSB, YOUSPB, NAXADX, None, OINELW, QBMJVH
-            ),
-            AXADXL: GeckoBoolStructAccessor(
-                self.struct, AXADXL, SVZSSB, BDFSRO, QBMJVH
-            ),
-            XADXLU: GeckoByteStructAccessor(self.struct, XADXLU, ADXLUB, QBMJVH),
-            DXLUBG: GeckoWordStructAccessor(self.struct, DXLUBG, XLUBGJ, QBMJVH),
-            LUBGJF: GeckoWordStructAccessor(self.struct, LUBGJF, UBGJFJ, QBMJVH),
-            BGJFJN: GeckoWordStructAccessor(self.struct, BGJFJN, GJFJNT, QBMJVH),
-            JFJNTT: GeckoWordStructAccessor(self.struct, JFJNTT, FJNTTU, QBMJVH),
-            JNTTUV: GeckoWordStructAccessor(self.struct, JNTTUV, NTTUVR, QBMJVH),
-            TTUVRF: GeckoWordStructAccessor(self.struct, TTUVRF, TUVRFL, QBMJVH),
-            UVRFLS: GeckoWordStructAccessor(self.struct, UVRFLS, VRFLSI, QBMJVH),
-            RFLSIJ: GeckoWordStructAccessor(self.struct, RFLSIJ, FLSIJU, QBMJVH),
-            LSIJUZ: GeckoWordStructAccessor(self.struct, LSIJUZ, SIJUZM, QBMJVH),
-            IJUZMR: GeckoWordStructAccessor(self.struct, IJUZMR, JUZMRK, QBMJVH),
-            UZMRKV: GeckoEnumStructAccessor(
-                self.struct, UZMRKV, ZMRKVF, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            KVFCPO: GeckoEnumStructAccessor(
-                self.struct, KVFCPO, ZMRKVF, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            POUBMI: GeckoEnumStructAccessor(
-                self.struct, POUBMI, OUBMIK, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            UBMIKG: GeckoEnumStructAccessor(
-                self.struct, UBMIKG, OUBMIK, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            BMIKGN: GeckoEnumStructAccessor(
-                self.struct, BMIKGN, MIKGNV, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            IKGNVF: GeckoEnumStructAccessor(
-                self.struct, IKGNVF, MIKGNV, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            KGNVFO: GeckoEnumStructAccessor(
-                self.struct, KGNVFO, GNVFOU, YOUSPB, RKVFCP, None, JYMOUN, None
-            ),
-            NVFOUU: GeckoEnumStructAccessor(
-                self.struct, NVFOUU, GNVFOU, MAOAWB, CPOUBM, None, JYMOUN, None
-            ),
-            VFOUUR: GeckoEnumStructAccessor(
-                self.struct, VFOUUR, FOUURI, YOUSPB, IEVBVH, None, OINELW, None
-            ),
-            EVBVHD: GeckoBoolStructAccessor(self.struct, EVBVHD, FOUURI, BDFSRO, None),
-            VBVHDV: GeckoBoolStructAccessor(self.struct, VBVHDV, ZMRKVF, MOUNBL, None),
-            BVHDVR: GeckoBoolStructAccessor(self.struct, BVHDVR, ZMRKVF, EAKSTS, None),
-            VHDVRI: GeckoBoolStructAccessor(self.struct, VHDVRI, ZMRKVF, EKBDFS, None),
-            HDVRID: GeckoBoolStructAccessor(self.struct, HDVRID, ZMRKVF, BDFSRO, None),
-            DVRIDK: GeckoBoolStructAccessor(self.struct, DVRIDK, OUBMIK, MOUNBL, None),
-            VRIDKE: GeckoBoolStructAccessor(self.struct, VRIDKE, OUBMIK, EAKSTS, None),
-            RIDKEY: GeckoBoolStructAccessor(self.struct, RIDKEY, OUBMIK, EKBDFS, None),
-            IDKEYG: GeckoBoolStructAccessor(self.struct, IDKEYG, OUBMIK, BDFSRO, None),
-            DKEYGG: GeckoBoolStructAccessor(self.struct, DKEYGG, MIKGNV, MOUNBL, None),
-            KEYGGV: GeckoBoolStructAccessor(self.struct, KEYGGV, MIKGNV, EAKSTS, None),
-            EYGGVY: GeckoBoolStructAccessor(self.struct, EYGGVY, MIKGNV, EKBDFS, None),
-            YGGVYK: GeckoBoolStructAccessor(self.struct, YGGVYK, MIKGNV, BDFSRO, None),
-            GGVYKL: GeckoBoolStructAccessor(self.struct, GGVYKL, GNVFOU, MOUNBL, None),
-            GVYKLT: GeckoBoolStructAccessor(self.struct, GVYKLT, GNVFOU, EAKSTS, None),
-            VYKLTQ: GeckoBoolStructAccessor(self.struct, VYKLTQ, GNVFOU, EKBDFS, None),
-            YKLTQL: GeckoBoolStructAccessor(self.struct, YKLTQL, GNVFOU, BDFSRO, None),
-            KLTQLV: GeckoEnumStructAccessor(
-                self.struct, KLTQLV, LTQLVH, None, SVSIBE, None, None, None
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-81.py
+++ b/src/geckolib/driver/packs/inyt-cfg-81.py
@@ -12,2072 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACQFFT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-ADXLUB = 134
-AFIKJP = 109
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-AIVEMV = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-AJVDQL = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AMJMAO = "".join(chr(c) for c in [72, 105])
-AOAWBS = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-AOESVZ = 174
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [80, 50])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = 10
-AWBSIR = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-AXNCUG = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-BDFSRO = 7
-BDJQRJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BEKBDF = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-BEXLTP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BGJFJN = 135
-BHZVOA = 157
-BIAMJM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [67, 89, 65, 78])
-BMIKGN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        56,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-BQNRXC = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-BQSNQL = 33
-BSIRYX = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-BSKSOK = 40
-BVHDVR = 124
-BVNAXA = 133
-BVWVUB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BWJYKL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-BXIBHZ = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-BXTIAC = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-BXYBQS = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BYGDSB = 167
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-CHWDAF = 107
-CMCVDS = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-CPOUBM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        54,
-    ]
-)
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-CRHYUA = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-CRTFMN = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CUGUCY = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = 121
-CYWONF = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-CZOLSI = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-DAFIKJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-DDPMXF = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DFSROG = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DJQRJJ = 170
-DKEYGG = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-DMPSCT = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-DNIBXT = 77
-DNQGVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-DQLAII = 68
-DRXAIV = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-DSBDJQ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DSSRUR = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-DUBSSU = "".join(chr(c) for c in [85, 76])
-DVRIDK = 125
-DXLUBG = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-DZXNQT = 71
-EAKSTS = 5
-EAOESV = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 50])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-EKBDFS = 6
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-ELHBQN = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-ELWUEU = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-EMCGET = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-EMVCYW = "".join(chr(c) for c in [76, 65])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = 175
-ETDRXA = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-EUHNNX = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-EUTOPH = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EXLTPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-EYGGVY = 127
-EZFETD = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FCPOUB = 145
-FCRTFM = 122
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-FIKJPU = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-FJBIAM = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-FJNTTU = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-FJTACC = 43
-FLSIJU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-FOUURI = 123
-FSROGM = 110
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-FUBJLO = "".join(chr(c) for c in [66, 76, 85, 69])
-FWRKIN = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-FXQGLR = 16
-FYLJUI = "".join(chr(c) for c in [80, 49])
-FZCZOL = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-FZDGKE = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GCRHYU = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-GDSBDJ = 168
-GETIXQ = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GGVYKL = "".join(chr(c) for c in [50])
-GJFJNT = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-GKEAKS = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GNVFOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-        48,
-    ]
-)
-GSELHB = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-GTYIYW = 89
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GVUNXN = 96
-GVYKLT = "".join(chr(c) for c in [51])
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = 52
-HBXIBH = 130
-HDVRID = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-HSVSIB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-HTBJEU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-HUGTYI = 88
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-HWOGXX = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-HXEKVK = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-HZVOAC = "".join(chr(c) for c in [79, 70, 70])
-IACQFF = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IAMJMA = "".join(chr(c) for c in [76, 111])
-IBEXLT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-IBHZVO = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-IBXTIA = 115
-IBXYBQ = 63
-ICXQIE = 13
-IDKEYG = 126
-IDNIBX = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IDUBSS = 51
-IEFXQG = 15
-IEVBVH = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-IFJBIA = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-IGYOUS = "".join(chr(c) for c in [79, 119, 110])
-IHBXIB = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-IJUGSE = 101
-IJUZMR = 137
-IKFWRK = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-IKGNVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        57,
-    ]
-)
-IKJPUN = 3
-INEJNI = 30
-INELWU = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-IPOUYN = 47
-IRYXBQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUVMKZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-IVEMVC = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 75
-IYWSKW = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JEUTOP = 85
-JFJNTT = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-JJJVYF = "".join(chr(c) for c in [105, 110, 89, 74])
-JLOINE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-JMAOAW = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JNTTUV = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-JPUNRJ = 4
-JQRJJJ = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JQSGME = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-JUIKFW = 28
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        50,
-    ]
-)
-JVDQLA = 66
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-JWMNZM = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-JYMOUN = 2
-JZTATD = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-KBDFSR = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-KCWAON = 21
-KEAKST = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KEYGGV = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-KGNVFO = 153
-KHTZBB = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-KINEJN = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-KJPUNR = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KLGQPL = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-KLTQLV = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-KMLOIJ = 99
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = 76
-KVFCPO = 143
-KWIVDN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-KXSJWM = 80
-KZHWOG = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-KZILXW = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-LAIIDN = 70
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-LHBQNR = 104
-LIUXFE = 25
-LJUIKF = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 31
-LOIJUG = 100
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = 136
-LSIPMD = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-LSPFTS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTPOXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-LTQLVH = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-LVHSVS = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-LXWAJV = 3
-MAOAWB = 1
-MCBFEG = 163
-MCGETI = 73
-MCVDSS = 158
-MDMPSC = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MECYXM = 81
-MFZDGK = 72
-MHXEKV = 164
-MIKGNV = 151
-MJIGYO = 81
-MJVHFT = 12
-MKQTDK = 64
-MKZHWO = 172
-MLOIJU = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-MNHTBJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-MNZMJI = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-MRKVFC = 141
-MVCYWO = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MXFUBJ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-NAXADX = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NEJNIB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-NELWUE = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-NFZCZO = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-NHTBJE = 83
-NIBXTI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-NIBXYB = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-NKMLOI = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-NMHXEK = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-NNXWEE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = 95
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQTMFZ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NRJZTA = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-NTTUVR = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-NVFOUU = 155
-NXNKML = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-NXWEEZ = "".join(chr(c) for c in [65, 108, 112, 115])
-NZMJIG = 56
-OACMCV = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-OAWBSI = 58
-OCTHBS = 38
-OESVZS = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 51])
-OGMDDP = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-OGXXYO = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-OIHBXI = 128
-OIJUGS = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-OINELW = 8
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-ONFZCZ = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = 87
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        55,
-    ]
-)
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-OUURIE = "".join(chr(c) for c in [82, 71, 66])
-OUYNQJ = 48
-OXIUVM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-PBWJYK = 120
-PHUGTY = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 27
-PMDMPS = "".join(chr(c) for c in [73, 100, 111, 108])
-PMXFUB = "".join(chr(c) for c in [82, 69, 68])
-POUBMI = 147
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-POXIUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-PUMEAO = "".join(chr(c) for c in [80, 51])
-PUNRJZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-QFYLJU = 78
-QGLRAH = 26
-QGVUNX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-QLNMHX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 105
-QPLSPF = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-QRJJJV = 171
-QSNQLN = "".join(chr(c) for c in [70])
-QTDKHT = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-QTMFZD = 82
-QVXOIH = 160
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 173
-RAZMKQ = "".join(chr(c) for c in [50, 52, 104])
-RFLSIJ = 178
-RHYUAX = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-RIDKEY = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-RIEVBV = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = "".join(chr(c) for c in [105, 110, 89, 84])
-RJZTAT = 116
-RKVFCP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        52,
-    ]
-)
-ROGMDD = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = 74
-RURAZM = 34
-RXAIVE = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-RXCHWD = 106
-RYXBQF = 61
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = 169
-SBVNAX = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-SCTTGC = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-SELHBQ = 103
-SIBEXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-SIFJBI = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-SIJUZM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-    ]
-)
-SIPMDM = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-SIRYXB = 60
-SJWMNZ = 54
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = 92
-SNQLNM = "".join(chr(c) for c in [67])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-SPFTSI = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-SROGMD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-SRURAZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = 177
-SSUHBV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-STSEMC = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-SUHBVW = 114
-SVSIBE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-SVZSSB = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 52])
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-TBJEUT = 84
-TDKHTZ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TDRXAI = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-TDZXNQ = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-TFMNHT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TGCRHY = 112
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-TIDUBS = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-TIXQVX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TMFZDG = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-TOPHUG = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TPOXIU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-TQLVHS = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-TSEMCG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-TSIFJB = 57
-TTGCRH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-TTIDUB = 162
-TTUVRF = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-TZBBEK = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-UAXNCU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-UBGJFJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-UBJLOI = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-UBMIKG = 149
-UBSSUH = "".join(chr(c) for c in [67, 69])
-UBYGDS = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-UCYRAP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-UEUHNN = 111
-UGSELH = 102
-UGTYIY = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-UGUCYR = 113
-UHBVWV = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-UHNNXW = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-UIKFWR = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-UJUTYE = 18
-UMEAOE = "".join(chr(c) for c in [80, 52])
-UNBLKX = 79
-UNRJZT = 6
-UNXNKM = 97
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [65, 109, 80, 109])
-URIEVB = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = 118
-UTOPHU = 86
-UTYEKC = 19
-UVMKZH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-UVRFLS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = 139
-VBVHDV = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-VCYWON = "".join(chr(c) for c in [77, 65, 65, 88])
-VDNQGV = 94
-VDQLAI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VDSSRU = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-VEMVCY = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-VFCPOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        53,
-    ]
-)
-VFOUUR = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-VHDVRI = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VHSVSI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-VKZILX = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-VLASSA = "".join(chr(c) for c in [])
-VMKZHW = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-VNAXAD = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-VRFLSI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        66,
-        117,
-        111,
-        121,
-        97,
-        110,
-        99,
-        121,
-        80,
-        117,
-        109,
-        112,
-    ]
-)
-VRIDKE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-VSIBEX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-VUBYGD = 166
-VUNXNK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VWVUBY = 165
-VYFCRT = 53
-VYKLTQ = "".join(chr(c) for c in [52])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = 176
-WAJVDQ = 35
-WAONPY = 22
-WBSIRY = 59
-WDAFIK = 108
-WEEZFE = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-WIVDNQ = 93
-WJYKLG = 32
-WMNZMJ = 55
-WOGXXY = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-WONFZC = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WRKINE = 29
-WSKWIV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-WUEUHN = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-WVUBYG = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XADXLU = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-XAIVEM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-XBQFYL = 62
-XCHWDA = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-XEKVKZ = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XFUBJL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-XIBHZV = 132
-XIUVMK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-XLTPOX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XLUBGJ = "".join(
-    chr(c)
-    for c in [
-        85,
-        83,
-        69,
-        95,
-        86,
-        65,
-        82,
-        73,
-        65,
-        66,
-        76,
-        69,
-        95,
-        83,
-        80,
-        69,
-        69,
-        68,
-        95,
-        80,
-        85,
-        77,
-        80,
-        83,
-    ]
-)
-XNCUGU = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-XNKMLO = 98
-XOIHBX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-XSJWMN = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-XTIACQ = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-XWEEZF = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-XXYOJQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-XYBQSN = 1
-XYOJQS = 179
-YBQSNQ = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YEKCWA = 20
-YFCRTF = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGDSBD = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YGGVYK = "".join(chr(c) for c in [49])
-YIYWSK = 90
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOJQSG = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-YOUSPB = 0
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 49])
-YUAXNC = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-YWONFZ = "".join(chr(c) for c in [80, 68, 67])
-YWSKWI = 91
-YXBQFY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZDGKEA = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ZFETDR = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-ZHWOGX = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-ZILXWA = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-ZMJIGY = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-ZMKQTD = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-ZMRKVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        51,
-    ]
-)
-ZOLSIP = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-ZSSBVN = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 53])
-ZTATDZ = 8
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-ZXNQTM = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-ACMCVD = [JVHFTH, HZVOAC, ZVOACM, VOACMC, OACMCV]
-AXADXL = [VNAXAD, NAXADX]
-AZMKQT = [JVHFTH, URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BSSUHB = [DUBSSU, UBSSUH]
-CTTGCR = [
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-]
-DKHTZB = [QTDKHT, TDKHTZ]
-ETIXQV = [VLASSA, CGETIX, GETIXQ]
-EVBVHD = [RIEVBV, IEVBVH]
-FFTTID = [BXTIAC, XTIACQ, TIACQF, IACQFF, ACQFFT, CQFFTT, QFFTTI]
-FMNHTB = [NEJNIB, TFMNHT]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-GMECYX = []
-GQPLSP = [JYKLGQ, YKLGQP, KLGQPL, LGQPLS]
-GXXYOJ = [KZHWOG, ZHWOGX, HWOGXX, WOGXXY, OGXXYO]
-GYOUSP = [JIGYOU, IGYOUS]
-HBQNRX = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-HYUAXN = [CRHYUA, RHYUAX, VLASSA, VLASSA]
-IIDNIB = [NEJNIB, AIIDNI]
-ILXWAJ = [KZILXW, ZILXWA]
-JBIAMJ = [SIFJBI, IFJBIA, FJBIAM]
-JJVYFC = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    RJJJVY,
-    VLASSA,
-    JJJVYF,
-]
-JNIBXY = [NEJNIB, EJNIBX]
-KFWRKI = [UIKFWR, IKFWRK]
-KVKZIL = [HXEKVK, XEKVKZ, EKVKZI]
-LOINEL = [HZVOAC, PMXFUB, MXFUBJ, XFUBJL, FUBJLO, UBJLOI, BJLOIN, JLOINE]
-LUBGJF = [DXLUBG, XLUBGJ]
-LWUEUH = [NELWUE, ELWUEU]
-MDDPMX = [OGMDDP, GMDDPM]
-MEAOES = [JVHFTH, FYLJUI, APUMEA, PUMEAO, UMEAOE, YYPIPI]
-MJMAOA = [IAMJMA, AMJMAO]
-NCUGUC = [JVHFTH, AXNCUG, XNCUGU, VLASSA]
-NQLNMH = [QSNQLN, SNQLNM]
-OJQSGM = [YOJQSG, JLOINE, MXFUBJ, LTQLVH, XFUBJL, BJLOIN, TQLVHS, HZVOAC]
-PFTSIF = [LSPFTS, SPFTSI]
-QLVHSV = [FUBJLO, JLOINE, MXFUBJ, LTQLVH, XFUBJL, BJLOIN, TQLVHS, HZVOAC]
-QSGMEC = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-]
-RKINEJ = [PIPIVL, FYLJUI]
-SEMCGE = [STSEMC, TSEMCG]
-SGMECY = [NBLKXS]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-SSRURA = [VDSSRU, DSSRUR]
-TUVRFL = [GJFJNT, JFJNTT, FJNTTU, JNTTUV, NTTUVR, TTUVRF, VLASSA, VLASSA]
-UURIEV = [OUURIE, JLOINE]
-VXOIHB = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XNQTMF = [JVHFTH, LSPFTS, ZXNQTM]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-YKLTQL = [VLASSA, YGGVYK, GGVYKL, GVYKLT, VYKLTQ]
-YLJUIK = [JVHFTH, FYLJUI, PIPIVL]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -2085,442 +19,1592 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return MECYXM
+        return 81
 
     @property
     def output_keys(self):
-        return QSGMEC
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoByteStructAccessor(self.struct, XSJWMN, SJWMNZ, QBMJVH),
-            JWMNZM: GeckoByteStructAccessor(self.struct, JWMNZM, WMNZMJ, QBMJVH),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoEnumStructAccessor(
-                self.struct, ZMJIGY, MJIGYO, YOUSPB, GYOUSP, None, JYMOUN, QBMJVH
-            ),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoByteStructAccessor(self.struct, SPBWJY, PBWJYK, QBMJVH),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, JBIAMJ, None, None, QBMJVH
-            ),
-            BIAMJM: GeckoEnumStructAccessor(
-                self.struct, BIAMJM, MJIGYO, JYMOUN, MJMAOA, None, JYMOUN, QBMJVH
-            ),
-            JMAOAW: GeckoBoolStructAccessor(
-                self.struct, JMAOAW, QJYMOU, MAOAWB, QBMJVH
-            ),
-            AOAWBS: GeckoByteStructAccessor(self.struct, AOAWBS, OAWBSI, QBMJVH),
-            AWBSIR: GeckoByteStructAccessor(self.struct, AWBSIR, WBSIRY, QBMJVH),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, QBMJVH),
-            IRYXBQ: GeckoByteStructAccessor(self.struct, IRYXBQ, RYXBQF, QBMJVH),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, QFYLJU, None, YLJUIK, None, None, QBMJVH
-            ),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, RKINEJ, None, None, QBMJVH
-            ),
-            KINEJN: GeckoEnumStructAccessor(
-                self.struct, KINEJN, INEJNI, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, QBMJVH),
-            BXYBQS: GeckoTempStructAccessor(self.struct, BXYBQS, XYBQSN, QBMJVH),
-            YBQSNQ: GeckoEnumStructAccessor(
-                self.struct, YBQSNQ, BQSNQL, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, RKINEJ, None, None, QBMJVH
-            ),
-            NMHXEK: GeckoEnumStructAccessor(
-                self.struct, NMHXEK, MHXEKV, None, KVKZIL, None, None, QBMJVH
-            ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, MJIGYO, LXWAJV, ILXWAJ, None, JYMOUN, QBMJVH
-            ),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, QBMJVH),
-            AJVDQL: GeckoTempStructAccessor(self.struct, AJVDQL, JVDQLA, QBMJVH),
-            VDQLAI: GeckoTempStructAccessor(self.struct, VDQLAI, DQLAII, QBMJVH),
-            QLAIID: GeckoEnumStructAccessor(
-                self.struct, QLAIID, LAIIDN, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, QBMJVH),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, FFTTID, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, QBMJVH),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, BSSUHB, None, None, QBMJVH
-            ),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoByteStructAccessor(self.struct, YGDSBD, GDSBDJ, QBMJVH),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, QBMJVH),
-            BDJQRJ: GeckoByteStructAccessor(self.struct, BDJQRJ, DJQRJJ, QBMJVH),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, JJVYFC, None, None, None
-            ),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, QBMJVH),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, FMNHTB, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, XLSXUJ, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, OPHUGT, None, XLSXUJ, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, XLSXUJ, None, None, QBMJVH
-            ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, QBMJVH),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, QBMJVH),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, QBMJVH),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, QBMJVH),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, QBMJVH),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, QBMJVH),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, HBQNRX, None, None, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, HBQNRX, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, HBQNRX, None, None, QBMJVH
-            ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, CHWDAF, None, HBQNRX, None, None, QBMJVH
-            ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, WDAFIK, None, HBQNRX, None, None, QBMJVH
-            ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, HBQNRX, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoTimeStructAccessor(self.struct, KJPUNR, JPUNRJ, QBMJVH),
-            PUNRJZ: GeckoTimeStructAccessor(self.struct, PUNRJZ, UNRJZT, QBMJVH),
-            NRJZTA: GeckoTimeStructAccessor(self.struct, NRJZTA, RJZTAT, QBMJVH),
-            JZTATD: GeckoTimeStructAccessor(self.struct, JZTATD, ZTATDZ, QBMJVH),
-            TATDZX: GeckoTimeStructAccessor(self.struct, TATDZX, ATDZXN, QBMJVH),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, None, XNQTMF, None, None, QBMJVH
-            ),
-            NQTMFZ: GeckoBoolStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, YOUSPB, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, MFZDGK, JYMOUN, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, MFZDGK, YOUSPB, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, MFZDGK, MAOAWB, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, MFZDGK, LXWAJV, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, MFZDGK, MOUNBL, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, MFZDGK, EAKSTS, QBMJVH
-            ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, SEMCGE, None, None, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, QBMJVH),
-            XQVXOI: GeckoEnumStructAccessor(
-                self.struct, XQVXOI, QVXOIH, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoTimeStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoTimeStructAccessor(self.struct, IHBXIB, HBXIBH, QBMJVH),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, QBMJVH),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, BHZVOA, None, ACMCVD, None, None, QBMJVH
-            ),
-            CMCVDS: GeckoTimeStructAccessor(self.struct, CMCVDS, MCVDSS, QBMJVH),
-            CVDSSR: GeckoEnumStructAccessor(
-                self.struct, CVDSSR, QJYMOU, LXWAJV, SSRURA, None, JYMOUN, QBMJVH
-            ),
-            SRURAZ: GeckoEnumStructAccessor(
-                self.struct, SRURAZ, RURAZM, None, AZMKQT, None, None, QBMJVH
-            ),
-            ZMKQTD: GeckoWordStructAccessor(self.struct, ZMKQTD, MKQTDK, QBMJVH),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, MJIGYO, MAOAWB, DKHTZB, None, JYMOUN, QBMJVH
-            ),
-            KHTZBB: GeckoBoolStructAccessor(
-                self.struct, KHTZBB, MJIGYO, MOUNBL, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MJIGYO, EAKSTS, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, MJIGYO, EKBDFS, QBMJVH
-            ),
-            KBDFSR: GeckoBoolStructAccessor(
-                self.struct, KBDFSR, MJIGYO, BDFSRO, QBMJVH
-            ),
-            DFSROG: GeckoBoolStructAccessor(
-                self.struct, DFSROG, FSROGM, YOUSPB, QBMJVH
-            ),
-            SROGMD: GeckoBoolStructAccessor(
-                self.struct, SROGMD, FSROGM, MAOAWB, QBMJVH
-            ),
-            ROGMDD: GeckoEnumStructAccessor(
-                self.struct, ROGMDD, FSROGM, JYMOUN, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DDPMXF: GeckoEnumStructAccessor(
-                self.struct, DDPMXF, FSROGM, LXWAJV, MDDPMX, None, JYMOUN, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, FSROGM, MOUNBL, LOINEL, None, OINELW, QBMJVH
-            ),
-            INELWU: GeckoEnumStructAccessor(
-                self.struct, INELWU, FSROGM, BDFSRO, LWUEUH, None, JYMOUN, QBMJVH
-            ),
-            TTGCRH: GeckoBoolStructAccessor(
-                self.struct, TTGCRH, TGCRHY, MAOAWB, QBMJVH
-            ),
-            GCRHYU: GeckoEnumStructAccessor(
-                self.struct, GCRHYU, TGCRHY, JYMOUN, HYUAXN, None, MOUNBL, QBMJVH
-            ),
-            YUAXNC: GeckoBoolStructAccessor(
-                self.struct, YUAXNC, TGCRHY, MOUNBL, QBMJVH
-            ),
-            UAXNCU: GeckoEnumStructAccessor(
-                self.struct, UAXNCU, TGCRHY, EKBDFS, NCUGUC, None, MOUNBL, QBMJVH
-            ),
-            CUGUCY: GeckoByteStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoBoolStructAccessor(
-                self.struct, GUCYRA, QJYMOU, YOUSPB, QBMJVH
-            ),
-            UCYRAP: GeckoByteStructAccessor(self.struct, UCYRAP, CYRAPU, QBMJVH),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, RAPUME, None, MEAOES, None, None, QBMJVH
-            ),
-            EAOESV: GeckoEnumStructAccessor(
-                self.struct, EAOESV, AOESVZ, None, MEAOES, None, None, QBMJVH
-            ),
-            OESVZS: GeckoEnumStructAccessor(
-                self.struct, OESVZS, ESVZSS, None, MEAOES, None, None, QBMJVH
-            ),
-            SVZSSB: GeckoEnumStructAccessor(
-                self.struct, SVZSSB, VZSSBV, None, MEAOES, None, None, QBMJVH
-            ),
-            ZSSBVN: GeckoEnumStructAccessor(
-                self.struct, ZSSBVN, SSBVNA, None, MEAOES, None, None, QBMJVH
-            ),
-            SBVNAX: GeckoEnumStructAccessor(
-                self.struct, SBVNAX, BVNAXA, None, AXADXL, None, None, QBMJVH
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, ADXLUB, None, LUBGJF, None, None, QBMJVH
-            ),
-            UBGJFJ: GeckoEnumStructAccessor(
-                self.struct, UBGJFJ, BGJFJN, YOUSPB, TUVRFL, None, OINELW, QBMJVH
-            ),
-            UVRFLS: GeckoBoolStructAccessor(
-                self.struct, UVRFLS, BGJFJN, BDFSRO, QBMJVH
-            ),
-            VRFLSI: GeckoEnumStructAccessor(
-                self.struct, VRFLSI, RFLSIJ, None, MEAOES, None, None, QBMJVH
-            ),
-            FLSIJU: GeckoByteStructAccessor(self.struct, FLSIJU, LSIJUZ, QBMJVH),
-            SIJUZM: GeckoWordStructAccessor(self.struct, SIJUZM, IJUZMR, QBMJVH),
-            JUZMRK: GeckoWordStructAccessor(self.struct, JUZMRK, UZMRKV, QBMJVH),
-            ZMRKVF: GeckoWordStructAccessor(self.struct, ZMRKVF, MRKVFC, QBMJVH),
-            RKVFCP: GeckoWordStructAccessor(self.struct, RKVFCP, KVFCPO, QBMJVH),
-            VFCPOU: GeckoWordStructAccessor(self.struct, VFCPOU, FCPOUB, QBMJVH),
-            CPOUBM: GeckoWordStructAccessor(self.struct, CPOUBM, POUBMI, QBMJVH),
-            OUBMIK: GeckoWordStructAccessor(self.struct, OUBMIK, UBMIKG, QBMJVH),
-            BMIKGN: GeckoWordStructAccessor(self.struct, BMIKGN, MIKGNV, QBMJVH),
-            IKGNVF: GeckoWordStructAccessor(self.struct, IKGNVF, KGNVFO, QBMJVH),
-            GNVFOU: GeckoWordStructAccessor(self.struct, GNVFOU, NVFOUU, QBMJVH),
-            VFOUUR: GeckoEnumStructAccessor(
-                self.struct, VFOUUR, FOUURI, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            URIEVB: GeckoEnumStructAccessor(
-                self.struct, URIEVB, FOUURI, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            VBVHDV: GeckoEnumStructAccessor(
-                self.struct, VBVHDV, BVHDVR, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            VHDVRI: GeckoEnumStructAccessor(
-                self.struct, VHDVRI, BVHDVR, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            HDVRID: GeckoEnumStructAccessor(
-                self.struct, HDVRID, DVRIDK, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            VRIDKE: GeckoEnumStructAccessor(
-                self.struct, VRIDKE, DVRIDK, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            RIDKEY: GeckoEnumStructAccessor(
-                self.struct, RIDKEY, IDKEYG, YOUSPB, UURIEV, None, JYMOUN, None
-            ),
-            DKEYGG: GeckoEnumStructAccessor(
-                self.struct, DKEYGG, IDKEYG, MAOAWB, EVBVHD, None, JYMOUN, None
-            ),
-            KEYGGV: GeckoEnumStructAccessor(
-                self.struct, KEYGGV, EYGGVY, YOUSPB, YKLTQL, None, OINELW, None
-            ),
-            KLTQLV: GeckoEnumStructAccessor(
-                self.struct, KLTQLV, EYGGVY, LXWAJV, QLVHSV, None, OINELW, QBMJVH
-            ),
-            LVHSVS: GeckoBoolStructAccessor(self.struct, LVHSVS, EYGGVY, BDFSRO, None),
-            VHSVSI: GeckoBoolStructAccessor(self.struct, VHSVSI, FOUURI, MOUNBL, None),
-            HSVSIB: GeckoBoolStructAccessor(self.struct, HSVSIB, FOUURI, EAKSTS, None),
-            SVSIBE: GeckoBoolStructAccessor(self.struct, SVSIBE, FOUURI, EKBDFS, None),
-            VSIBEX: GeckoBoolStructAccessor(self.struct, VSIBEX, FOUURI, BDFSRO, None),
-            SIBEXL: GeckoBoolStructAccessor(self.struct, SIBEXL, BVHDVR, MOUNBL, None),
-            IBEXLT: GeckoBoolStructAccessor(self.struct, IBEXLT, BVHDVR, EAKSTS, None),
-            BEXLTP: GeckoBoolStructAccessor(self.struct, BEXLTP, BVHDVR, EKBDFS, None),
-            EXLTPO: GeckoBoolStructAccessor(self.struct, EXLTPO, BVHDVR, BDFSRO, None),
-            XLTPOX: GeckoBoolStructAccessor(self.struct, XLTPOX, DVRIDK, MOUNBL, None),
-            LTPOXI: GeckoBoolStructAccessor(self.struct, LTPOXI, DVRIDK, EAKSTS, None),
-            TPOXIU: GeckoBoolStructAccessor(self.struct, TPOXIU, DVRIDK, EKBDFS, None),
-            POXIUV: GeckoBoolStructAccessor(self.struct, POXIUV, DVRIDK, BDFSRO, None),
-            OXIUVM: GeckoBoolStructAccessor(self.struct, OXIUVM, IDKEYG, MOUNBL, None),
-            XIUVMK: GeckoBoolStructAccessor(self.struct, XIUVMK, IDKEYG, EAKSTS, None),
-            IUVMKZ: GeckoBoolStructAccessor(self.struct, IUVMKZ, IDKEYG, EKBDFS, None),
-            UVMKZH: GeckoBoolStructAccessor(self.struct, UVMKZH, IDKEYG, BDFSRO, None),
-            VMKZHW: GeckoEnumStructAccessor(
-                self.struct, VMKZHW, MKZHWO, None, GXXYOJ, None, None, None
-            ),
-            XXYOJQ: GeckoEnumStructAccessor(
-                self.struct, XXYOJQ, XYOJQS, MOUNBL, OJQSGM, None, OINELW, QBMJVH
-            ),
-            JQSGME: GeckoBoolStructAccessor(self.struct, JQSGME, XYOJQS, BDFSRO, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-82.py
+++ b/src/geckolib/driver/packs/inyt-cfg-82.py
@@ -12,2100 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACMCVD = 157
-ACQFFT = 115
-AFIKJP = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = 66
-AIVEMV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-AJVDQL = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AMJMAO = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-AOAWBS = "".join(chr(c) for c in [76, 111])
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 49])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-AXADXL = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BDFSRO = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BDJQRJ = 167
-BEKBDF = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BEXLTP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BHZVOA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-BIAMJM = 57
-BJLOIN = "".join(chr(c) for c in [82, 69, 68])
-BMIKGN = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        55,
-    ]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 60
-BQNRXC = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-BQSNQL = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-BSIRYX = 1
-BSKSOK = 40
-BSSUHB = 162
-BVNAXA = 177
-BWJYKL = 0
-BXYBQS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-CHWDAF = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-CMCVDS = "".join(chr(c) for c in [79, 70, 70])
-CPOUBM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        53,
-    ]
-)
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-CRHYUA = 112
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CTTGCR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-CUGUCY = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-CVDSSR = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CYWONF = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-CYXMPY = 82
-CZOLSI = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DAFIKJ = 106
-DDPMXF = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-DGKEAK = 82
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DKEYGG = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-DKHTZB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-DMPSCT = "".join(chr(c) for c in [73, 100, 111, 108])
-DNIBXT = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-DNQGVU = 92
-DPMXFU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-DRXAIV = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-DSBDJQ = 166
-DVRIDK = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-DXLUBG = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-DZXNQT = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-EAKSTS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-EAOESV = "".join(chr(c) for c in [80, 52])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = 29
-EKBDFS = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = 31
-ELHBQN = 101
-ELWUEU = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-EMCGET = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EMVCYW = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = 174
-ETDRXA = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-EUHNNX = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-EUTOPH = 83
-EVBVHD = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EXLTPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-EYGGVY = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-EZFETD = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-FCPOUB = 143
-FCRTFM = "".join(chr(c) for c in [105, 110, 89, 74])
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FFTTID = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-FIKJPU = 107
-FJNTTU = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-FJTACC = 43
-FLSIJU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        66,
-        117,
-        111,
-        121,
-        97,
-        110,
-        99,
-        121,
-        80,
-        117,
-        109,
-        112,
-    ]
-)
-FMNHTB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-FOUURI = 155
-FSROGM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTTIDU = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-FUBJLO = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-FWRKIN = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FXQGLR = 16
-FYLJUI = 61
-FZCZOL = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-GCRHYU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-GETIXQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-GGVYKL = 127
-GJFJNT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-GKEAKS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GNVFOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        57,
-    ]
-)
-GQPLSP = 32
-GSELHB = 100
-GTYIYW = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-GUCYRA = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-GVUNXN = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-GVYKLT = "".join(chr(c) for c in [49])
-GXXYOJ = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-GYOUSP = 56
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBQNRX = 102
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = "".join(chr(c) for c in [67, 69])
-HBXIBH = 160
-HDVRID = 124
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-HSVSIB = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-HTBJEU = 74
-HTZBBE = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HUGTYI = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = 105
-HWOGXX = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-HYUAXN = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HZVOAC = 130
-IACQFF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-IAMJMA = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-IBEXLT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-IBHZVO = 128
-IBXTIA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-IBXYBQ = 30
-ICXQIE = 13
-IDKEYG = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-IDNIBX = 68
-IDUBSS = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IEFXQG = 15
-IEVBVH = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-IFJBIA = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-IGYOUS = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IHBXIB = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-IIDNIB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IJUGSE = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-IJUZMR = 136
-IKFWRK = "".join(chr(c) for c in [80, 49])
-IKGNVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        56,
-    ]
-)
-IKJPUN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-ILXWAJ = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-INELWU = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-IPOUYN = 47
-IRYXBQ = 58
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUVMKZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = 91
-IVEMVC = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 73
-IYWSKW = 88
-JBIAMJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-JEUTOP = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JFJNTT = 135
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = 55
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-JJVYFC = 170
-JLOINE = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JNTTUV = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-JPUNRJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JQRJJJ = 168
-JQSGME = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = 99
-JUIKFW = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-    ]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JWMNZM = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JYKLGQ = 118
-JYMOUN = 2
-JZTATD = 4
-KBDFSR = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-KCWAON = 21
-KEAKST = 72
-KEYGGV = 126
-KGNVFO = 151
-KHTZBB = 64
-KINEJN = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-KJPUNR = 108
-KLGQPL = 120
-KLTQLV = "".join(chr(c) for c in [52])
-KMLOIJ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(chr(c) for c in [65, 109, 80, 109])
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KVFCPO = 141
-KVKZIL = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-KWIVDN = 90
-KXSJWM = 80
-KZHWOG = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-LAIIDN = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LHBQNR = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-LIUXFE = 25
-LJUIKF = 62
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 33
-LOIJUG = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-LOINEL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = 178
-LSIPMD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-LSPFTS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTPOXI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-LUBGJF = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-LVHSVS = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-MAOAWB = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-MCBFEG = 163
-MCGETI = 76
-MCVDSS = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-MDDPMX = 110
-MDMPSC = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-MEAOES = "".join(chr(c) for c in [80, 51])
-MFZDGK = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-MHXEKV = "".join(chr(c) for c in [67])
-MIKGNV = 149
-MJIGYO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-MJMAOA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-MJVHFT = 12
-MKQTDK = 34
-MKZHWO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-MLOIJU = 97
-MNHTBJ = 122
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MRKVFC = 139
-MVCYWO = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-MXFUBJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-NAXADX = 133
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NCUGUC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-NEJNIB = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-NELWUE = "".join(chr(c) for c in [67, 89, 65, 78])
-NFZCZO = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-NHTBJE = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-NIBXTI = 70
-NIBXYB = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-NKMLOI = 96
-NMHXEK = "".join(chr(c) for c in [70])
-NNXWEE = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQLNMH = 1
-NQTMFZ = 10
-NRJZTA = 3
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-NTTUVR = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-NVFOUU = 153
-NXNKML = 95
-NXWEEZ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-NZMJIG = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OACMCV = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-OAWBSI = "".join(chr(c) for c in [72, 105])
-OCTHBS = 38
-OESVZS = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 50])
-OGMDDP = 7
-OGXXYO = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-OIHBXI = 75
-OIJUGS = 98
-OINELW = "".join(chr(c) for c in [66, 76, 85, 69])
-OJQSGM = 179
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-ONFZCZ = "".join(chr(c) for c in [80, 68, 67])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        54,
-    ]
-)
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = 81
-OUURIE = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-OUYNQJ = 48
-OXIUVM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-PHUGTY = 85
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-PMDMPS = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-PMXFUB = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-POUBMI = 145
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-POXIUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-PUMEAO = 173
-PUNRJZ = 109
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-QGLRAH = 26
-QGVUNX = 93
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = 35
-QLNMHX = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QLVHSV = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 103
-QPLSPF = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-QSNQLN = 63
-QTDKHT = "".join(chr(c) for c in [50, 52, 104])
-QTMFZD = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QVXOIH = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 121
-RAZMKQ = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-RFLSIJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-RHYUAX = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-RIDKEY = 125
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = 169
-RJZTAT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-RKVFCP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        51,
-    ]
-)
-ROGMDD = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-RURAZM = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-RXAIVE = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-RXCHWD = 104
-RYXBQF = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-SBVNAX = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 53])
-SCTTGC = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-SELHBQ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-SEMCGE = 5
-SGMECY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-SIBEXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-SIFJBI = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-SIJUZM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SIPMDM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-SIRYXB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SJWMNZ = 180
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-SNQLNM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [79, 119, 110])
-SPFTSI = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SROGMD = 6
-SRURAZ = 158
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = 176
-SSRURA = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SSUHBV = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-STSEMC = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-SUHBVW = 51
-SVSIBE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-SVZSSB = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 51])
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = 6
-TBJEUT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TDRXAI = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-TDZXNQ = 116
-TFMNHT = 53
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 77
-TIDUBS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-TIXQVX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-TMFZDG = 71
-TOPHUG = 84
-TPOXIU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-TQLVHS = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-TSEMCG = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-TSIFJB = 27
-TTGCRH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-TTIDUB = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-TTUVRF = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-TUVRFL = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = 87
-TZBBEK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBGJFJ = "".join(
-    chr(c)
-    for c in [
-        85,
-        83,
-        69,
-        95,
-        86,
-        65,
-        82,
-        73,
-        65,
-        66,
-        76,
-        69,
-        95,
-        83,
-        80,
-        69,
-        69,
-        68,
-        95,
-        80,
-        85,
-        77,
-        80,
-        83,
-    ]
-)
-UBJLOI = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-UBMIKG = 147
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-UBYGDS = 52
-UCYRAP = 113
-UEUHNN = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-UGSELH = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UGTYIY = 86
-UHBVWV = "".join(chr(c) for c in [85, 76])
-UHNNXW = 111
-UIKFWR = 78
-UJUTYE = 18
-UMEAOE = "".join(chr(c) for c in [80, 50])
-UNBLKX = 79
-UNRJZT = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-UNXNKM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-URIEVB = "".join(chr(c) for c in [82, 71, 66])
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UTOPHU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-UTYEKC = 19
-UURIEV = 123
-UVMKZH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-UVRFLS = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = 137
-VBVHDV = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-VCYWON = "".join(chr(c) for c in [76, 65])
-VDNQGV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-VDQLAI = 3
-VDSSRU = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-VEMVCY = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-VFCPOU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        52,
-    ]
-)
-VFOUUR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-        48,
-    ]
-)
-VHDVRI = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 164
-VLASSA = "".join(chr(c) for c in [])
-VMKZHW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-VNAXAD = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-VOACMC = 132
-VRIDKE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-VSIBEX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-VUBYGD = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-VUNXNK = 94
-VWVUBY = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-VYFCRT = 171
-VYKLTQ = "".join(chr(c) for c in [50])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = 175
-WAJVDQ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-WAONPY = 22
-WBSIRY = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WDAFIK = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-WEEZFE = "".join(chr(c) for c in [65, 108, 112, 115])
-WIVDNQ = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-WJYKLG = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-WMNZMJ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-WOGXXY = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-WONFZC = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-WRKINE = 28
-WSKWIV = 89
-WUEUHN = 8
-WVUBYG = 114
-XADXLU = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-XAIVEM = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XIBHZV = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XIUVMK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-XLTPOX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-XLUBGJ = 134
-XNCUGU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-XNKMLO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-XNQTMF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-XOIHBX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        83,
-        97,
-        102,
-        101,
-        116,
-        121,
-    ]
-)
-XTIACQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XWEEZF = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-XXYOJQ = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-XYBQSN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-YEKCWA = 20
-YFCRTF = "".join(chr(c) for c in [105, 110, 89, 84])
-YGDSBD = 165
-YGGVYK = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-YIYWSK = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-YKLGQP = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-YKLTQL = "".join(chr(c) for c in [51])
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YLJUIK = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOJQSG = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-YOUSPB = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-YUAXNC = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-YWONFZ = "".join(chr(c) for c in [77, 65, 65, 88])
-YWSKWI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-YXBQFY = 59
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-ZDGKEA = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ZFETDR = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ZHWOGX = 172
-ZILXWA = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-ZMJIGY = 54
-ZMKQTD = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-ZMRKVF = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        50,
-    ]
-)
-ZOLSIP = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZSSBVN = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 52])
-ZTATDZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZXNQTM = 8
-ADXLUB = [AXADXL, XADXLU]
-AOESVZ = [JVHFTH, IKFWRK, UMEAOE, MEAOES, EAOESV, YYPIPI]
-AWBSIR = [AOAWBS, OAWBSI]
-AZMKQT = [URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BGJFJN = [LUBGJF, UBGJFJ]
-BJEUTO = [BXYBQS, TBJEUT]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BVHDVR = [EVBVHD, VBVHDV]
-BVWVUB = [UHBVWV, HBVWVU]
-BXIBHZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-BXTIAC = [BXYBQS, IBXTIA]
-CRTFMN = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    YFCRTF,
-    VLASSA,
-    FCRTFM,
-]
-DFSROG = [KBDFSR, BDFSRO]
-DSSRUR = [JVHFTH, CMCVDS, MCVDSS, CVDSSR, VDSSRU]
-DUBSSU = [CQFFTT, QFFTTI, FFTTID, FTTIDU, TTIDUB, TIDUBS, IDUBSS]
-ECYXMP = []
-ETIXQV = [CGETIX, GETIXQ]
-FJBIAM = [SIFJBI, IFJBIA]
-FZDGKE = [JVHFTH, SIFJBI, MFZDGK]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-GMECYX = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-    XSJWMN,
-]
-HXEKVK = [NMHXEK, MHXEKV]
-INEJNI = [RKINEJ, KINEJN]
-JMAOAW = [IAMJMA, AMJMAO, MJMAOA]
-JNIBXY = [PIPIVL, IKFWRK]
-JVDQLA = [WAJVDQ, AJVDQL]
-KFWRKI = [JVHFTH, IKFWRK, PIPIVL]
-LTQLVH = [VLASSA, GVYKLT, VYKLTQ, YKLTQL, KLTQLV]
-LWUEUH = [CMCVDS, BJLOIN, JLOINE, LOINEL, OINELW, INELWU, NELWUE, ELWUEU]
-LXWAJV = [KZILXW, ZILXWA, ILXWAJ]
-MECYXM = [NBLKXS]
-MNZMJI = [JWMNZM, WMNZMJ]
-PBWJYK = [USPBWJ, SPBWJY]
-PFTSIF = [QPLSPF, PLSPFT, LSPFTS, SPFTSI]
-QSGMEC = [JQSGME, ELWUEU, JLOINE, QLVHSV, LOINEL, NELWUE, LVHSVS, CMCVDS]
-RIEVBV = [URIEVB, ELWUEU]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-TDKHTZ = [JVHFTH, KQTDKH, QTDKHT]
-TGCRHY = [
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-    CTTGCR,
-    TTGCRH,
-]
-UAXNCU = [HYUAXN, YUAXNC, VLASSA, VLASSA]
-UGUCYR = [JVHFTH, NCUGUC, CUGUCY, VLASSA]
-VHSVSI = [OINELW, ELWUEU, JLOINE, QLVHSV, LOINEL, NELWUE, LVHSVS, CMCVDS]
-VRFLSI = [FJNTTU, JNTTUV, NTTUVR, TTUVRF, TUVRFL, UVRFLS, VLASSA, VLASSA]
-VXOIHB = [VLASSA, XQVXOI, QVXOIH]
-XCHWDA = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-XFUBJL = [PMXFUB, MXFUBJ]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-XYOJQS = [HWOGXX, WOGXXY, OGXXYO, GXXYOJ, XXYOJQ]
-YBQSNQ = [BXYBQS, XYBQSN]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -2113,445 +19,1603 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return CYXMPY
+        return 82
 
     @property
     def output_keys(self):
-        return GMECYX
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MNZMJI, None, None, None
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, BWJYKL, PBWJYK, None, JYMOUN, QBMJVH
-            ),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, JMAOAW, None, None, QBMJVH
-            ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, OUSPBW, JYMOUN, AWBSIR, None, JYMOUN, QBMJVH
-            ),
-            WBSIRY: GeckoBoolStructAccessor(
-                self.struct, WBSIRY, QJYMOU, BSIRYX, QBMJVH
-            ),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoByteStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
-            ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoEnumStructAccessor(
-                self.struct, NIBXYB, IBXYBQ, None, YBQSNQ, None, None, QBMJVH
-            ),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoTempStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, HXEKVK, None, None, QBMJVH
-            ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, JNIBXY, None, None, QBMJVH
-            ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, LXWAJV, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, OUSPBW, VDQLAI, JVDQLA, None, JYMOUN, QBMJVH
-            ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoTempStructAccessor(self.struct, LAIIDN, AIIDNI, QBMJVH),
-            IIDNIB: GeckoTempStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, DUBSSU, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, SUHBVW, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, CRTFMN, None, None, None
-            ),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, BJEUTO, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, XLSXUJ, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NKMLOI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, QBMJVH),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, QBMJVH),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, XCHWDA, None, None, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, XCHWDA, None, None, QBMJVH
-            ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, XCHWDA, None, None, QBMJVH
-            ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, None, XCHWDA, None, None, QBMJVH
-            ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, XCHWDA, None, None, QBMJVH
-            ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, XCHWDA, None, None, QBMJVH
-            ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, QBMJVH),
-            RJZTAT: GeckoTimeStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoTimeStructAccessor(self.struct, ZTATDZ, TATDZX, QBMJVH),
-            ATDZXN: GeckoTimeStructAccessor(self.struct, ATDZXN, TDZXNQ, QBMJVH),
-            DZXNQT: GeckoTimeStructAccessor(self.struct, DZXNQT, ZXNQTM, QBMJVH),
-            XNQTMF: GeckoTimeStructAccessor(self.struct, XNQTMF, NQTMFZ, QBMJVH),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, None, FZDGKE, None, None, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, BWJYKL, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, KEAKST, JYMOUN, QBMJVH
-            ),
-            EAKSTS: GeckoBoolStructAccessor(
-                self.struct, EAKSTS, KEAKST, BWJYKL, QBMJVH
-            ),
-            AKSTSE: GeckoBoolStructAccessor(
-                self.struct, AKSTSE, KEAKST, BSIRYX, QBMJVH
-            ),
-            KSTSEM: GeckoBoolStructAccessor(
-                self.struct, KSTSEM, KEAKST, VDQLAI, QBMJVH
-            ),
-            STSEMC: GeckoBoolStructAccessor(
-                self.struct, STSEMC, KEAKST, MOUNBL, QBMJVH
-            ),
-            TSEMCG: GeckoBoolStructAccessor(
-                self.struct, TSEMCG, KEAKST, SEMCGE, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, IXQVXO, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoByteStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, HBXIBH, None, BXIBHZ, None, None, QBMJVH
-            ),
-            XIBHZV: GeckoTimeStructAccessor(self.struct, XIBHZV, IBHZVO, QBMJVH),
-            BHZVOA: GeckoTimeStructAccessor(self.struct, BHZVOA, HZVOAC, QBMJVH),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, QBMJVH),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, ACMCVD, None, DSSRUR, None, None, QBMJVH
-            ),
-            SSRURA: GeckoTimeStructAccessor(self.struct, SSRURA, SRURAZ, QBMJVH),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, QJYMOU, VDQLAI, AZMKQT, None, JYMOUN, QBMJVH
-            ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, TDKHTZ, None, None, QBMJVH
-            ),
-            DKHTZB: GeckoWordStructAccessor(self.struct, DKHTZB, KHTZBB, QBMJVH),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, OUSPBW, BSIRYX, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, OUSPBW, MOUNBL, QBMJVH
-            ),
-            EKBDFS: GeckoEnumStructAccessor(
-                self.struct, EKBDFS, OUSPBW, SEMCGE, DFSROG, None, JYMOUN, QBMJVH
-            ),
-            FSROGM: GeckoBoolStructAccessor(
-                self.struct, FSROGM, OUSPBW, SROGMD, QBMJVH
-            ),
-            ROGMDD: GeckoBoolStructAccessor(
-                self.struct, ROGMDD, OUSPBW, OGMDDP, QBMJVH
-            ),
-            GMDDPM: GeckoBoolStructAccessor(
-                self.struct, GMDDPM, MDDPMX, BWJYKL, QBMJVH
-            ),
-            DDPMXF: GeckoBoolStructAccessor(
-                self.struct, DDPMXF, MDDPMX, BSIRYX, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, MDDPMX, JYMOUN, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            FUBJLO: GeckoEnumStructAccessor(
-                self.struct, FUBJLO, MDDPMX, VDQLAI, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            UBJLOI: GeckoEnumStructAccessor(
-                self.struct, UBJLOI, MDDPMX, MOUNBL, LWUEUH, None, WUEUHN, QBMJVH
-            ),
-            UEUHNN: GeckoEnumStructAccessor(
-                self.struct, UEUHNN, MDDPMX, OGMDDP, MNZMJI, None, JYMOUN, QBMJVH
-            ),
-            GCRHYU: GeckoBoolStructAccessor(
-                self.struct, GCRHYU, CRHYUA, BSIRYX, QBMJVH
-            ),
-            RHYUAX: GeckoEnumStructAccessor(
-                self.struct, RHYUAX, CRHYUA, JYMOUN, UAXNCU, None, MOUNBL, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, CRHYUA, MOUNBL, QBMJVH
-            ),
-            XNCUGU: GeckoEnumStructAccessor(
-                self.struct, XNCUGU, CRHYUA, SROGMD, UGUCYR, None, MOUNBL, QBMJVH
-            ),
-            GUCYRA: GeckoByteStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoBoolStructAccessor(
-                self.struct, CYRAPU, QJYMOU, BWJYKL, QBMJVH
-            ),
-            YRAPUM: GeckoByteStructAccessor(self.struct, YRAPUM, RAPUME, QBMJVH),
-            APUMEA: GeckoEnumStructAccessor(
-                self.struct, APUMEA, PUMEAO, None, AOESVZ, None, None, QBMJVH
-            ),
-            OESVZS: GeckoEnumStructAccessor(
-                self.struct, OESVZS, ESVZSS, None, AOESVZ, None, None, QBMJVH
-            ),
-            SVZSSB: GeckoEnumStructAccessor(
-                self.struct, SVZSSB, VZSSBV, None, AOESVZ, None, None, QBMJVH
-            ),
-            ZSSBVN: GeckoEnumStructAccessor(
-                self.struct, ZSSBVN, SSBVNA, None, AOESVZ, None, None, QBMJVH
-            ),
-            SBVNAX: GeckoEnumStructAccessor(
-                self.struct, SBVNAX, BVNAXA, None, AOESVZ, None, None, QBMJVH
-            ),
-            VNAXAD: GeckoEnumStructAccessor(
-                self.struct, VNAXAD, NAXADX, None, ADXLUB, None, None, QBMJVH
-            ),
-            DXLUBG: GeckoEnumStructAccessor(
-                self.struct, DXLUBG, XLUBGJ, None, BGJFJN, None, None, QBMJVH
-            ),
-            GJFJNT: GeckoEnumStructAccessor(
-                self.struct, GJFJNT, JFJNTT, BWJYKL, VRFLSI, None, WUEUHN, QBMJVH
-            ),
-            RFLSIJ: GeckoBoolStructAccessor(
-                self.struct, RFLSIJ, JFJNTT, OGMDDP, QBMJVH
-            ),
-            FLSIJU: GeckoEnumStructAccessor(
-                self.struct, FLSIJU, LSIJUZ, None, AOESVZ, None, None, QBMJVH
-            ),
-            SIJUZM: GeckoByteStructAccessor(self.struct, SIJUZM, IJUZMR, QBMJVH),
-            JUZMRK: GeckoWordStructAccessor(self.struct, JUZMRK, UZMRKV, QBMJVH),
-            ZMRKVF: GeckoWordStructAccessor(self.struct, ZMRKVF, MRKVFC, QBMJVH),
-            RKVFCP: GeckoWordStructAccessor(self.struct, RKVFCP, KVFCPO, QBMJVH),
-            VFCPOU: GeckoWordStructAccessor(self.struct, VFCPOU, FCPOUB, QBMJVH),
-            CPOUBM: GeckoWordStructAccessor(self.struct, CPOUBM, POUBMI, QBMJVH),
-            OUBMIK: GeckoWordStructAccessor(self.struct, OUBMIK, UBMIKG, QBMJVH),
-            BMIKGN: GeckoWordStructAccessor(self.struct, BMIKGN, MIKGNV, QBMJVH),
-            IKGNVF: GeckoWordStructAccessor(self.struct, IKGNVF, KGNVFO, QBMJVH),
-            GNVFOU: GeckoWordStructAccessor(self.struct, GNVFOU, NVFOUU, QBMJVH),
-            VFOUUR: GeckoWordStructAccessor(self.struct, VFOUUR, FOUURI, QBMJVH),
-            OUURIE: GeckoEnumStructAccessor(
-                self.struct, OUURIE, UURIEV, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            IEVBVH: GeckoEnumStructAccessor(
-                self.struct, IEVBVH, UURIEV, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            VHDVRI: GeckoEnumStructAccessor(
-                self.struct, VHDVRI, HDVRID, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            DVRIDK: GeckoEnumStructAccessor(
-                self.struct, DVRIDK, HDVRID, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            VRIDKE: GeckoEnumStructAccessor(
-                self.struct, VRIDKE, RIDKEY, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            IDKEYG: GeckoEnumStructAccessor(
-                self.struct, IDKEYG, RIDKEY, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            DKEYGG: GeckoEnumStructAccessor(
-                self.struct, DKEYGG, KEYGGV, BWJYKL, RIEVBV, None, JYMOUN, None
-            ),
-            EYGGVY: GeckoEnumStructAccessor(
-                self.struct, EYGGVY, KEYGGV, BSIRYX, BVHDVR, None, JYMOUN, None
-            ),
-            YGGVYK: GeckoEnumStructAccessor(
-                self.struct, YGGVYK, GGVYKL, BWJYKL, LTQLVH, None, WUEUHN, None
-            ),
-            TQLVHS: GeckoEnumStructAccessor(
-                self.struct, TQLVHS, GGVYKL, VDQLAI, VHSVSI, None, WUEUHN, QBMJVH
-            ),
-            HSVSIB: GeckoBoolStructAccessor(self.struct, HSVSIB, GGVYKL, OGMDDP, None),
-            SVSIBE: GeckoBoolStructAccessor(self.struct, SVSIBE, UURIEV, MOUNBL, None),
-            VSIBEX: GeckoBoolStructAccessor(self.struct, VSIBEX, UURIEV, SEMCGE, None),
-            SIBEXL: GeckoBoolStructAccessor(self.struct, SIBEXL, UURIEV, SROGMD, None),
-            IBEXLT: GeckoBoolStructAccessor(self.struct, IBEXLT, UURIEV, OGMDDP, None),
-            BEXLTP: GeckoBoolStructAccessor(self.struct, BEXLTP, HDVRID, MOUNBL, None),
-            EXLTPO: GeckoBoolStructAccessor(self.struct, EXLTPO, HDVRID, SEMCGE, None),
-            XLTPOX: GeckoBoolStructAccessor(self.struct, XLTPOX, HDVRID, SROGMD, None),
-            LTPOXI: GeckoBoolStructAccessor(self.struct, LTPOXI, HDVRID, OGMDDP, None),
-            TPOXIU: GeckoBoolStructAccessor(self.struct, TPOXIU, RIDKEY, MOUNBL, None),
-            POXIUV: GeckoBoolStructAccessor(self.struct, POXIUV, RIDKEY, SEMCGE, None),
-            OXIUVM: GeckoBoolStructAccessor(self.struct, OXIUVM, RIDKEY, SROGMD, None),
-            XIUVMK: GeckoBoolStructAccessor(self.struct, XIUVMK, RIDKEY, OGMDDP, None),
-            IUVMKZ: GeckoBoolStructAccessor(self.struct, IUVMKZ, KEYGGV, MOUNBL, None),
-            UVMKZH: GeckoBoolStructAccessor(self.struct, UVMKZH, KEYGGV, SEMCGE, None),
-            VMKZHW: GeckoBoolStructAccessor(self.struct, VMKZHW, KEYGGV, SROGMD, None),
-            MKZHWO: GeckoBoolStructAccessor(self.struct, MKZHWO, KEYGGV, OGMDDP, None),
-            KZHWOG: GeckoEnumStructAccessor(
-                self.struct, KZHWOG, ZHWOGX, None, XYOJQS, None, None, None
-            ),
-            YOJQSG: GeckoEnumStructAccessor(
-                self.struct, YOJQSG, OJQSGM, MOUNBL, QSGMEC, None, WUEUHN, QBMJVH
-            ),
-            SGMECY: GeckoBoolStructAccessor(self.struct, SGMECY, OJQSGM, OGMDDP, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-83.py
+++ b/src/geckolib/driver/packs/inyt-cfg-83.py
@@ -12,2155 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-ACMCVD = 157
-ACQFFT = 115
-ADXLUB = 175
-AFIKJP = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-AIIDNI = 66
-AIVEMV = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-AJVDQL = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-AKQXPI = "".join(chr(c) for c in [72, 84, 82, 50])
-AKSTSE = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AMJMAO = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-AOAWBS = "".join(chr(c) for c in [76, 111])
-AOESVZ = "".join(
-    chr(c)
-    for c in [86, 83, 80, 72, 101, 97, 116, 105, 110, 103, 83, 112, 101, 101, 100]
-)
-AONPYY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-APUMEA = "".join(chr(c) for c in [86, 83, 80, 84, 121, 112, 101])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-AXADXL = 174
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BDFSRO = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BDJQRJ = 167
-BEKBDF = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BEXLTP = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-BFEGZU = "".join(chr(c) for c in [70, 50])
-BGJFJN = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-BHZVOA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-BIAMJM = 57
-BJLOIN = "".join(chr(c) for c in [82, 69, 68])
-BMIKGN = 139
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 60
-BQNRXC = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-BQSNQL = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-BSIRYX = 1
-BSKSOK = 40
-BSSUHB = 162
-BVHDVR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-        48,
-    ]
-)
-BVNAXA = "".join(chr(c) for c in [80, 52])
-BWJYKL = 0
-BXYBQS = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-BYGDSB = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-CBFEGZ = "".join(chr(c) for c in [70, 49])
-CCPQIP = 45
-CGETIX = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-CHWDAF = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-CMCVDS = "".join(chr(c) for c in [79, 70, 70])
-CPOUBM = 136
-CPQIPO = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-CRHYUA = 112
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-CTTGCR = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-CUGUCY = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-CVDSSR = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 51])
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CYWONF = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-CZOLSI = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DAFIKJ = 106
-DDPMXF = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-DGKEAK = 82
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        49,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-DKEYGG = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-DKHTZB = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-DMPSCT = "".join(chr(c) for c in [73, 100, 111, 108])
-DNIBXT = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-DNQGVU = 92
-DPMXFU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-DRXAIV = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-DSBDJQ = 166
-DVRIDK = 123
-DXLUBG = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 52])
-DZXNQT = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-EAKSTS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-ECYXMP = "".join(chr(c) for c in [65, 83, 95, 49, 50, 86, 95, 83, 85, 80, 80, 76, 89])
-EEZFET = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-EFJTAC = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 53])
-EGZUQE = "".join(chr(c) for c in [70, 50, 49])
-EJNIBX = 29
-EKBDFS = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EKCWAO = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-EKVKZI = 31
-ELHBQN = 101
-ELWUEU = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-EMCGET = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-EMVCYW = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        86,
-        83,
-        80,
-        70,
-        105,
-        108,
-        116,
-        101,
-        114,
-        105,
-        110,
-        103,
-        83,
-        112,
-        101,
-        101,
-        100,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-EUHNNX = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-EUTOPH = 83
-EVBVHD = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        57,
-    ]
-)
-EXLSXU = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-EXLTPO = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-EZFETD = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-FCPOUB = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-FCRTFM = "".join(chr(c) for c in [105, 110, 89, 74])
-FEFJTA = 42
-FEGZUQ = "".join(chr(c) for c in [70, 51])
-FETDRX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-FFTTID = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-FIKJPU = 107
-FJNTTU = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-FJTACC = 43
-FLSIJU = 135
-FMNHTB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-FOUURI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        54,
-    ]
-)
-FSROGM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-FTTIDU = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-FUBJLO = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-FWRKIN = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-FXQGLR = 16
-FYLJUI = 61
-FZCZOL = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-GCRHYU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-GDSBDJ = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-GETIXQ = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-GGVYKL = 124
-GJFJNT = 133
-GKEAKS = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-GMDDPM = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-GMECYX = "".join(chr(c) for c in [90, 79, 78, 69, 51])
-GNVFOU = 143
-GQPLSP = 32
-GSELHB = 100
-GTYIYW = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-GUCYRA = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-GVUNXN = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-GVYKLT = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-GXXYOJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-GYOUSP = 56
-GZUQEX = "".join(chr(c) for c in [70, 50, 50])
-HBQNRX = 102
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-HBVWVU = "".join(chr(c) for c in [67, 69])
-HBXIBH = 160
-HDVRID = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 37
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [55, 65])
-HNNXWE = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-HSVSIB = "".join(chr(c) for c in [49])
-HTBJEU = 74
-HTZBBE = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HUGTYI = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-HUOJRJ = "".join(chr(c) for c in [49, 65])
-HWDAFI = 105
-HWOGXX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-HYUAXN = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-HZVOAC = 130
-IACQFF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-IAMJMA = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-IBHZVO = 128
-IBXTIA = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-IBXYBQ = 30
-ICXQIE = 13
-IDKEYG = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-IDNIBX = 68
-IDUBSS = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IEFXQG = 15
-IEVBVH = 151
-IFJBIA = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-IGYOUS = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-IHBXIB = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-IIDNIB = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-IJUGSE = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-IJUZMR = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-IKFWRK = "".join(chr(c) for c in [80, 49])
-IKGNVF = 141
-IKJPUN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-ILXWAJ = "".join(
-    chr(c) for c in [80, 114, 101, 115, 115, 117, 114, 101, 83, 119, 105, 116, 99, 104]
-)
-INELWU = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-IPOUYN = 47
-IRYXBQ = 58
-IUSOOQ = "".join(chr(c) for c in [56, 65])
-IUVMKZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-IUXFEF = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-IVDNQG = 91
-IVEMVC = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = 73
-IYWSKW = 88
-JBIAMJ = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-JEUTOP = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-JFJNTT = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-JHIUSO = "".join(chr(c) for c in [54, 65])
-JIGYOU = 55
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-JJVGBX = 83
-JJVYFC = 170
-JLOINE = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-JMCBFE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-JPUNRJ = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JQRJJJ = 168
-JQSGME = 172
-JRJHIU = "".join(chr(c) for c in [52, 65])
-JTACCP = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-JUGSEL = 99
-JUIKFW = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-JUTYEK = "".join(chr(c) for c in [79, 117, 116, 56])
-JUZMRK = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [82, 101, 97, 108, 80, 97, 99, 107, 84, 121, 112, 101])
-JWMNZM = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-JYKLGQ = 118
-JYMOUN = 2
-JZTATD = 4
-KBDFSR = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-KCWAON = 21
-KEAKST = 72
-KEYGGV = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-KGNVFO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        52,
-    ]
-)
-KHTZBB = 64
-KINEJN = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-KJPUNR = 108
-KLGQPL = 120
-KLTQLV = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-KMLOIJ = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-KPHUOJ = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-KQTDKH = "".join(chr(c) for c in [65, 109, 80, 109])
-KQXPIC = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KSOKPH = 50
-KSTSEM = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-KVFCPO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        66,
-        117,
-        111,
-        121,
-        97,
-        110,
-        99,
-        121,
-        80,
-        117,
-        109,
-        112,
-    ]
-)
-KVKZIL = "".join(
-    chr(c) for c in [70, 108, 111, 119, 68, 101, 116, 101, 99, 116, 111, 114]
-)
-KWIVDN = 90
-KXSJWM = 80
-KZHWOG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 70, 108, 111])
-LAIIDN = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-LHBQNR = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-LIUXFE = 25
-LJUIKF = 62
-LKXSJW = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-LNMHXE = 33
-LOIJUG = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-LOINEL = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-LSIJUZ = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-LSIPMD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-LSPFTS = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-LSXUJU = "".join(chr(c) for c in [79, 117, 116, 54])
-LTQLVH = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-LUBGJF = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 53])
-LVHSVS = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-MAOAWB = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-MCBFEG = 163
-MCGETI = 76
-MCVDSS = "".join(chr(c) for c in [69, 67, 79, 78, 79, 77, 89])
-MDDPMX = 110
-MDMPSC = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-MEAOES = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        99,
-        107,
-        111,
-        95,
-        86,
-        77,
-        83,
-        95,
-        79,
-        110,
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-    ]
-)
-MECYXM = "".join(chr(c) for c in [90, 79, 78, 69, 52])
-MFZDGK = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-MHXEKV = "".join(chr(c) for c in [67])
-MIKGNV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        51,
-    ]
-)
-MJIGYO = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-MJMAOA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-MJVHFT = 12
-MKQTDK = 34
-MKZHWO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-MLOIJU = 97
-MNHTBJ = 122
-MOUNBL = 4
-MPSCTT = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-MPYDZQ = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-MVCYWO = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-MXFUBJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-NAXADX = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 50])
-NBLKXS = "".join(chr(c) for c in [76, 73])
-NCUGUC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-NEJNIB = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-NELWUE = "".join(chr(c) for c in [67, 89, 65, 78])
-NFZCZO = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-NHTBJE = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-NIBXTI = 70
-NIBXYB = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-NKMLOI = 96
-NMHXEK = "".join(chr(c) for c in [70])
-NNXWEE = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-NPYYLI = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-NQGVUN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-NQJYMO = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-NQLNMH = 1
-NQTMFZ = 10
-NRJZTA = 3
-NRSJMC = "".join(chr(c) for c in [49, 52, 65])
-NRXCHW = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-NTTUVR = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-NVFOUU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        53,
-    ]
-)
-NXNKML = 95
-NXWEEZ = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-NZMJIG = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OACMCV = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-OAWBSI = "".join(chr(c) for c in [72, 105])
-OCTHBS = 38
-OESVZS = 182
-OGMDDP = 7
-OGXXYO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-OIHBXI = 75
-OIJUGS = 98
-OINELW = "".join(chr(c) for c in [66, 76, 85, 69])
-OJQSGM = "".join(
-    chr(c)
-    for c in [
-        73,
-        110,
-        77,
-        105,
-        120,
-        90,
-        111,
-        110,
-        101,
-        84,
-        111,
-        70,
-        111,
-        108,
-        108,
-        111,
-        119,
-    ]
-)
-OJRJHI = "".join(chr(c) for c in [51, 65])
-OKPHUO = 161
-OLSIPM = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-ONFZCZ = "".join(chr(c) for c in [80, 68, 67])
-ONPYYL = 23
-OOQNRS = "".join(chr(c) for c in [49, 49, 65])
-OPHUGT = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-OQNRSJ = "".join(chr(c) for c in [49, 50, 65])
-OUBMIK = 137
-OUNBLK = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-OUSPBW = 81
-OUURIE = 147
-OUYNQJ = 48
-OXIUVM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-PHUGTY = 85
-PHUOJR = "".join(chr(c) for c in [48, 65])
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 50])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-PMDMPS = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-PMXFUB = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-POUBMI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        49,
-    ]
-)
-POUYNQ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-POXIUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-PQIPOU = 46
-PSCTTG = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-PUMEAO = 181
-PUNRJZ = 109
-PYYLIU = 24
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-QFFTTI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-QGLRAH = 26
-QGVUNX = 93
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 52])
-QIPOUY = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QJYMOU = 119
-QLAIID = 35
-QLNMHX = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-QLVHSV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-QNRSJM = "".join(chr(c) for c in [49, 51, 65])
-QNRXCH = 103
-QPLSPF = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QRJJJV = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        50,
-        112,
-        104,
-        97,
-        115,
-        101,
-        68,
-        117,
-        97,
-        108,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-QSGMEC = "".join(chr(c) for c in [90, 79, 78, 69, 49])
-QSNQLN = 63
-QTDKHT = "".join(chr(c) for c in [50, 52, 104])
-QTMFZD = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-QVXOIH = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-QXPICX = "".join(chr(c) for c in [65, 85, 88])
-RAHEOC = 36
-RAPUME = 121
-RAZMKQ = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-RFLSIJ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-RHYUAX = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-RIEVBV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        56,
-    ]
-)
-RJHIUS = "".join(chr(c) for c in [53, 65])
-RJJJVY = 169
-RJZTAT = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-RKINEJ = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-RKVFCP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-ROGMDD = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-RSJMCB = "".join(chr(c) for c in [49, 53, 65])
-RTFMNH = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-RURAZM = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-RXAIVE = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-RXCHWD = 104
-RYXBQF = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-SAKQXP = "".join(chr(c) for c in [80, 114, 111, 116, 101, 99, 116, 105, 111, 110])
-SBDJQR = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        51,
-        112,
-        104,
-        97,
-        115,
-        101,
-        83,
-        105,
-        110,
-        103,
-        108,
-        101,
-        80,
-        97,
-        99,
-        107,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-SBVNAX = "".join(chr(c) for c in [80, 51])
-SCTTGC = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-SELHBQ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-SEMCGE = 5
-SGMECY = "".join(chr(c) for c in [90, 79, 78, 69, 50])
-SIBEXL = "".join(chr(c) for c in [52])
-SIFJBI = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-SIJUZM = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-SIPMDM = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-SIRYXB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-SJWMNZ = 180
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-SKWIVD = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-SNQLNM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-SOKPHU = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-SOOQNR = "".join(chr(c) for c in [49, 48, 65])
-SPBWJY = "".join(chr(c) for c in [79, 119, 110])
-SPFTSI = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-SROGMD = 6
-SRURAZ = 158
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(chr(c) for c in [80, 50])
-SSRURA = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SSUHBV = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-STSEMC = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-SUHBVW = 51
-SVSIBE = "".join(chr(c) for c in [50])
-SVZSSB = 183
-SXUJUT = 17
-TACCPQ = 44
-TATDZX = 6
-TBJEUT = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-TDRXAI = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-TDZXNQ = 116
-TFMNHT = 53
-THBSKS = 39
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 77
-TIDUBS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-TIXQVX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-TMFZDG = 71
-TOPHUG = 84
-TPOXIU = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-TQLVHS = 126
-TSEMCG = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-TSIFJB = 27
-TTGCRH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-TTIDUB = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-TTUVRF = 134
-TUVRFL = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 57])
-TYIYWS = 87
-TZBBEK = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-UBGJFJ = 177
-UBJLOI = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-UBMIKG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        50,
-    ]
-)
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-UBYGDS = 52
-UCYRAP = 113
-UEUHNN = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-UGSELH = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UGTYIY = 86
-UHBVWV = "".join(chr(c) for c in [85, 76])
-UHNNXW = 111
-UIKFWR = 78
-UJUTYE = 18
-UMEAOE = "".join(chr(c) for c in [78, 111, 86, 115, 112])
-UNBLKX = 79
-UNRJZT = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-UNXNKM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-UOJRJH = "".join(chr(c) for c in [50, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-URAZMK = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-URIEVB = 149
-USOOQN = "".join(chr(c) for c in [57, 65])
-USPBWJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UTOPHU = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-UTYEKC = 19
-UURIEV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        99,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-        55,
-    ]
-)
-UVMKZH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-UVRFLS = "".join(
-    chr(c)
-    for c in [
-        85,
-        83,
-        69,
-        95,
-        86,
-        65,
-        82,
-        73,
-        65,
-        66,
-        76,
-        69,
-        95,
-        83,
-        80,
-        69,
-        69,
-        68,
-        95,
-        80,
-        85,
-        77,
-        80,
-        83,
-    ]
-)
-UXFEFJ = 41
-UYNQJY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UZMRKV = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-VBVHDV = 153
-VCYWON = "".join(chr(c) for c in [76, 65])
-VDNQGV = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-VDQLAI = 3
-VDSSRU = "".join(chr(c) for c in [78, 73, 71, 72, 84])
-VEMVCY = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-VFCPOU = 178
-VFOUUR = 145
-VHDVRI = 155
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VHSVSI = 127
-VKZILX = 164
-VLASSA = "".join(chr(c) for c in [])
-VMKZHW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-VOACMC = 132
-VRIDKE = "".join(chr(c) for c in [82, 71, 66])
-VSIBEX = "".join(chr(c) for c in [51])
-VUBYGD = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-VUNXNK = 94
-VWVUBY = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-VYFCRT = 171
-VYKLTQ = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 49])
-WAJVDQ = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-WAONPY = 22
-WBSIRY = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WDAFIK = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-WEEZFE = "".join(chr(c) for c in [65, 108, 112, 115])
-WIVDNQ = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-WJYKLG = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-WMNZMJ = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-WOGXXY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-WONFZC = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-WRKINE = 28
-WSKWIV = 89
-WUEUHN = 8
-WVUBYG = 114
-XADXLU = "".join(chr(c) for c in [65, 115, 115, 105, 103, 110, 86, 83, 80, 51])
-XAIVEM = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XBQFYL = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-XEKVKZ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-XFEFJT = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-XIBHZV = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-XIUVMK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-XLTPOX = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-XLUBGJ = 176
-XMPYDZ = 179
-XNCUGU = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-XNKMLO = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-XNQTMF = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-XOIHBX = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-XQGLRA = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-XQIEFX = 14
-XQVXOI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        76,
-        105,
-        103,
-        104,
-        116,
-        65,
-        99,
-        116,
-        105,
-        118,
-        97,
-        116,
-        105,
-        111,
-        110,
-        83,
-        97,
-        102,
-        101,
-        116,
-        121,
-    ]
-)
-XTIACQ = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-XUJUTY = "".join(chr(c) for c in [79, 117, 116, 55])
-XWAJVD = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-XWEEZF = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-XXYOJQ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-XYBQSN = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-XYOJQS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-YDZQJJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-YEKCWA = 20
-YFCRTF = "".join(chr(c) for c in [105, 110, 89, 84])
-YGDSBD = 165
-YGGVYK = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-YIYWSK = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-YKLGQP = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-YKLTQL = 125
-YLIUXF = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YLJUIK = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-YNQJYM = 49
-YOJQSG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-YOUSPB = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-YUAXNC = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-YWONFZ = "".join(chr(c) for c in [77, 65, 65, 88])
-YWSKWI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-YXBQFY = 59
-YXMPYD = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-ZDGKEA = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-ZFETDR = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ZHWOGX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-ZILXWA = "".join(
-    chr(c) for c in [78, 111, 116, 73, 110, 115, 116, 97, 108, 108, 101, 100]
-)
-ZMJIGY = 54
-ZMKQTD = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-ZMRKVF = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-ZOLSIP = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZSSBVN = 173
-ZTATDZ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [70, 50, 51])
-ZVOACM = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZXNQTM = 8
-AWBSIR = [AOAWBS, OAWBSI]
-AZMKQT = [URAZMK, RAZMKQ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BJEUTO = [BXYBQS, TBJEUT]
-BLKXSJ = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    NBLKXS,
-]
-BVWVUB = [UHBVWV, HBVWVU]
-BXIBHZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    QXPICX,
-]
-BXTIAC = [BXYBQS, IBXTIA]
-CRTFMN = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    YFCRTF,
-    VLASSA,
-    FCRTFM,
-]
-CYXMPY = [QSGMEC, SGMECY, GMECYX, MECYXM, ECYXMP]
-DFSROG = [KBDFSR, BDFSRO]
-DSSRUR = [JVHFTH, CMCVDS, MCVDSS, CVDSSR, VDSSRU]
-DUBSSU = [CQFFTT, QFFTTI, FFTTID, FTTIDU, TTIDUB, TIDUBS, IDUBSS]
-DZQJJV = [
-    BMJVHF,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    XQGLRA,
-    SOKPHU,
-    JMCBFE,
-    LSXUJU,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    AONPYY,
-    NPYYLI,
-    YLIUXF,
-    OUNBLK,
-    XSJWMN,
-]
-EAOESV = [UMEAOE, NNXWEE, MEAOES]
-ETIXQV = [CGETIX, GETIXQ]
-EYGGVY = [DKEYGG, KEYGGV]
-FJBIAM = [SIFJBI, IFJBIA]
-FZDGKE = [JVHFTH, SIFJBI, MFZDGK]
-GLRAHE = [
-    JVHFTH,
-    VHFTHE,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    AKQXPI,
-]
-HXEKVK = [NMHXEK, MHXEKV]
-IBEXLT = [VLASSA, HSVSIB, SVSIBE, VSIBEX, SIBEXL]
-INEJNI = [RKINEJ, KINEJN]
-JMAOAW = [IAMJMA, AMJMAO, MJMAOA]
-JNIBXY = [PIPIVL, IKFWRK]
-JNTTUV = [JFJNTT, FJNTTU]
-JVDQLA = [WAJVDQ, AJVDQL]
-KFWRKI = [JVHFTH, IKFWRK, PIPIVL]
-LTPOXI = [OINELW, ELWUEU, JLOINE, EXLTPO, LOINEL, NELWUE, XLTPOX, CMCVDS]
-LWUEUH = [CMCVDS, BJLOIN, JLOINE, LOINEL, OINELW, INELWU, NELWUE, ELWUEU]
-LXWAJV = [KZILXW, ZILXWA, ILXWAJ]
-MNZMJI = [JWMNZM, WMNZMJ]
-MRKVFC = [LSIJUZ, SIJUZM, IJUZMR, JUZMRK, UZMRKV, ZMRKVF, VLASSA, VLASSA]
-PBWJYK = [USPBWJ, SPBWJY]
-PFTSIF = [QPLSPF, PLSPFT, LSPFTS, SPFTSI]
-PYDZQJ = [MPYDZQ, ELWUEU, JLOINE, EXLTPO, LOINEL, NELWUE, XLTPOX, CMCVDS]
-QJJVGB = []
-RIDKEY = [VRIDKE, ELWUEU]
-SJMCBF = [
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-]
-TDKHTZ = [JVHFTH, KQTDKH, QTDKHT]
-TGCRHY = [
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-    XAIVEM,
-    AIVEMV,
-    IVEMVC,
-    VEMVCY,
-    EMVCYW,
-    MVCYWO,
-    VCYWON,
-    CYWONF,
-    YWONFZ,
-    WONFZC,
-    ONFZCZ,
-    NFZCZO,
-    FZCZOL,
-    ZCZOLS,
-    CZOLSI,
-    ZOLSIP,
-    OLSIPM,
-    LSIPMD,
-    SIPMDM,
-    IPMDMP,
-    PMDMPS,
-    MDMPSC,
-    DMPSCT,
-    MPSCTT,
-    PSCTTG,
-    SCTTGC,
-    CTTGCR,
-    TTGCRH,
-]
-UAXNCU = [HYUAXN, YUAXNC, VLASSA, VLASSA]
-UGUCYR = [JVHFTH, NCUGUC, CUGUCY, VLASSA]
-VNAXAD = [JVHFTH, IKFWRK, SSBVNA, SBVNAX, BVNAXA, YYPIPI]
-VRFLSI = [TUVRFL, UVRFLS]
-VXOIHB = [VLASSA, XQVXOI, QVXOIH]
-XCHWDA = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, UQEXLS, QEXLSX, EXLSXU]
-XFUBJL = [PMXFUB, MXFUBJ]
-XLSXUJ = [CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX, EXLSXU]
-XPICXQ = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-    QXPICX,
-]
-YBQSNQ = [BXYBQS, XYBQSN]
-YYLIUX = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-ZQJJVG = [NBLKXS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -2168,450 +19,1619 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JJVGBX
+        return 83
 
     @property
     def output_keys(self):
-        return DZQJJV
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, XPICXQ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, XPICXQ, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XPICXQ, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, XPICXQ, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XPICXQ, None, None, QBMJVH
-            ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, QGLRAH, None, GLRAHE, None, None, QBMJVH
-            ),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoByteStructAccessor(self.struct, SKSOKP, KSOKPH, QBMJVH),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, SJMCBF, None, None, QBMJVH
-            ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, XPICXQ, None, None, QBMJVH
-            ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, XPICXQ, None, None, QBMJVH
-            ),
-            JUTYEK: GeckoEnumStructAccessor(
-                self.struct, JUTYEK, UTYEKC, None, XPICXQ, None, None, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, XPICXQ, None, None, QBMJVH
-            ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, XPICXQ, None, None, QBMJVH
-            ),
-            CWAONP: GeckoEnumStructAccessor(
-                self.struct, CWAONP, WAONPY, None, XPICXQ, None, None, QBMJVH
-            ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, XPICXQ, None, None, QBMJVH
-            ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, YYLIUX, None, None, QBMJVH
-            ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, QBMJVH
-            ),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, QBMJVH),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, QBMJVH),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, QBMJVH),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, QBMJVH),
-            QIPOUY: GeckoByteStructAccessor(self.struct, QIPOUY, IPOUYN, QBMJVH),
-            POUYNQ: GeckoByteStructAccessor(self.struct, POUYNQ, OUYNQJ, QBMJVH),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, QBMJVH),
-            NQJYMO: GeckoBoolStructAccessor(
-                self.struct, NQJYMO, QJYMOU, JYMOUN, QBMJVH
-            ),
-            YMOUNB: GeckoBoolStructAccessor(
-                self.struct, YMOUNB, QJYMOU, MOUNBL, QBMJVH
-            ),
-            OUNBLK: GeckoEnumStructAccessor(
-                self.struct, OUNBLK, UNBLKX, None, BLKXSJ, None, None, None
-            ),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MNZMJI, None, None, None
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoEnumStructAccessor(
-                self.struct, YOUSPB, OUSPBW, BWJYKL, PBWJYK, None, JYMOUN, QBMJVH
-            ),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, QBMJVH),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, QBMJVH),
-            LGQPLS: GeckoEnumStructAccessor(
-                self.struct, LGQPLS, GQPLSP, None, PFTSIF, None, None, QBMJVH
-            ),
-            FTSIFJ: GeckoEnumStructAccessor(
-                self.struct, FTSIFJ, TSIFJB, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, BIAMJM, None, JMAOAW, None, None, QBMJVH
-            ),
-            MAOAWB: GeckoEnumStructAccessor(
-                self.struct, MAOAWB, OUSPBW, JYMOUN, AWBSIR, None, JYMOUN, QBMJVH
-            ),
-            WBSIRY: GeckoBoolStructAccessor(
-                self.struct, WBSIRY, QJYMOU, BSIRYX, QBMJVH
-            ),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoByteStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoByteStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoByteStructAccessor(self.struct, YLJUIK, LJUIKF, QBMJVH),
-            JUIKFW: GeckoEnumStructAccessor(
-                self.struct, JUIKFW, UIKFWR, None, KFWRKI, None, None, QBMJVH
-            ),
-            FWRKIN: GeckoEnumStructAccessor(
-                self.struct, FWRKIN, WRKINE, None, INEJNI, None, None, QBMJVH
-            ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, JNIBXY, None, None, QBMJVH
-            ),
-            NIBXYB: GeckoEnumStructAccessor(
-                self.struct, NIBXYB, IBXYBQ, None, YBQSNQ, None, None, QBMJVH
-            ),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, QBMJVH),
-            SNQLNM: GeckoTempStructAccessor(self.struct, SNQLNM, NQLNMH, QBMJVH),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, HXEKVK, None, None, QBMJVH
-            ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, EKVKZI, None, JNIBXY, None, None, QBMJVH
-            ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, LXWAJV, None, None, QBMJVH
-            ),
-            XWAJVD: GeckoEnumStructAccessor(
-                self.struct, XWAJVD, OUSPBW, VDQLAI, JVDQLA, None, JYMOUN, QBMJVH
-            ),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, QBMJVH),
-            LAIIDN: GeckoTempStructAccessor(self.struct, LAIIDN, AIIDNI, QBMJVH),
-            IIDNIB: GeckoTempStructAccessor(self.struct, IIDNIB, IDNIBX, QBMJVH),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, DUBSSU, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, SUHBVW, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoByteStructAccessor(self.struct, VWVUBY, WVUBYG, QBMJVH),
-            VUBYGD: GeckoByteStructAccessor(self.struct, VUBYGD, UBYGDS, QBMJVH),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, CRTFMN, None, None, None
-            ),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, QBMJVH),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, QBMJVH),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, BJEUTO, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, XLSXUJ, None, None, QBMJVH
-            ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, XLSXUJ, None, None, QBMJVH
-            ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, XLSXUJ, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, XLSXUJ, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, XLSXUJ, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, XLSXUJ, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, XLSXUJ, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NKMLOI, None, XLSXUJ, None, None, QBMJVH
-            ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, XLSXUJ, None, None, QBMJVH
-            ),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, QBMJVH),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, QBMJVH),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, XCHWDA, None, None, QBMJVH
-            ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, XCHWDA, None, None, QBMJVH
-            ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, XCHWDA, None, None, QBMJVH
-            ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, None, XCHWDA, None, None, QBMJVH
-            ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, XCHWDA, None, None, QBMJVH
-            ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, XCHWDA, None, None, QBMJVH
-            ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, QBMJVH),
-            RJZTAT: GeckoTimeStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoTimeStructAccessor(self.struct, ZTATDZ, TATDZX, QBMJVH),
-            ATDZXN: GeckoTimeStructAccessor(self.struct, ATDZXN, TDZXNQ, QBMJVH),
-            DZXNQT: GeckoTimeStructAccessor(self.struct, DZXNQT, ZXNQTM, QBMJVH),
-            XNQTMF: GeckoTimeStructAccessor(self.struct, XNQTMF, NQTMFZ, QBMJVH),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, None, FZDGKE, None, None, QBMJVH
-            ),
-            ZDGKEA: GeckoBoolStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, BWJYKL, QBMJVH
-            ),
-            GKEAKS: GeckoBoolStructAccessor(
-                self.struct, GKEAKS, KEAKST, JYMOUN, QBMJVH
-            ),
-            EAKSTS: GeckoBoolStructAccessor(
-                self.struct, EAKSTS, KEAKST, BWJYKL, QBMJVH
-            ),
-            AKSTSE: GeckoBoolStructAccessor(
-                self.struct, AKSTSE, KEAKST, BSIRYX, QBMJVH
-            ),
-            KSTSEM: GeckoBoolStructAccessor(
-                self.struct, KSTSEM, KEAKST, VDQLAI, QBMJVH
-            ),
-            STSEMC: GeckoBoolStructAccessor(
-                self.struct, STSEMC, KEAKST, MOUNBL, QBMJVH
-            ),
-            TSEMCG: GeckoBoolStructAccessor(
-                self.struct, TSEMCG, KEAKST, SEMCGE, QBMJVH
-            ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, ETIXQV, None, None, QBMJVH
-            ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, IXQVXO, None, VXOIHB, None, None, QBMJVH
-            ),
-            XOIHBX: GeckoByteStructAccessor(self.struct, XOIHBX, OIHBXI, QBMJVH),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, HBXIBH, None, BXIBHZ, None, None, QBMJVH
-            ),
-            XIBHZV: GeckoTimeStructAccessor(self.struct, XIBHZV, IBHZVO, QBMJVH),
-            BHZVOA: GeckoTimeStructAccessor(self.struct, BHZVOA, HZVOAC, QBMJVH),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, QBMJVH),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, ACMCVD, None, DSSRUR, None, None, QBMJVH
-            ),
-            SSRURA: GeckoTimeStructAccessor(self.struct, SSRURA, SRURAZ, QBMJVH),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, QJYMOU, VDQLAI, AZMKQT, None, JYMOUN, QBMJVH
-            ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, TDKHTZ, None, None, QBMJVH
-            ),
-            DKHTZB: GeckoWordStructAccessor(self.struct, DKHTZB, KHTZBB, QBMJVH),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, OUSPBW, BSIRYX, BBEKBD, None, JYMOUN, QBMJVH
-            ),
-            BEKBDF: GeckoBoolStructAccessor(
-                self.struct, BEKBDF, OUSPBW, MOUNBL, QBMJVH
-            ),
-            EKBDFS: GeckoEnumStructAccessor(
-                self.struct, EKBDFS, OUSPBW, SEMCGE, DFSROG, None, JYMOUN, QBMJVH
-            ),
-            FSROGM: GeckoBoolStructAccessor(
-                self.struct, FSROGM, OUSPBW, SROGMD, QBMJVH
-            ),
-            ROGMDD: GeckoBoolStructAccessor(
-                self.struct, ROGMDD, OUSPBW, OGMDDP, QBMJVH
-            ),
-            GMDDPM: GeckoBoolStructAccessor(
-                self.struct, GMDDPM, MDDPMX, BWJYKL, QBMJVH
-            ),
-            DDPMXF: GeckoBoolStructAccessor(
-                self.struct, DDPMXF, MDDPMX, BSIRYX, QBMJVH
-            ),
-            DPMXFU: GeckoEnumStructAccessor(
-                self.struct, DPMXFU, MDDPMX, JYMOUN, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            FUBJLO: GeckoEnumStructAccessor(
-                self.struct, FUBJLO, MDDPMX, VDQLAI, XFUBJL, None, JYMOUN, QBMJVH
-            ),
-            UBJLOI: GeckoEnumStructAccessor(
-                self.struct, UBJLOI, MDDPMX, MOUNBL, LWUEUH, None, WUEUHN, QBMJVH
-            ),
-            UEUHNN: GeckoEnumStructAccessor(
-                self.struct, UEUHNN, MDDPMX, OGMDDP, MNZMJI, None, JYMOUN, QBMJVH
-            ),
-            GCRHYU: GeckoBoolStructAccessor(
-                self.struct, GCRHYU, CRHYUA, BSIRYX, QBMJVH
-            ),
-            RHYUAX: GeckoEnumStructAccessor(
-                self.struct, RHYUAX, CRHYUA, JYMOUN, UAXNCU, None, MOUNBL, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, CRHYUA, MOUNBL, QBMJVH
-            ),
-            XNCUGU: GeckoEnumStructAccessor(
-                self.struct, XNCUGU, CRHYUA, SROGMD, UGUCYR, None, MOUNBL, QBMJVH
-            ),
-            GUCYRA: GeckoByteStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoBoolStructAccessor(
-                self.struct, CYRAPU, QJYMOU, BWJYKL, QBMJVH
-            ),
-            YRAPUM: GeckoByteStructAccessor(self.struct, YRAPUM, RAPUME, QBMJVH),
-            APUMEA: GeckoEnumStructAccessor(
-                self.struct, APUMEA, PUMEAO, None, EAOESV, None, None, QBMJVH
-            ),
-            AOESVZ: GeckoByteStructAccessor(self.struct, AOESVZ, OESVZS, QBMJVH),
-            ESVZSS: GeckoByteStructAccessor(self.struct, ESVZSS, SVZSSB, QBMJVH),
-            VZSSBV: GeckoEnumStructAccessor(
-                self.struct, VZSSBV, ZSSBVN, None, VNAXAD, None, None, QBMJVH
-            ),
-            NAXADX: GeckoEnumStructAccessor(
-                self.struct, NAXADX, AXADXL, None, VNAXAD, None, None, QBMJVH
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, ADXLUB, None, VNAXAD, None, None, QBMJVH
-            ),
-            DXLUBG: GeckoEnumStructAccessor(
-                self.struct, DXLUBG, XLUBGJ, None, VNAXAD, None, None, QBMJVH
-            ),
-            LUBGJF: GeckoEnumStructAccessor(
-                self.struct, LUBGJF, UBGJFJ, None, VNAXAD, None, None, QBMJVH
-            ),
-            BGJFJN: GeckoEnumStructAccessor(
-                self.struct, BGJFJN, GJFJNT, None, JNTTUV, None, None, QBMJVH
-            ),
-            NTTUVR: GeckoEnumStructAccessor(
-                self.struct, NTTUVR, TTUVRF, None, VRFLSI, None, None, QBMJVH
-            ),
-            RFLSIJ: GeckoEnumStructAccessor(
-                self.struct, RFLSIJ, FLSIJU, BWJYKL, MRKVFC, None, WUEUHN, QBMJVH
-            ),
-            RKVFCP: GeckoBoolStructAccessor(
-                self.struct, RKVFCP, FLSIJU, OGMDDP, QBMJVH
-            ),
-            KVFCPO: GeckoEnumStructAccessor(
-                self.struct, KVFCPO, VFCPOU, None, VNAXAD, None, None, QBMJVH
-            ),
-            FCPOUB: GeckoByteStructAccessor(self.struct, FCPOUB, CPOUBM, QBMJVH),
-            POUBMI: GeckoWordStructAccessor(self.struct, POUBMI, OUBMIK, QBMJVH),
-            UBMIKG: GeckoWordStructAccessor(self.struct, UBMIKG, BMIKGN, QBMJVH),
-            MIKGNV: GeckoWordStructAccessor(self.struct, MIKGNV, IKGNVF, QBMJVH),
-            KGNVFO: GeckoWordStructAccessor(self.struct, KGNVFO, GNVFOU, QBMJVH),
-            NVFOUU: GeckoWordStructAccessor(self.struct, NVFOUU, VFOUUR, QBMJVH),
-            FOUURI: GeckoWordStructAccessor(self.struct, FOUURI, OUURIE, QBMJVH),
-            UURIEV: GeckoWordStructAccessor(self.struct, UURIEV, URIEVB, QBMJVH),
-            RIEVBV: GeckoWordStructAccessor(self.struct, RIEVBV, IEVBVH, QBMJVH),
-            EVBVHD: GeckoWordStructAccessor(self.struct, EVBVHD, VBVHDV, QBMJVH),
-            BVHDVR: GeckoWordStructAccessor(self.struct, BVHDVR, VHDVRI, QBMJVH),
-            HDVRID: GeckoEnumStructAccessor(
-                self.struct, HDVRID, DVRIDK, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            IDKEYG: GeckoEnumStructAccessor(
-                self.struct, IDKEYG, DVRIDK, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            YGGVYK: GeckoEnumStructAccessor(
-                self.struct, YGGVYK, GGVYKL, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            GVYKLT: GeckoEnumStructAccessor(
-                self.struct, GVYKLT, GGVYKL, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            VYKLTQ: GeckoEnumStructAccessor(
-                self.struct, VYKLTQ, YKLTQL, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            KLTQLV: GeckoEnumStructAccessor(
-                self.struct, KLTQLV, YKLTQL, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            LTQLVH: GeckoEnumStructAccessor(
-                self.struct, LTQLVH, TQLVHS, BWJYKL, RIDKEY, None, JYMOUN, None
-            ),
-            QLVHSV: GeckoEnumStructAccessor(
-                self.struct, QLVHSV, TQLVHS, BSIRYX, EYGGVY, None, JYMOUN, None
-            ),
-            LVHSVS: GeckoEnumStructAccessor(
-                self.struct, LVHSVS, VHSVSI, BWJYKL, IBEXLT, None, WUEUHN, None
-            ),
-            BEXLTP: GeckoEnumStructAccessor(
-                self.struct, BEXLTP, VHSVSI, VDQLAI, LTPOXI, None, WUEUHN, QBMJVH
-            ),
-            TPOXIU: GeckoBoolStructAccessor(self.struct, TPOXIU, VHSVSI, OGMDDP, None),
-            POXIUV: GeckoBoolStructAccessor(self.struct, POXIUV, DVRIDK, MOUNBL, None),
-            OXIUVM: GeckoBoolStructAccessor(self.struct, OXIUVM, DVRIDK, SEMCGE, None),
-            XIUVMK: GeckoBoolStructAccessor(self.struct, XIUVMK, DVRIDK, SROGMD, None),
-            IUVMKZ: GeckoBoolStructAccessor(self.struct, IUVMKZ, DVRIDK, OGMDDP, None),
-            UVMKZH: GeckoBoolStructAccessor(self.struct, UVMKZH, GGVYKL, MOUNBL, None),
-            VMKZHW: GeckoBoolStructAccessor(self.struct, VMKZHW, GGVYKL, SEMCGE, None),
-            MKZHWO: GeckoBoolStructAccessor(self.struct, MKZHWO, GGVYKL, SROGMD, None),
-            KZHWOG: GeckoBoolStructAccessor(self.struct, KZHWOG, GGVYKL, OGMDDP, None),
-            ZHWOGX: GeckoBoolStructAccessor(self.struct, ZHWOGX, YKLTQL, MOUNBL, None),
-            HWOGXX: GeckoBoolStructAccessor(self.struct, HWOGXX, YKLTQL, SEMCGE, None),
-            WOGXXY: GeckoBoolStructAccessor(self.struct, WOGXXY, YKLTQL, SROGMD, None),
-            OGXXYO: GeckoBoolStructAccessor(self.struct, OGXXYO, YKLTQL, OGMDDP, None),
-            GXXYOJ: GeckoBoolStructAccessor(self.struct, GXXYOJ, TQLVHS, MOUNBL, None),
-            XXYOJQ: GeckoBoolStructAccessor(self.struct, XXYOJQ, TQLVHS, SEMCGE, None),
-            XYOJQS: GeckoBoolStructAccessor(self.struct, XYOJQS, TQLVHS, SROGMD, None),
-            YOJQSG: GeckoBoolStructAccessor(self.struct, YOJQSG, TQLVHS, OGMDDP, None),
-            OJQSGM: GeckoEnumStructAccessor(
-                self.struct, OJQSGM, JQSGME, None, CYXMPY, None, None, None
-            ),
-            YXMPYD: GeckoEnumStructAccessor(
-                self.struct, YXMPYD, XMPYDZ, MOUNBL, PYDZQJ, None, WUEUHN, QBMJVH
-            ),
-            YDZQJJ: GeckoBoolStructAccessor(self.struct, YDZQJJ, XMPYDZ, OGMDDP, None),
         }

--- a/src/geckolib/driver/packs/inyt-cfg-84.py
+++ b/src/geckolib/driver/packs/inyt-cfg-84.py
@@ -1,0 +1,1640 @@
+#!/usr/bin/python3
+"""
+    GeckoConfigStruct - A class to manage the ConfigStruct for 'InYT v84'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoConfigStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 84
+
+    @property
+    def output_keys(self):
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
+            ),
+            "StatusLightFading": GeckoBoolStructAccessor(
+                self.struct, "StatusLightFading", 184, 0, None
+            ),
+        }

--- a/src/geckolib/driver/packs/inyt-cfg-85.py
+++ b/src/geckolib/driver/packs/inyt-cfg-85.py
@@ -1,0 +1,1655 @@
+#!/usr/bin/python3
+"""
+    GeckoConfigStruct - A class to manage the ConfigStruct for 'InYT v85'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoConfigStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 85
+
+    @property
+    def output_keys(self):
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "MassageEnablePump1": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump1", 185, 0, None
+            ),
+            "MassageEnablePump2": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump2", 185, 1, None
+            ),
+            "MassageEnablePump3": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump3", 185, 2, None
+            ),
+            "MassageEnablePump4": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump4", 185, 3, None
+            ),
+            "MassageEnablePump5": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump5", 185, 4, None
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
+            ),
+            "StatusLightFading": GeckoBoolStructAccessor(
+                self.struct, "StatusLightFading", 184, 0, None
+            ),
+        }

--- a/src/geckolib/driver/packs/inyt-cfg-86.py
+++ b/src/geckolib/driver/packs/inyt-cfg-86.py
@@ -1,0 +1,1658 @@
+#!/usr/bin/python3
+"""
+    GeckoConfigStruct - A class to manage the ConfigStruct for 'InYT v86'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoConfigStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 86
+
+    @property
+    def output_keys(self):
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+            "LightActivationSafety",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "ColdPump",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "Protection",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "LightActivationSafety": GeckoEnumStructAccessor(
+                self.struct,
+                "LightActivationSafety",
+                180,
+                None,
+                ["Disable", "Enable"],
+                None,
+                None,
+                None,
+            ),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "FlowDetector": GeckoEnumStructAccessor(
+                self.struct,
+                "FlowDetector",
+                164,
+                None,
+                ["inFlo", "NotInstalled", "PressureSwitch"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "Max1phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseSinglePackCurrent", 165, "ALL"
+            ),
+            "Max2phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseSinglePackCurrent", 166, "ALL"
+            ),
+            "Max3phaseSinglePackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseSinglePackCurrent", 167, "ALL"
+            ),
+            "Max1phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max1phaseDualPackCurrent", 168, "ALL"
+            ),
+            "Max2phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max2phaseDualPackCurrent", 169, "ALL"
+            ),
+            "Max3phaseDualPackCurrent": GeckoByteStructAccessor(
+                self.struct, "Max3phaseDualPackCurrent", 170, "ALL"
+            ),
+            "RealPackType": GeckoEnumStructAccessor(
+                self.struct,
+                "RealPackType",
+                171,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "inYT", "", "inYJ"],
+                None,
+                None,
+                None,
+            ),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "ECONOMY", "SLEEP", "NIGHT"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "GfciTestEnabled": GeckoBoolStructAccessor(
+                self.struct, "GfciTestEnabled", 119, 5, "ALL"
+            ),
+            "VSPType": GeckoEnumStructAccessor(
+                self.struct,
+                "VSPType",
+                181,
+                None,
+                ["NoVsp", "Hydropool", "Gecko_VMS_OnModbus"],
+                None,
+                None,
+                "ALL",
+            ),
+            "VSPHeatingSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPHeatingSpeed", 182, "ALL"
+            ),
+            "VSPFilteringSpeed": GeckoByteStructAccessor(
+                self.struct, "VSPFilteringSpeed", 183, "ALL"
+            ),
+            "AssignVSP1": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP1",
+                173,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP2": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP2",
+                174,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP3": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP3",
+                175,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP4": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP4",
+                176,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AssignVSP5": GeckoEnumStructAccessor(
+                self.struct,
+                "AssignVSP5",
+                177,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS", "USE_VARIABLE_SPEED_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseBuoyancyPump": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseBuoyancyPump",
+                178,
+                None,
+                ["NA", "P1", "P2", "P3", "P4", "P5"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExcercisePumpIntensity1": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity1", 137, "ALL"
+            ),
+            "ExcercisePumpIntensity2": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity2", 139, "ALL"
+            ),
+            "ExcercisePumpIntensity3": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity3", 141, "ALL"
+            ),
+            "ExcercisePumpIntensity4": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity4", 143, "ALL"
+            ),
+            "ExcercisePumpIntensity5": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity5", 145, "ALL"
+            ),
+            "ExcercisePumpIntensity6": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity6", 147, "ALL"
+            ),
+            "ExcercisePumpIntensity7": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity7", 149, "ALL"
+            ),
+            "ExcercisePumpIntensity8": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity8", 151, "ALL"
+            ),
+            "ExcercisePumpIntensity9": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity9", 153, "ALL"
+            ),
+            "ExcercisePumpIntensity10": GeckoWordStructAccessor(
+                self.struct, "ExcercisePumpIntensity10", 155, "ALL"
+            ),
+            "MassageEnablePump1": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump1", 185, 0, None
+            ),
+            "MassageEnablePump2": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump2", 185, 1, None
+            ),
+            "MassageEnablePump3": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump3", 185, 2, None
+            ),
+            "MassageEnablePump4": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump4", 185, 3, None
+            ),
+            "MassageEnablePump5": GeckoBoolStructAccessor(
+                self.struct, "MassageEnablePump5", 185, 4, None
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "InMixZoneToFollow": GeckoEnumStructAccessor(
+                self.struct,
+                "InMixZoneToFollow",
+                172,
+                None,
+                ["ZONE1", "ZONE2", "ZONE3", "ZONE4", "AS_12V_SUPPLY"],
+                None,
+                None,
+                None,
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                179,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 179, 7, None
+            ),
+            "StatusLightFading": GeckoBoolStructAccessor(
+                self.struct, "StatusLightFading", 184, 0, None
+            ),
+        }

--- a/src/geckolib/driver/packs/inyt-log-50.py
+++ b/src/geckolib/driver/packs/inyt-log-50.py
@@ -12,833 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 57])
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-AJVDQL = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 470
-AMJMAO = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BDJQRJ = "".join(chr(c) for c in [72, 84, 82])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-BJEUTO = 328
-BLKXSJ = 274
-BMJVHF = 284
-BQFYLJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 452
-BQSNQL = "".join(chr(c) for c in [105, 110, 89, 84])
-BSIRYX = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 52, 72])
-BVWVUB = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-BWJYKL = 282
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-BXYBQS = "".join(chr(c) for c in [75, 54, 48, 48])
-BYGDSB = 323
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 55])
-CPQIPO = 273
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-CRTFMN = 339
-CTHBSK = 303
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 265
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 456
-DGKEAK = 468
-DNIBXT = 300
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-DQLAII = 296
-DSBDJQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-DUBSSU = "".join(chr(c) for c in [80, 51, 72])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 272
-EFXQGL = 257
-EJNIBX = "".join(chr(c) for c in [77, 73, 65])
-EKCWAO = 263
-EKVKZI = "".join(chr(c) for c in [85, 76])
-ELHBQN = "".join(chr(c) for c in [67, 70, 71, 51])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EUTOPH = 329
-FCRTFM = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = "".join(chr(c) for c in [78, 65])
-FIKJPU = 457
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FTTIDU = "".join(chr(c) for c in [80, 49, 72])
-FWRKIN = 288
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-FZDGKE = 467
-GDSBDJ = 324
-GETIXQ = 474
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-GQPLSP = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [67, 70, 71, 50])
-GTYIYW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-GVUNXN = 345
-GYOUSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 52])
-HBSKSO = 304
-HBXIBH = 479
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 259
-HTBJEU = 327
-HUGTYI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 455
-IACQFF = "".join(chr(c) for c in [70, 117, 108, 108])
-IAMJMA = 354
-IBXTIA = 301
-IBXYBQ = "".join(chr(c) for c in [105, 110, 88, 77])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-IDUBSS = "".join(chr(c) for c in [80, 50, 76])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IGYOUS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-IIDNIB = 299
-IJUGSE = 448
-IKFWRK = 287
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-ILXWAJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-INEJNI = "".join(chr(c) for c in [105, 110, 88, 69])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IUXFEF = 270
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-IYWSKW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = 336
-JJVYFC = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [68, 74, 83, 52])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-JQRJJJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = "".join(chr(c) for c in [67, 70, 71, 49])
-JUIKFW = 285
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = 295
-JVHFTH = 319
-JVYFCR = 337
-JWMNZM = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-JZTATD = 461
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 469
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-KINEJN = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-KJPUNR = 458
-KLGQPL = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 348
-KPHUOJ = 260
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-KVKZIL = "".join(chr(c) for c in [67, 69])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KXSJWM = 276
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-LAIIDN = 297
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LHBQNR = 451
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-LKXSJW = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-LNMHXE = "".join(chr(c) for c in [51, 50, 75])
-LOIJUG = 349
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 262
-LXWAJV = 293
-MAOAWB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-MCBFEG = 310
-MCGETI = 473
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-MHXEKV = "".join(chr(c) for c in [54, 52, 75])
-MJIGYO = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-MJMAOA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-MNHTBJ = 326
-MNZMJI = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MOUNBL = 353
-NBLKXS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NHTBJE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-NIBXTI = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-NIBXYB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-NKMLOI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [52, 56, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = 344
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = 290
-NQTMFZ = 465
-NRJZTA = 460
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 453
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-OACMCV = 479
-OAWBSI = 309
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 478
-OIJUGS = "".join(chr(c) for c in [67, 70, 71, 48])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 266
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PFTSIF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-PHUGTY = 331
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = 350
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 459
-PYYLIU = 267
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = 320
-QFYLJU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-QIEFXQ = 6
-QIPOUY = 281
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-QLNMHX = "".join(chr(c) for c in [49, 54, 75])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 53])
-QPLSPF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-QRJJJV = 335
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-RKINEJ = 289
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 54])
-RYXBQF = 314
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = 325
-SELHBQ = 450
-SEMCGE = 472
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-SIRYXB = 311
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SKSOKP = 305
-SKWIVD = 341
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SSAKQX = 258
-SSUHBV = "".join(chr(c) for c in [80, 52, 76])
-STSEMC = 471
-SUHBVW = "".join(chr(c) for c in [66, 76, 79])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 462
-TBJEUT = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-TDZXNQ = 463
-TFMNHT = 340
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-TIDUBS = "".join(chr(c) for c in [80, 50, 72])
-TIXQVX = 475
-TMFZDG = 466
-TOPHUG = 330
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-TSIFJB = 351
-TTIDUB = "".join(chr(c) for c in [80, 49, 76])
-TYIYWS = 333
-UBSSUH = "".join(chr(c) for c in [80, 51, 76])
-UBYGDS = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-UGSELH = 449
-UGTYIY = 332
-UHBVWV = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-UNXNKM = 346
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = 343
-VDQLAI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VOACMC = 256
-VUBYGD = 322
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-VWVUBY = 321
-VXOIHB = 477
-VYFCRT = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-WAJVDQ = 294
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 56])
-WIVDNQ = 342
-WJYKLG = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-WMNZMJ = 278
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-WVUBYG = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-XBQFYL = 315
-XCHWDA = 454
-XEKVKZ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-XFEFJT = 271
-XIBHZV = "".join(chr(c) for c in [76, 73])
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 347
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 476
-XSJWMN = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-XTIACQ = 316
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-XYBQSN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 338
-YGDSBD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-YKLGQP = 283
-YLIUXF = 269
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = 352
-YPIPIV = 256
-YWSKWI = 334
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ZILXWA = 291
-ZMJIGY = 279
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ZUQEXL = 261
-ZVOACM = 50
-ZXNQTM = 464
-ACQFFT = [TIACQF, IACQFF]
-BHZVOA = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-BXIBHZ = []
-DJQRJJ = [
-    FFTTID,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    BDJQRJ,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HBVWVU = [
-    FFTTID,
-    FTTIDU,
-    TTIDUB,
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    JHIUSO,
-    SUHBVW,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    UHBVWV,
-]
-HXEKVK = [QLNMHX, LNMHXE, NMHXEK, MHXEKV]
-HZVOAC = [
-    QFYLJU,
-    SIFJBI,
-    JBIAMJ,
-    KLGQPL,
-    UNBLKX,
-    BQFYLJ,
-    FYLJUI,
-    JWMNZM,
-    ACCPQI,
-    PFTSIF,
-    QPLSPF,
-    OUSPBW,
-    GYOUSP,
-    YXBQFY,
-    GQPLSP,
-    FTSIFJ,
-    SPFTSI,
-    WJYKLG,
-    BIAMJM,
-    PBWJYK,
-    USPBWJ,
-    IFJBIA,
-    JMAOAW,
-    FJBIAM,
-    SPBWJY,
-    LSPFTS,
-    LGQPLS,
-    JYKLGQ,
-]
-IBHZVO = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    XIBHZV,
-]
-IUSOOQ = [IVLASS, PHUOJR]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-QSNQLN = [
-    KINEJN,
-    INEJNI,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-]
-SJWMNZ = [HFTHEC, XSJWMN, XSJWMN, XSJWMN]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VKZILX = [EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WBSIRY = [HFTHEC, AWBSIR, AWBSIR, AWBSIR]
-YIYWSK = [
-    FFTTID,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -846,265 +19,936 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return ZVOACM
+        return 50
 
     @property
     def begin(self):
-        return VOACMC
+        return 256
 
     @property
     def end(self):
-        return OACMCV
+        return 479
 
     @property
     def all_device_keys(self):
-        return IBHZVO
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return BHZVOA
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return HZVOAC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 284, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                256,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 258, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 258, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 258, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 258, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 257, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 257, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 260, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 260, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 260, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 260, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 259, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 259, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 259, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 259, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 259, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 259, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 259, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, CPQIPO, LRAHEO, None),
-            NBLKXS: GeckoTempStructAccessor(self.struct, NBLKXS, BLKXSJ, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, HIUSOO, RSJMCB, SJWMNZ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                261,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, WMNZMJ, ICXQIE, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, WMNZMJ, QIEFXQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, ICXQIE, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, LRAHEO, None),
-            IGYOUS: GeckoBoolStructAccessor(
-                self.struct, IGYOUS, JIGYOU, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                262,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, YOUSPB, LRAHEO, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, CPQIPO, OQNRSJ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, QIPOUY, QXPICX, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, QIPOUY, LRAHEO, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, ICXQIE, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, OQNRSJ, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, YKLGQP, XPICXQ, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, YKLGQP, RSJMCB, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, YKLGQP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, OQNRSJ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, PLSPFT, XPICXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PLSPFT, RSJMCB, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, PLSPFT, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, ICXQIE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, TSIFJB, OQNRSJ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, YOUSPB, OQNRSJ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, MOUNBL, QXPICX, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, MOUNBL, LRAHEO, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QXPICX, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, ZMJIGY, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, BWJYKL, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, BWJYKL, LRAHEO, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, BWJYKL, XPICXQ, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QXPICX, None),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, OAWBSI, LRAHEO, WBSIRY, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 263, "ALL"
             ),
-            BSIRYX: GeckoWordStructAccessor(self.struct, BSIRYX, SIRYXB, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, QXPICX, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, XBQFYL, LRAHEO, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, TSIFJB, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, TSIFJB, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, TSIFJB, XPICXQ, None),
-            LJUIKF: GeckoWordStructAccessor(self.struct, LJUIKF, JUIKFW, None),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, QSNQLN, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 265, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, QXPICX, HXEKVK, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                261,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, NQLNMH, ICXQIE, VKZILX, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                266,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KZILXW: GeckoWordStructAccessor(self.struct, KZILXW, ZILXWA, None),
-            ILXWAJ: GeckoByteStructAccessor(self.struct, ILXWAJ, LXWAJV, None),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, None),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, None),
-            VDQLAI: GeckoByteStructAccessor(self.struct, VDQLAI, DQLAII, None),
-            QLAIID: GeckoWordStructAccessor(self.struct, QLAIID, LAIIDN, None),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, None),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, None),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, ACQFFT, None, ICXQIE, LASSAK
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 267, "ALL"
             ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, HBVWVU, None, None, LASSAK
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 269, "ALL"
             ),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, VWVUBY, None, HBVWVU, None, None, LASSAK
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 270, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, VUBYGD, None, HBVWVU, None, None, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 271, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, HBVWVU, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 272, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 272, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 272, 3, None
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, HBVWVU, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 272, 4, None
             ),
-            DSBDJQ: GeckoEnumStructAccessor(
-                self.struct, DSBDJQ, SBDJQR, None, DJQRJJ, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 272, 5, None
             ),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, LASSAK),
-            RJJJVY: GeckoByteStructAccessor(self.struct, RJJJVY, JJJVYF, LASSAK),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, LASSAK),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, LASSAK),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, LASSAK),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, LASSAK),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, HBVWVU, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 273, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 281, 3, None
             ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, HBVWVU, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 281, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 281, 6, None
             ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, HBVWVU, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, HBVWVU, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, HBVWVU, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, HBVWVU, None, None, LASSAK
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 273, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 274, None
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, HBVWVU, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 276, None
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, YIYWSK, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                259,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, YIYWSK, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 278, 2, None
             ),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, LASSAK),
-            KWIVDN: GeckoByteStructAccessor(self.struct, KWIVDN, WIVDNQ, LASSAK),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, LASSAK),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, LASSAK),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, LASSAK),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, LASSAK),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, LASSAK),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 278, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 279, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 280, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 280, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 273, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 281, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 281, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 282, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 282, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 283, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 283, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 283, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 283, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 279, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 282, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 282, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 282, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                325,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 340, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                332,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 341, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 342, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 343, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 344, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 345, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 346, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 347, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 348, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 349, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-51.py
+++ b/src/geckolib/driver/packs/inyt-log-51.py
@@ -12,833 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-AFIKJP = "".join(chr(c) for c in [67, 70, 71, 57])
-AHEOCT = 308
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-AJVDQL = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 470
-AMJMAO = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BDJQRJ = "".join(chr(c) for c in [72, 84, 82])
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-BJEUTO = 327
-BLKXSJ = 275
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BQNRXC = 452
-BQSNQL = "".join(chr(c) for c in [105, 110, 89, 84])
-BSIRYX = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 52, 72])
-BVWVUB = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-BWJYKL = 283
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-BXYBQS = "".join(chr(c) for c in [75, 54, 48, 48])
-BYGDSB = 323
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-CHWDAF = "".join(chr(c) for c in [67, 70, 71, 55])
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-CRTFMN = 339
-CTHBSK = 303
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 456
-DGKEAK = 468
-DNIBXT = 300
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-DQLAII = 296
-DSBDJQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-DUBSSU = "".join(chr(c) for c in [80, 51, 72])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [77, 73, 65])
-EKCWAO = 264
-EKVKZI = "".join(chr(c) for c in [85, 76])
-ELHBQN = "".join(chr(c) for c in [67, 70, 71, 51])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EUTOPH = 328
-FCRTFM = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FFTTID = "".join(chr(c) for c in [78, 65])
-FIKJPU = 457
-FJBIAM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FTTIDU = "".join(chr(c) for c in [80, 49, 72])
-FWRKIN = 288
-FYLJUI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-FZDGKE = 467
-GDSBDJ = 324
-GETIXQ = 474
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-GQPLSP = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-GSELHB = "".join(chr(c) for c in [67, 70, 71, 50])
-GTYIYW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-GVUNXN = 344
-GYOUSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = "".join(chr(c) for c in [67, 70, 71, 52])
-HBSKSO = 304
-HBXIBH = 479
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = 326
-HUGTYI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = 455
-IACQFF = "".join(chr(c) for c in [70, 117, 108, 108])
-IAMJMA = 354
-IBXTIA = 301
-IBXYBQ = "".join(chr(c) for c in [105, 110, 88, 77])
-ICXQIE = 2
-IDNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-IDUBSS = "".join(chr(c) for c in [80, 50, 76])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IGYOUS = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-IIDNIB = 299
-IJUGSE = 448
-IKFWRK = 287
-IKJPUN = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-ILXWAJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-INEJNI = "".join(chr(c) for c in [105, 110, 88, 69])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IUXFEF = 271
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-IYWSKW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 281
-JJJVYF = 336
-JJVYFC = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [68, 74, 83, 52])
-JPUNRJ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-JQRJJJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = "".join(chr(c) for c in [67, 70, 71, 49])
-JUIKFW = 285
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = 295
-JVHFTH = 319
-JVYFCR = 337
-JWMNZM = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-JYKLGQ = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-JZTATD = 461
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = 469
-KFWRKI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-KINEJN = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-KJPUNR = 458
-KLGQPL = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 347
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-KVKZIL = "".join(chr(c) for c in [67, 69])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KXSJWM = 277
-KZILXW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-LAIIDN = 297
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LHBQNR = 451
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-LKXSJW = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-LNMHXE = "".join(chr(c) for c in [51, 50, 75])
-LOIJUG = 348
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = 293
-MAOAWB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-MCBFEG = 310
-MCGETI = 473
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-MHXEKV = "".join(chr(c) for c in [54, 52, 75])
-MJIGYO = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-MJMAOA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-MNHTBJ = 325
-MNZMJI = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MOUNBL = 353
-NBLKXS = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-NEJNIB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NHTBJE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-NIBXTI = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-NIBXYB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-NKMLOI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [52, 56, 75])
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = 343
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = 290
-NQTMFZ = 465
-NRJZTA = 460
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = 453
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-OACMCV = 479
-OAWBSI = 309
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 478
-OIJUGS = "".join(chr(c) for c in [67, 70, 71, 48])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-PFTSIF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-PHUGTY = 330
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = 350
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = 459
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = 320
-QFYLJU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-QLNMHX = "".join(chr(c) for c in [49, 54, 75])
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = "".join(chr(c) for c in [67, 70, 71, 53])
-QPLSPF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-QRJJJV = 335
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-RKINEJ = 289
-RSJMCB = 5
-RTFMNH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-RXCHWD = "".join(chr(c) for c in [67, 70, 71, 54])
-RYXBQF = 314
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = 334
-SELHBQ = 450
-SEMCGE = 472
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-SIRYXB = 311
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SKSOKP = 305
-SKWIVD = 340
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SSAKQX = 259
-SSUHBV = "".join(chr(c) for c in [80, 52, 76])
-STSEMC = 471
-SUHBVW = "".join(chr(c) for c in [66, 76, 79])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = 462
-TBJEUT = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-TDZXNQ = 463
-TFMNHT = 349
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-TIDUBS = "".join(chr(c) for c in [80, 50, 72])
-TIXQVX = 475
-TMFZDG = 466
-TOPHUG = 329
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-TSIFJB = 351
-TTIDUB = "".join(chr(c) for c in [80, 49, 76])
-TYIYWS = 332
-UBSSUH = "".join(chr(c) for c in [80, 51, 76])
-UBYGDS = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-UGSELH = 449
-UGTYIY = 331
-UHBVWV = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-UIKFWR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-UNRJZT = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-UNXNKM = 345
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = 342
-VDQLAI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VOACMC = 256
-VUBYGD = 322
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-VWVUBY = 321
-VXOIHB = 477
-VYFCRT = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-WAJVDQ = 294
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WDAFIK = "".join(chr(c) for c in [67, 70, 71, 56])
-WIVDNQ = 341
-WJYKLG = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-WMNZMJ = 279
-WRKINE = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-WVUBYG = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-XBQFYL = 315
-XCHWDA = 454
-XEKVKZ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-XFEFJT = 272
-XIBHZV = "".join(chr(c) for c in [76, 73])
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 346
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 476
-XSJWMN = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-XTIACQ = 316
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-XYBQSN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = 338
-YGDSBD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-YKLGQP = 284
-YLIUXF = 270
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = 352
-YPIPIV = 257
-YWSKWI = 333
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ZILXWA = 291
-ZMJIGY = 280
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ZUQEXL = 262
-ZVOACM = 51
-ZXNQTM = 464
-ACQFFT = [TIACQF, IACQFF]
-BHZVOA = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-BXIBHZ = []
-DJQRJJ = [
-    FFTTID,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    BDJQRJ,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HBVWVU = [
-    FFTTID,
-    FTTIDU,
-    TTIDUB,
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    JHIUSO,
-    SUHBVW,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    UHBVWV,
-]
-HXEKVK = [QLNMHX, LNMHXE, NMHXEK, MHXEKV]
-HZVOAC = [
-    QFYLJU,
-    SIFJBI,
-    JBIAMJ,
-    KLGQPL,
-    UNBLKX,
-    BQFYLJ,
-    FYLJUI,
-    JWMNZM,
-    ACCPQI,
-    PFTSIF,
-    QPLSPF,
-    OUSPBW,
-    GYOUSP,
-    YXBQFY,
-    GQPLSP,
-    FTSIFJ,
-    SPFTSI,
-    WJYKLG,
-    BIAMJM,
-    PBWJYK,
-    USPBWJ,
-    IFJBIA,
-    JMAOAW,
-    FJBIAM,
-    SPBWJY,
-    LSPFTS,
-    LGQPLS,
-    JYKLGQ,
-]
-IBHZVO = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    XIBHZV,
-]
-IUSOOQ = [IVLASS, PHUOJR]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-QSNQLN = [
-    KINEJN,
-    INEJNI,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-]
-SJWMNZ = [HFTHEC, XSJWMN, XSJWMN, XSJWMN]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VKZILX = [EKVKZI, KVKZIL]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WBSIRY = [HFTHEC, AWBSIR, AWBSIR, AWBSIR]
-YIYWSK = [
-    FFTTID,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -846,265 +19,936 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return ZVOACM
+        return 51
 
     @property
     def begin(self):
-        return VOACMC
+        return 256
 
     @property
     def end(self):
-        return OACMCV
+        return 479
 
     @property
     def all_device_keys(self):
-        return IBHZVO
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return BHZVOA
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return HZVOAC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, CPQIPO, LRAHEO, None),
-            NBLKXS: GeckoTempStructAccessor(self.struct, NBLKXS, BLKXSJ, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, HIUSOO, RSJMCB, SJWMNZ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, WMNZMJ, ICXQIE, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, WMNZMJ, QIEFXQ, None),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, ICXQIE, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, LRAHEO, None),
-            IGYOUS: GeckoBoolStructAccessor(
-                self.struct, IGYOUS, JIGYOU, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, YOUSPB, LRAHEO, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, CPQIPO, OQNRSJ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, QIPOUY, QXPICX, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, QIPOUY, LRAHEO, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, ICXQIE, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, OQNRSJ, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, YKLGQP, XPICXQ, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, YKLGQP, RSJMCB, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, YKLGQP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, OQNRSJ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, PLSPFT, XPICXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PLSPFT, RSJMCB, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, PLSPFT, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, ICXQIE, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, TSIFJB, OQNRSJ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, YOUSPB, OQNRSJ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, MOUNBL, QXPICX, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, MOUNBL, LRAHEO, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QXPICX, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, ZMJIGY, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, BWJYKL, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, BWJYKL, LRAHEO, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, BWJYKL, XPICXQ, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, QXPICX, None),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, OAWBSI, LRAHEO, WBSIRY, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            BSIRYX: GeckoWordStructAccessor(self.struct, BSIRYX, SIRYXB, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, QXPICX, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, XBQFYL, LRAHEO, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, TSIFJB, QXPICX, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, TSIFJB, LRAHEO, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, TSIFJB, XPICXQ, None),
-            LJUIKF: GeckoWordStructAccessor(self.struct, LJUIKF, JUIKFW, None),
-            UIKFWR: GeckoByteStructAccessor(self.struct, UIKFWR, IKFWRK, None),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, None),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, QSNQLN, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            SNQLNM: GeckoEnumStructAccessor(
-                self.struct, SNQLNM, NQLNMH, QXPICX, HXEKVK, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XEKVKZ: GeckoEnumStructAccessor(
-                self.struct, XEKVKZ, NQLNMH, ICXQIE, VKZILX, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KZILXW: GeckoWordStructAccessor(self.struct, KZILXW, ZILXWA, None),
-            ILXWAJ: GeckoByteStructAccessor(self.struct, ILXWAJ, LXWAJV, None),
-            XWAJVD: GeckoByteStructAccessor(self.struct, XWAJVD, WAJVDQ, None),
-            AJVDQL: GeckoByteStructAccessor(self.struct, AJVDQL, JVDQLA, None),
-            VDQLAI: GeckoByteStructAccessor(self.struct, VDQLAI, DQLAII, None),
-            QLAIID: GeckoWordStructAccessor(self.struct, QLAIID, LAIIDN, None),
-            AIIDNI: GeckoByteStructAccessor(self.struct, AIIDNI, IIDNIB, None),
-            IDNIBX: GeckoByteStructAccessor(self.struct, IDNIBX, DNIBXT, None),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, ACQFFT, None, ICXQIE, LASSAK
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, HBVWVU, None, None, LASSAK
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            BVWVUB: GeckoEnumStructAccessor(
-                self.struct, BVWVUB, VWVUBY, None, HBVWVU, None, None, LASSAK
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, VUBYGD, None, HBVWVU, None, None, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, HBVWVU, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, HBVWVU, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            DSBDJQ: GeckoEnumStructAccessor(
-                self.struct, DSBDJQ, SBDJQR, None, DJQRJJ, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, LASSAK),
-            RJJJVY: GeckoByteStructAccessor(self.struct, RJJJVY, JJJVYF, LASSAK),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, LASSAK),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, LASSAK),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, LASSAK),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, LASSAK),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, HBVWVU, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, HBVWVU, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, HBVWVU, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, HBVWVU, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, HBVWVU, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, HBVWVU, None, None, LASSAK
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, HBVWVU, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, YIYWSK, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, YIYWSK, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, LASSAK),
-            KWIVDN: GeckoByteStructAccessor(self.struct, KWIVDN, WIVDNQ, LASSAK),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, LASSAK),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, LASSAK),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, LASSAK),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, LASSAK),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, LASSAK),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, LASSAK),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, LASSAK),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-52.py
+++ b/src/geckolib/driver/packs/inyt-log-52.py
@@ -12,837 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACMCVD = 52
-ACQFFT = 316
-AFIKJP = 455
-AHEOCT = 308
-AIIDNI = 296
-AJVDQL = 293
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = 461
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BDJQRJ = 324
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = 314
-BQNRXC = "".join(chr(c) for c in [67, 70, 71, 51])
-BQSNQL = "".join(chr(c) for c in [75, 54, 48, 48])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [80, 50, 76])
-BVWVUB = "".join(chr(c) for c in [66, 76, 79])
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = 478
-BXTIAC = 300
-BXYBQS = "".join(chr(c) for c in [68, 74, 83, 52])
-BYGDSB = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = 472
-CHWDAF = 453
-CMCVDS = 256
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-CRTFMN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-CTHBSK = 303
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = "".join(chr(c) for c in [67, 70, 71, 55])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-DJQRJJ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-DNIBXT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DNQGVU = 341
-DQLAII = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-DSBDJQ = 323
-DUBSSU = "".join(chr(c) for c in [80, 49, 76])
-DZXNQT = 462
-EAKSTS = 468
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-EKCWAO = 264
-EKVKZI = "".join(chr(c) for c in [54, 52, 75])
-ELHBQN = 449
-EMCGET = 471
-EOCTHB = 307
-ETIXQV = 473
-EUTOPH = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-FCRTFM = 337
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FIKJPU = "".join(chr(c) for c in [67, 70, 71, 56])
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = 339
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-FWRKIN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-FYLJUI = 315
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-GDSBDJ = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-GKEAKS = 467
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = 448
-GTYIYW = 330
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = 450
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [80, 52, 76])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-HUGTYI = 329
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = "".join(chr(c) for c in [67, 70, 71, 54])
-HXEKVK = "".join(chr(c) for c in [51, 50, 75])
-HZVOAC = "".join(chr(c) for c in [76, 73])
-IACQFF = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = 479
-IBXTIA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-IBXYBQ = "".join(chr(c) for c in [77, 73, 65])
-ICXQIE = 2
-IDNIBX = 297
-IDUBSS = "".join(chr(c) for c in [80, 49, 72])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = 477
-IIDNIB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-IJUGSE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-IKFWRK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IKJPUN = 456
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IUXFEF = 271
-IVDNQG = 340
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = 474
-IYWSKW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = 326
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-JJVYFC = 335
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [105, 110, 88, 69])
-JPUNRJ = 457
-JQRJJJ = 334
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUGSEL = 348
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-KFWRKI = 285
-KINEJN = 288
-KJPUNR = "".join(chr(c) for c in [67, 70, 71, 57])
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-KPHUOJ = 261
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = 469
-KWIVDN = 333
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [85, 76])
-LAIIDN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = "".join(chr(c) for c in [67, 70, 71, 50])
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-LOIJUG = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-MCVDSS = 479
-MFZDGK = 465
-MHXEKV = "".join(chr(c) for c in [49, 54, 75])
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MLOIJU = 346
-MNHTBJ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = 289
-NHTBJE = 349
-NIBXTI = 299
-NIBXYB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NKMLOI = 345
-NMHXEK = 290
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = "".join(chr(c) for c in [105, 110, 89, 84])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = "".join(chr(c) for c in [67, 70, 71, 52])
-NXNKML = 344
-NZMJIG = 279
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-OIJUGS = 347
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OPHUGT = 328
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(chr(c) for c in [70, 117, 108, 108])
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 342
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = 295
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = 451
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [72, 84, 82])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-QTMFZD = 464
-QVXOIH = 475
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJZTAT = 459
-RKINEJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-RSJMCB = 5
-RTFMNH = 338
-RXCHWD = 452
-RYXBQF = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-SELHBQ = "".join(chr(c) for c in [67, 70, 71, 49])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-SNQLNM = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SSAKQX = 259
-SSUHBV = "".join(chr(c) for c in [80, 51, 72])
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-SUHBVW = "".join(chr(c) for c in [80, 51, 76])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-TBJEUT = 325
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-TFMNHT = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = 301
-TIDUBS = "".join(chr(c) for c in [78, 65])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-TOPHUG = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-TSEMCG = 470
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 320
-TYIYWS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-UBSSUH = "".join(chr(c) for c in [80, 50, 72])
-UBYGDS = 321
-UGSELH = "".join(chr(c) for c in [67, 70, 71, 48])
-UGTYIY = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-UHBVWV = "".join(chr(c) for c in [80, 52, 72])
-UIKFWR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = 458
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = 327
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-VDQLAI = 294
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-VUBYGD = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-VUNXNK = 343
-VWVUBY = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VYFCRT = 336
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = 454
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = 287
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = "".join(chr(c) for c in [67, 70, 71, 53])
-XEKVKZ = "".join(chr(c) for c in [52, 56, 75])
-XFEFJT = 272
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-XNQTMF = 463
-XOIHBX = 476
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = 291
-XYBQSN = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 88, 77])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-YGDSBD = 322
-YIYWSK = 331
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = 332
-YXBQFY = 311
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 466
-ZILXWA = "".join(chr(c) for c in [67, 69])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZTATDZ = 460
-ZUQEXL = 262
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-BHZVOA = []
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FFTTID = [CQFFTT, QFFTTI]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-ILXWAJ = [KZILXW, ZILXWA]
-IUSOOQ = [IVLASS, PHUOJR]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-KVKZIL = [MHXEKV, HXEKVK, XEKVKZ, EKVKZI]
-OACMCV = [
-    LJUIKF,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    IRYXBQ,
-    YLJUIK,
-    JUIKFW,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    QFYLJU,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-QLNMHX = [
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-]
-RJJJVY = [
-    TIDUBS,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    QRJJJV,
-]
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VOACMC = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-WSKWIV = [
-    TIDUBS,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-WVUBYG = [
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    JHIUSO,
-    BVWVUB,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    VWVUBY,
-]
-ZVOACM = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    HZVOAC,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -850,267 +19,939 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return ACMCVD
+        return 52
 
     @property
     def begin(self):
-        return CMCVDS
+        return 256
 
     @property
     def end(self):
-        return MCVDSS
+        return 479
 
     @property
     def all_device_keys(self):
-        return ZVOACM
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return VOACMC
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return OACMCV
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, OQNRSJ, None),
-            RYXBQF: GeckoWordStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, QXPICX, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, QXPICX, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, LRAHEO, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, QXPICX, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, LRAHEO, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IFJBIA, XPICXQ, None),
-            IKFWRK: GeckoWordStructAccessor(self.struct, IKFWRK, KFWRKI, None),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, None),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, None),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, NEJNIB, None, QLNMHX, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, NMHXEK, QXPICX, KVKZIL, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, NMHXEK, ICXQIE, ILXWAJ, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            LXWAJV: GeckoWordStructAccessor(self.struct, LXWAJV, XWAJVD, None),
-            WAJVDQ: GeckoByteStructAccessor(self.struct, WAJVDQ, AJVDQL, None),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, None),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, None),
-            LAIIDN: GeckoByteStructAccessor(self.struct, LAIIDN, AIIDNI, None),
-            IIDNIB: GeckoWordStructAccessor(self.struct, IIDNIB, IDNIBX, None),
-            DNIBXT: GeckoByteStructAccessor(self.struct, DNIBXT, NIBXTI, None),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, None),
-            XTIACQ: GeckoWordStructAccessor(self.struct, XTIACQ, TIACQF, None),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, FFTTID, None, ICXQIE, LASSAK
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, WVUBYG, None, None, LASSAK
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, WVUBYG, None, None, LASSAK
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, WVUBYG, None, None, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, WVUBYG, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, WVUBYG, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, RJJJVY, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, LASSAK),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, LASSAK),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, LASSAK),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, LASSAK),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, LASSAK),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, LASSAK),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, WVUBYG, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, WVUBYG, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, WVUBYG, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, OPHUGT, None, WVUBYG, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, WVUBYG, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, WVUBYG, None, None, LASSAK
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, WVUBYG, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, WSKWIV, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, WSKWIV, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            WIVDNQ: GeckoByteStructAccessor(self.struct, WIVDNQ, IVDNQG, LASSAK),
-            VDNQGV: GeckoByteStructAccessor(self.struct, VDNQGV, DNQGVU, LASSAK),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, LASSAK),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, LASSAK),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, LASSAK),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, LASSAK),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, LASSAK),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, LASSAK),
-            IJUGSE: GeckoByteStructAccessor(self.struct, IJUGSE, JUGSEL, LASSAK),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-53.py
+++ b/src/geckolib/driver/packs/inyt-log-53.py
@@ -12,872 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-ACMCVD = 472
-ACQFFT = 316
-AFIKJP = 346
-AHEOCT = 308
-AIIDNI = 296
-AJVDQL = 293
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AONPYY = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = 451
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-BBEKBD = 479
-BDJQRJ = 320
-BFEGZU = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-BLKXSJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-BMJVHF = 256
-BQFYLJ = 314
-BQNRXC = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-BQSNQL = "".join(chr(c) for c in [75, 54, 48, 48])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [75, 52])
-BVWVUB = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-BWJYKL = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-BXIBHZ = 468
-BXTIAC = 300
-BXYBQS = "".join(chr(c) for c in [68, 74, 83, 52])
-BYGDSB = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-CBFEGZ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CCPQIP = "".join(chr(c) for c in [67, 80, 79, 84])
-CGETIX = 462
-CHWDAF = 344
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-CPQIPO = 274
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-CRTFMN = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-CTHBSK = 303
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 266
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 57])
-DJQRJJ = "".join(chr(c) for c in [78, 65])
-DNIBXT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-DQLAII = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-DSBDJQ = 361
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-DUBSSU = "".join(chr(c) for c in [75, 56, 53])
-DZXNQT = 452
-EAKSTS = 458
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 273
-EFXQGL = 258
-EJNIBX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-EKCWAO = 264
-EKVKZI = "".join(chr(c) for c in [54, 52, 75])
-ELHBQN = 340
-EMCGET = 461
-EOCTHB = 307
-ETIXQV = 463
-EUTOPH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-FCRTFM = "".join(chr(c) for c in [66, 76, 79])
-FEFJTA = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FEGZUQ = "".join(chr(c) for c in [70, 85, 76, 76])
-FIKJPU = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FJTACC = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-FMNHTB = 321
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-FTTIDU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-FWRKIN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-FYLJUI = 315
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 56])
-GDSBDJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-GKEAKS = 457
-GQPLSP = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-GSELHB = 333
-GTYIYW = 336
-GVUNXN = 327
-GYOUSP = 281
-GZUQEX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-HBQNRX = 341
-HBSKSO = 304
-HBVWVU = "".join(chr(c) for c in [75, 56, 48, 48])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = 260
-HTBJEU = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-HUGTYI = 335
-HUOJRJ = "".join(chr(c) for c in [76, 79, 87])
-HWDAFI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-HXEKVK = "".join(chr(c) for c in [51, 50, 75])
-HZVOAC = 470
-IACQFF = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IBHZVO = 469
-IBXTIA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-IBXYBQ = "".join(chr(c) for c in [77, 73, 65])
-ICXQIE = 2
-IDNIBX = 297
-IDUBSS = "".join(chr(c) for c in [75, 52, 48, 48])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = 351
-IGYOUS = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IHBXIB = 467
-IIDNIB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-IJUGSE = 332
-IKFWRK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IKJPUN = 347
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-IRYXBQ = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IUXFEF = 271
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = 464
-IYWSKW = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-JEUTOP = 324
-JHIUSO = "".join(chr(c) for c in [80, 53])
-JIGYOU = 280
-JJJVYF = "".join(chr(c) for c in [80, 50, 76])
-JJVYFC = "".join(chr(c) for c in [80, 51, 72])
-JMAOAW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-JNIBXY = "".join(chr(c) for c in [105, 110, 88, 69])
-JPUNRJ = 348
-JQRJJJ = "".join(chr(c) for c in [80, 49, 72])
-JRJHIU = "".join(chr(c) for c in [80, 51])
-JTACCP = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JUTYEK = "".join(chr(c) for c in [78, 69, 87])
-JVDQLA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [80, 51, 76])
-JWMNZM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JYKLGQ = 283
-JZTATD = "".join(chr(c) for c in [67, 70, 71, 50])
-KCWAON = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KFWRKI = 285
-KINEJN = 288
-KJPUNR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-KLGQPL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-KMLOIJ = 330
-KPHUOJ = 261
-KQTDKH = 479
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-KSTSEM = 459
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-KXSJWM = 275
-KZILXW = "".join(chr(c) for c in [85, 76])
-LAIIDN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = 284
-LHBQNR = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LJUIKF = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-LKXSJW = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-LNMHXE = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-LOIJUG = 331
-LRAHEO = 1
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-LSXUJU = 263
-LXWAJV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-MAOAWB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-MCBFEG = 310
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-MCVDSS = 473
-MFZDGK = 455
-MHXEKV = "".join(chr(c) for c in [49, 54, 75])
-MJIGYO = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJMAOA = 354
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-MNHTBJ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-MNZMJI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MOUNBL = 353
-NBLKXS = 355
-NEJNIB = 289
-NHTBJE = 322
-NIBXTI = 299
-NIBXYB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-NMHXEK = 290
-NPYYLI = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-NQGVUN = 326
-NQJYMO = "".join(chr(c) for c in [77, 69, 68])
-NQLNMH = "".join(chr(c) for c in [105, 110, 89, 84])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 54])
-NRJZTA = "".join(chr(c) for c in [67, 70, 71, 49])
-NRSJMC = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-NRXCHW = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-NZMJIG = 279
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-OAWBSI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-OIJUGS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-OJRJHI = "".join(chr(c) for c in [80, 50])
-OKPHUO = "".join(chr(c) for c in [80, 49])
-ONPYYL = 267
-OOQNRS = "".join(chr(c) for c in [79, 51])
-OQNRSJ = 3
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-PBWJYK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-PHUOJR = "".join(chr(c) for c in [72, 73, 71, 72])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-POUYNQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PQIPOU = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PUNRJZ = "".join(chr(c) for c in [67, 70, 71, 48])
-PYYLIU = 268
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QFFTTI = "".join(chr(c) for c in [70, 117, 108, 108])
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-QIEFXQ = 6
-QIPOUY = 282
-QJYMOU = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QLAIID = 295
-QNRSJM = "".join(chr(c) for c in [76, 49, 50, 48])
-QNRXCH = 342
-QPLSPF = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QRJJJV = "".join(chr(c) for c in [80, 49, 76])
-QSNQLN = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-QTMFZD = 454
-QVXOIH = 465
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RAZMKQ = 477
-RJHIUS = "".join(chr(c) for c in [80, 52])
-RJJJVY = "".join(chr(c) for c in [80, 50, 72])
-RJZTAT = 449
-RKINEJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-RSJMCB = 5
-RURAZM = 476
-RXCHWD = 343
-RYXBQF = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-SELHBQ = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-SIFJBI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SJMCBF = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 277
-SKSOKP = 305
-SKWIVD = 339
-SNQLNM = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-SOKPHU = 306
-SOOQNR = "".join(chr(c) for c in [67, 80])
-SPBWJY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-SPFTSI = 350
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-SSAKQX = 259
-SSRURA = 475
-SSUHBV = "".join(chr(c) for c in [75, 53])
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-SUHBVW = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-SXUJUT = "".join(chr(c) for c in [73, 68, 76, 69])
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-TATDZX = "".join(chr(c) for c in [67, 70, 71, 51])
-TBJEUT = 323
-TDKHTZ = "".join(chr(c) for c in [76, 73])
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 52])
-TFMNHT = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-THBSKS = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = 301
-TIDUBS = "".join(chr(c) for c in [75, 50, 48, 48])
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 55])
-TOPHUG = "".join(chr(c) for c in [72, 84, 82])
-TSEMCG = 460
-TSIFJB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-TTIDUB = 357
-TYIYWS = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-TZBBEK = 53
-UBSSUH = "".join(chr(c) for c in [75, 56])
-UBYGDS = 358
-UGSELH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-UGTYIY = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-UHBVWV = "".join(chr(c) for c in [75, 49, 48, 48])
-UIKFWR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-UJUTYE = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UNBLKX = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-UNRJZT = 448
-UNXNKM = 328
-UQEXLS = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-USOOQN = "".join(chr(c) for c in [66, 76])
-USPBWJ = 352
-UTOPHU = 334
-UTYEKC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-UYNQJY = 313
-VDNQGV = 325
-VDQLAI = 294
-VDSSRU = 474
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-VOACMC = 471
-VUBYGD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-VWVUBY = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-VYFCRT = "".join(chr(c) for c in [80, 52, 72])
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-WAONPY = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-WBSIRY = 309
-WDAFIK = 345
-WIVDNQ = 349
-WJYKLG = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-WRKINE = 287
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-XEKVKZ = "".join(chr(c) for c in [52, 56, 75])
-XFEFJT = 272
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-XLSXUJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XNKMLO = 329
-XNQTMF = 453
-XOIHBX = 466
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XSJWMN = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-XTIACQ = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-XUJUTY = "".join(chr(c) for c in [83, 84, 79, 80])
-XWAJVD = 291
-XYBQSN = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-YBQSNQ = "".join(chr(c) for c in [105, 110, 88, 77])
-YEKCWA = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YFCRTF = "".join(chr(c) for c in [80, 52, 76])
-YGDSBD = 360
-YIYWSK = 337
-YKLGQP = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YLIUXF = 270
-YLJUIK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YMOUNB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-YNQJYM = "".join(chr(c) for c in [78, 79])
-YOUSPB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-YPIPIV = 257
-YWSKWI = 338
-YXBQFY = 311
-YYLIUX = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZBBEKB = 256
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 456
-ZILXWA = "".join(chr(c) for c in [67, 69])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZMKQTD = 478
-ZTATDZ = 450
-ZUQEXL = 262
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 53])
-DKHTZB = [
-    OKPHUO,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    NRSJMC,
-    SJMCBF,
-    JMCBFE,
-    TDKHTZ,
-]
-EGZUQE = [CBFEGZ, BFEGZU, FEGZUQ]
-EXLSXU = [UQEXLS, QEXLSX]
-FFTTID = [CQFFTT, QFFTTI]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-HTZBBE = [
-    LJUIKF,
-    FJBIAM,
-    IAMJMA,
-    GQPLSP,
-    BLKXSJ,
-    IRYXBQ,
-    YLJUIK,
-    JUIKFW,
-    MNZMJI,
-    ACCPQI,
-    TSIFJB,
-    LSPFTS,
-    SPBWJY,
-    OUSPBW,
-    QFYLJU,
-    PLSPFT,
-    SIFJBI,
-    FTSIFJ,
-    YKLGQP,
-    AMJMAO,
-    WJYKLG,
-    PBWJYK,
-    JBIAMJ,
-    AOAWBS,
-    BIAMJM,
-    BWJYKL,
-    PFTSIF,
-    QPLSPF,
-    KLGQPL,
-]
-ILXWAJ = [KZILXW, ZILXWA]
-IUSOOQ = [IVLASS, PHUOJR]
-JUGSEL = [
-    DJQRJJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    SOOQNR,
-]
-JYMOUN = [YNQJYM, SAKQXP, NQJYMO, AKQXPI, QJYMOU]
-KHTZBB = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-KVKZIL = [MHXEKV, HXEKVK, XEKVKZ, EKVKZI]
-OPHUGT = [
-    DJQRJJ,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    TOPHUG,
-]
-QLNMHX = [
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-]
-QTDKHT = []
-RTFMNH = [
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    JHIUSO,
-    FCRTFM,
-    SOOQNR,
-    OOQNRS,
-    QNRSJM,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    CRTFMN,
-]
-SIRYXB = [HFTHEC, BSIRYX, BSIRYX, BSIRYX]
-TYEKCW = [SXUJUT, XUJUTY, UJUTYE, JUTYEK, UTYEKC]
-UOJRJH = [IVLASS, PHUOJR, HUOJRJ]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-WMNZMJ = [HFTHEC, JWMNZM, JWMNZM, JWMNZM]
-WVUBYG = [
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    BVWVUB,
-    VWVUBY,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -885,273 +19,967 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return TZBBEK
+        return 53
 
     @property
     def begin(self):
-        return ZBBEKB
+        return 256
 
     @property
     def end(self):
-        return BBEKBD
+        return 479
 
     @property
     def all_device_keys(self):
-        return DKHTZB
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return KHTZBB
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return HTZBBE
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, QXPICX, UOJRJH, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, KPHUOJ, ICXQIE, UOJRJH, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, KPHUOJ, XPICXQ, UOJRJH, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, KPHUOJ, QIEFXQ, UOJRJH, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, QXPICX, IUSOOQ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, HIUSOO, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, HIUSOO, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, HIUSOO, OQNRSJ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, HIUSOO, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, HIUSOO, RSJMCB, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, HIUSOO, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, MCBFEG, None, EGZUQE, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, QXPICX, EXLSXU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, TYEKCW, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            YEKCWA: GeckoTimeStructAccessor(self.struct, YEKCWA, EKCWAO, LASSAK),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, ZUQEXL, ICXQIE, EXLSXU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, None, TYEKCW, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoTimeStructAccessor(self.struct, NPYYLI, PYYLIU, LASSAK),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoBoolStructAccessor(self.struct, FEFJTA, EFJTAC, QXPICX, None),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, EFJTAC, ICXQIE, None),
-            JTACCP: GeckoBoolStructAccessor(self.struct, JTACCP, EFJTAC, OQNRSJ, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, EFJTAC, XPICXQ, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, EFJTAC, RSJMCB, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, ICXQIE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, OQNRSJ, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, QIPOUY, RSJMCB, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, QIPOUY, QIEFXQ, None),
-            OUYNQJ: GeckoEnumStructAccessor(
-                self.struct, OUYNQJ, UYNQJY, None, JYMOUN, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, RSJMCB, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, CPQIPO, LRAHEO, None),
-            LKXSJW: GeckoTempStructAccessor(self.struct, LKXSJW, KXSJWM, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoEnumStructAccessor(
-                self.struct, JWMNZM, HIUSOO, RSJMCB, WMNZMJ, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, ICXQIE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, QIEFXQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, JIGYOU, ICXQIE, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, LRAHEO, None),
-            YOUSPB: GeckoBoolStructAccessor(
-                self.struct, YOUSPB, GYOUSP, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, LRAHEO, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, CPQIPO, OQNRSJ, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, QIPOUY, QXPICX, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, ICXQIE, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, OQNRSJ, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, OQNRSJ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, LGQPLS, XPICXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, LGQPLS, RSJMCB, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LGQPLS, QIEFXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, OQNRSJ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, XPICXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, SPFTSI, RSJMCB, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SPFTSI, QIEFXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, ICXQIE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, OQNRSJ, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, USPBWJ, OQNRSJ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, MOUNBL, QXPICX, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, MOUNBL, LRAHEO, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QXPICX, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, JIGYOU, QXPICX, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JYKLGQ, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JYKLGQ, LRAHEO, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JYKLGQ, XPICXQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoEnumStructAccessor(
-                self.struct, BSIRYX, WBSIRY, LRAHEO, SIRYXB, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, OQNRSJ, None),
-            RYXBQF: GeckoWordStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, QXPICX, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, QXPICX, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, LRAHEO, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, QXPICX, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, IFJBIA, LRAHEO, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IFJBIA, XPICXQ, None),
-            IKFWRK: GeckoWordStructAccessor(self.struct, IKFWRK, KFWRKI, None),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, None),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, None),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, NEJNIB, None, QLNMHX, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, NMHXEK, QXPICX, KVKZIL, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, NMHXEK, ICXQIE, ILXWAJ, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            LXWAJV: GeckoWordStructAccessor(self.struct, LXWAJV, XWAJVD, None),
-            WAJVDQ: GeckoByteStructAccessor(self.struct, WAJVDQ, AJVDQL, None),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, None),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, None),
-            LAIIDN: GeckoByteStructAccessor(self.struct, LAIIDN, AIIDNI, None),
-            IIDNIB: GeckoWordStructAccessor(self.struct, IIDNIB, IDNIBX, None),
-            DNIBXT: GeckoByteStructAccessor(self.struct, DNIBXT, NIBXTI, None),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, None),
-            XTIACQ: GeckoWordStructAccessor(self.struct, XTIACQ, TIACQF, None),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, FFTTID, None, ICXQIE, LASSAK
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, WVUBYG, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            VUBYGD: GeckoWordStructAccessor(self.struct, VUBYGD, UBYGDS, None),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, None),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, None),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, RTFMNH, None, None, LASSAK
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, RTFMNH, None, None, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, RTFMNH, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, RTFMNH, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, RTFMNH, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, OPHUGT, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, LASSAK),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, LASSAK),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, LASSAK),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, LASSAK),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, LASSAK),
-            KWIVDN: GeckoByteStructAccessor(self.struct, KWIVDN, WIVDNQ, LASSAK),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, RTFMNH, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, RTFMNH, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, RTFMNH, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, RTFMNH, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, RTFMNH, None, None, LASSAK
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, RTFMNH, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, LOIJUG, None, RTFMNH, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, JUGSEL, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, GSELHB, None, JUGSEL, None, None, LASSAK
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, LASSAK),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, LASSAK),
-            BQNRXC: GeckoByteStructAccessor(self.struct, BQNRXC, QNRXCH, LASSAK),
-            NRXCHW: GeckoByteStructAccessor(self.struct, NRXCHW, RXCHWD, LASSAK),
-            XCHWDA: GeckoByteStructAccessor(self.struct, XCHWDA, CHWDAF, LASSAK),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, LASSAK),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, LASSAK),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, LASSAK),
-            KJPUNR: GeckoByteStructAccessor(self.struct, KJPUNR, JPUNRJ, LASSAK),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "INVALID",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-54.py
+++ b/src/geckolib/driver/packs/inyt-log-54.py
@@ -12,877 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ACQFFT = 301
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-AHEOCT = 308
-AIIDNI = 295
-AJVDQL = 291
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = 457
-AMJMAO = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AOAWBS = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AONPYY = 266
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = "".join(chr(c) for c in [67, 70, 71, 50])
-AWBSIR = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AZMKQT = 476
-BDJQRJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-BEKBDF = 54
-BFEGZU = 310
-BHZVOA = 468
-BIAMJM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BJEUTO = 322
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-BMJVHF = 256
-BQFYLJ = 311
-BQNRXC = 340
-BQSNQL = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [75, 56, 53])
-BVWVUB = "".join(chr(c) for c in [75, 49, 48, 48])
-BWJYKL = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-BXTIAC = 299
-BXYBQS = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-CBFEGZ = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-CMCVDS = 471
-CPQIPO = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-CRTFMN = "".join(chr(c) for c in [80, 52, 72])
-CTHBSK = 303
-CVDSSR = 472
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = 264
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = 344
-DGKEAK = 455
-DJQRJJ = 361
-DKHTZB = 479
-DNIBXT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-DNQGVU = 349
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-DSBDJQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-DSSRUR = 473
-DUBSSU = "".join(chr(c) for c in [75, 50, 48, 48])
-DZXNQT = "".join(chr(c) for c in [67, 70, 71, 51])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 57])
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 272
-EFXQGL = 258
-EGZUQE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-EJNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-EKBDFS = 256
-EKVKZI = "".join(chr(c) for c in [51, 50, 75])
-ELHBQN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EOCTHB = 307
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-EUTOPH = 323
-EXLSXU = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-FCRTFM = "".join(chr(c) for c in [80, 51, 76])
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FFTTID = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-FIKJPU = 345
-FJBIAM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FJTACC = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FMNHTB = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = 350
-FTTIDU = "".join(chr(c) for c in [70, 117, 108, 108])
-FWRKIN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-FYLJUI = 314
-FZDGKE = 454
-GDSBDJ = 358
-GETIXQ = 461
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 56])
-GQPLSP = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-GSELHB = 332
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-GYOUSP = 280
-GZUQEX = "".join(chr(c) for c in [70, 85, 76, 76])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-HBSKSO = 362
-HBVWVU = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-HBXIBH = 466
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = "".join(chr(c) for c in [80, 52])
-HTBJEU = 321
-HTZBBE = "".join(chr(c) for c in [76, 73])
-HUGTYI = "".join(chr(c) for c in [72, 84, 82])
-HUOJRJ = 261
-HWDAFI = 343
-HXEKVK = 290
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IACQFF = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-IAMJMA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IBXTIA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-IBXYBQ = "".join(chr(c) for c in [105, 110, 88, 69])
-ICXQIE = 2
-IDNIBX = 296
-IDUBSS = 357
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IGYOUS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-IIDNIB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-ILXWAJ = "".join(chr(c) for c in [85, 76])
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 53])
-IUXFEF = 270
-IVDNQG = 339
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-IYWSKW = 336
-JBIAMJ = 351
-JEUTOP = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-JHIUSO = "".join(chr(c) for c in [80, 51])
-JIGYOU = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JJJVYF = "".join(chr(c) for c in [80, 49, 72])
-JJVYFC = "".join(chr(c) for c in [80, 49, 76])
-JMAOAW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-JMCBFE = 5
-JNIBXY = 289
-JPUNRJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-JQRJJJ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-JTACCP = 273
-JUGSEL = 331
-JUIKFW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JUTYEK = "".join(chr(c) for c in [83, 84, 79, 80])
-JVDQLA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-JVHFTH = 319
-JVYFCR = "".join(chr(c) for c in [80, 50, 72])
-JWMNZM = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JYKLGQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JYMOUN = "".join(chr(c) for c in [77, 69, 68])
-JZTATD = 448
-KBDFSR = 479
-KCWAON = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-KEAKST = 456
-KFWRKI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-KINEJN = 287
-KJPUNR = 346
-KLGQPL = 283
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-KPHUOJ = 306
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KVKZIL = "".join(chr(c) for c in [52, 56, 75])
-KWIVDN = 338
-KXSJWM = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-LAIIDN = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-LHBQNR = 333
-LIUXFE = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LJUIKF = 315
-LKXSJW = 355
-LNMHXE = "".join(chr(c) for c in [105, 110, 89, 84])
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-LRAHEO = 1
-LSPFTS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LXWAJV = "".join(chr(c) for c in [67, 69])
-MAOAWB = 354
-MCBFEG = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = 460
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 54])
-MHXEKV = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-MJIGYO = 279
-MJMAOA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MKQTDK = 477
-MLOIJU = 329
-MNZMJI = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-NBLKXS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-NEJNIB = 288
-NHTBJE = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-NIBXTI = 297
-NIBXYB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NKMLOI = 328
-NPYYLI = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-NQJYMO = 313
-NQLNMH = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-NQTMFZ = 452
-NRJZTA = 348
-NRSJMC = 3
-NRXCHW = 341
-NXNKML = 327
-OACMCV = 470
-OAWBSI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-OCTHBS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-OIHBXI = 465
-OIJUGS = 330
-OJRJHI = "".join(chr(c) for c in [76, 79, 87])
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-OOQNRS = "".join(chr(c) for c in [66, 76])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-OQNRSJ = "".join(chr(c) for c in [67, 80])
-OUNBLK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-OUSPBW = 281
-OUYNQJ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-PBWJYK = 352
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-PHUGTY = 334
-PHUOJR = "".join(chr(c) for c in [80, 49])
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-POUYNQ = 282
-PQIPOU = "".join(chr(c) for c in [67, 80, 79, 84])
-PUNRJZ = 347
-PYYLIU = 267
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 262
-QFFTTI = 316
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = 325
-QIEFXQ = 6
-QIPOUY = 274
-QJYMOU = "".join(chr(c) for c in [78, 79])
-QLAIID = 294
-QLNMHX = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QNRSJM = "".join(chr(c) for c in [79, 51])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-QPLSPF = 284
-QRJJJV = 320
-QSNQLN = "".join(chr(c) for c in [105, 110, 88, 77])
-QTDKHT = 478
-QTMFZD = "".join(chr(c) for c in [67, 70, 71, 53])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-RJHIUS = "".join(chr(c) for c in [80, 50])
-RJJJVY = "".join(chr(c) for c in [78, 65])
-RJZTAT = "".join(chr(c) for c in [67, 70, 71, 48])
-RKINEJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-RSJMCB = "".join(chr(c) for c in [76, 49, 50, 48])
-RTFMNH = "".join(chr(c) for c in [80, 52, 76])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SBDJQR = 360
-SEMCGE = 459
-SIFJBI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SIRYXB = 309
-SJMCBF = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-SJWMNZ = 275
-SKSOKP = 304
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-SNQLNM = "".join(chr(c) for c in [75, 54, 48, 48])
-SOKPHU = 305
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SPFTSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-SRURAZ = 474
-SSAKQX = 259
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-SSUHBV = "".join(chr(c) for c in [75, 56])
-STSEMC = 458
-SUHBVW = "".join(chr(c) for c in [75, 52])
-SXUJUT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-TACCPQ = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-TATDZX = 449
-TBJEUT = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-TDZXNQ = 450
-TFMNHT = "".join(chr(c) for c in [66, 76, 79])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 49, 76, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = 300
-TIDUBS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-TIXQVX = 462
-TMFZDG = 453
-TOPHUG = 324
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-TYEKCW = "".join(chr(c) for c in [78, 69, 87])
-TYIYWS = 335
-UBSSUH = "".join(chr(c) for c in [75, 52, 48, 48])
-UBYGDS = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68])
-UGSELH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-UHBVWV = "".join(chr(c) for c in [75, 53])
-UIKFWR = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-UJUTYE = "".join(chr(c) for c in [73, 68, 76, 69])
-UNBLKX = 353
-UNRJZT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-UOJRJH = "".join(chr(c) for c in [72, 73, 71, 72])
-UQEXLS = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-URAZMK = 475
-USOOQN = 260
-USPBWJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-UTYEKC = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UXFEFJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-UYNQJY = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-VDNQGV = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-VDQLAI = 293
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = "".join(chr(c) for c in [54, 52, 75])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-VUBYGD = "".join(chr(c) for c in [75, 51, 48, 48])
-VUNXNK = 326
-VWVUBY = "".join(chr(c) for c in [75, 56, 48, 48])
-VXOIHB = 464
-VYFCRT = "".join(chr(c) for c in [80, 50, 76])
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-WAONPY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-WBSIRY = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-WJYKLG = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-WMNZMJ = 277
-WRKINE = 285
-WSKWIV = 337
-WVUBYG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-XBQFYL = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-XCHWDA = 342
-XEKVKZ = "".join(chr(c) for c in [49, 54, 75])
-XFEFJT = 271
-XIBHZV = 467
-XLSXUJ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-XNQTMF = "".join(chr(c) for c in [67, 70, 71, 52])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = 463
-XSJWMN = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-XUJUTY = 263
-XYBQSN = "".join(chr(c) for c in [77, 73, 65])
-YBQSNQ = "".join(chr(c) for c in [68, 74, 83, 52])
-YEKCWA = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-YFCRTF = "".join(chr(c) for c in [80, 51, 72])
-YGDSBD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-YKLGQP = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-YLIUXF = 268
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YMOUNB = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-YNQJYM = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YOUSPB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = 257
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-YXBQFY = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-YYLIUX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 55])
-ZILXWA = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-ZMJIGY = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-ZTATDZ = "".join(chr(c) for c in [67, 70, 71, 49])
-ZVOACM = 469
-ZXNQTM = 451
-BBEKBD = [
-    UIKFWR,
-    BIAMJM,
-    MJMAOA,
-    PLSPFT,
-    KXSJWM,
-    YXBQFY,
-    JUIKFW,
-    IKFWRK,
-    ZMJIGY,
-    CPQIPO,
-    IFJBIA,
-    PFTSIF,
-    BWJYKL,
-    SPBWJY,
-    YLJUIK,
-    SPFTSI,
-    FJBIAM,
-    SIFJBI,
-    LGQPLS,
-    JMAOAW,
-    YKLGQP,
-    WJYKLG,
-    IAMJMA,
-    AWBSIR,
-    AMJMAO,
-    JYKLGQ,
-    TSIFJB,
-    LSPFTS,
-    GQPLSP,
-]
-BYGDSB = [
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-]
-EKCWAO = [UJUTYE, JUTYEK, UTYEKC, TYEKCW, YEKCWA]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-JRJHIU = [IVLASS, UOJRJH, OJRJHI]
-KHTZBB = []
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-KZILXW = [XEKVKZ, EKVKZI, KVKZIL, VKZILX]
-LSXUJU = [EXLSXU, XLSXUJ]
-MNHTBJ = [
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    IUSOOQ,
-    TFMNHT,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FMNHTB,
-]
-MOUNBL = [QJYMOU, SAKQXP, JYMOUN, AKQXPI, YMOUNB]
-NMHXEK = [
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-]
-NZMJIG = [HFTHEC, MNZMJI, MNZMJI, MNZMJI]
-RYXBQF = [HFTHEC, IRYXBQ, IRYXBQ, IRYXBQ]
-SELHBQ = [
-    RJJJVY,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    OQNRSJ,
-]
-SOOQNR = [IVLASS, UOJRJH]
-TTIDUB = [FFTTID, FTTIDU]
-TZBBEK = [
-    PHUOJR,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    RSJMCB,
-    SJMCBF,
-    MCBFEG,
-    CBFEGZ,
-    HTZBBE,
-]
-UGTYIY = [
-    RJJJVY,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HUGTYI,
-]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-XWAJVD = [ILXWAJ, LXWAJV]
-ZBBEKB = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-]
-ZUQEXL = [FEGZUQ, EGZUQE, GZUQEX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -890,274 +19,970 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return BEKBDF
+        return 54
 
     @property
     def begin(self):
-        return EKBDFS
+        return 256
 
     @property
     def end(self):
-        return KBDFSR
+        return 479
 
     @property
     def all_device_keys(self):
-        return TZBBEK
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ZBBEKB
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdPumpTime",
+            "UdP1LTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+        ]
 
     @property
     def error_keys(self):
-        return BBEKBD
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, LASSAK),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, LASSAK),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, QXPICX, JRJHIU, None, XPICXQ, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, HUOJRJ, ICXQIE, JRJHIU, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HUOJRJ, XPICXQ, JRJHIU, None, XPICXQ, None
+            "UdP1LTime": GeckoByteStructAccessor(self.struct, "UdP1LTime", 362, "ALL"),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, HUOJRJ, QIEFXQ, JRJHIU, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, QXPICX, SOOQNR, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, USOOQN, LRAHEO, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, USOOQN, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, NRSJMC, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, USOOQN, JMCBFE, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, USOOQN, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, None, ZUQEXL, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, QXPICX, LSXUJU, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, EKCWAO, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            KCWAON: GeckoTimeStructAccessor(self.struct, KCWAON, CWAONP, LASSAK),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, LASSAK),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, QEXLSX, ICXQIE, LSXUJU, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, EKCWAO, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            YYLIUX: GeckoTimeStructAccessor(self.struct, YYLIUX, YLIUXF, LASSAK),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, LASSAK),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, LASSAK),
-            FJTACC: GeckoBoolStructAccessor(self.struct, FJTACC, JTACCP, QXPICX, None),
-            TACCPQ: GeckoBoolStructAccessor(self.struct, TACCPQ, JTACCP, ICXQIE, None),
-            ACCPQI: GeckoBoolStructAccessor(self.struct, ACCPQI, JTACCP, NRSJMC, None),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, JTACCP, XPICXQ, None),
-            CPQIPO: GeckoBoolStructAccessor(self.struct, CPQIPO, JTACCP, JMCBFE, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, QIPOUY, ICXQIE, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, POUYNQ, NRSJMC, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, POUYNQ, JMCBFE, None),
-            UYNQJY: GeckoBoolStructAccessor(self.struct, UYNQJY, POUYNQ, QIEFXQ, None),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, MOUNBL, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, UNBLKX, JMCBFE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, UNBLKX, QIEFXQ, None),
-            BLKXSJ: GeckoWordStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, QIPOUY, LRAHEO, None),
-            XSJWMN: GeckoTempStructAccessor(self.struct, XSJWMN, SJWMNZ, None),
-            JWMNZM: GeckoTempStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, USOOQN, JMCBFE, NZMJIG, None, XPICXQ, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, MJIGYO, ICXQIE, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, MJIGYO, QIEFXQ, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, ICXQIE, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, OUSPBW, LRAHEO, None),
-            USPBWJ: GeckoBoolStructAccessor(
-                self.struct, USPBWJ, OUSPBW, ICXQIE, LASSAK
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, LRAHEO, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, QIPOUY, NRSJMC, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, POUYNQ, QXPICX, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, POUYNQ, LRAHEO, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, KLGQPL, ICXQIE, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, KLGQPL, NRSJMC, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, NRSJMC, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, QPLSPF, XPICXQ, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, QPLSPF, JMCBFE, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, QPLSPF, QIEFXQ, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, FTSIFJ, NRSJMC, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, FTSIFJ, XPICXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, FTSIFJ, JMCBFE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FTSIFJ, QIEFXQ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, JBIAMJ, ICXQIE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, JBIAMJ, NRSJMC, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, PBWJYK, NRSJMC, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, UNBLKX, QXPICX, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, UNBLKX, LRAHEO, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, QXPICX, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, GYOUSP, QXPICX, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, KLGQPL, QXPICX, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, KLGQPL, LRAHEO, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, KLGQPL, XPICXQ, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, QXPICX, None),
-            IRYXBQ: GeckoEnumStructAccessor(
-                self.struct, IRYXBQ, SIRYXB, LRAHEO, RYXBQF, None, XPICXQ, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, SIRYXB, NRSJMC, None),
-            XBQFYL: GeckoWordStructAccessor(self.struct, XBQFYL, BQFYLJ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, QXPICX, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, QXPICX, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, LJUIKF, LRAHEO, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JBIAMJ, QXPICX, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JBIAMJ, LRAHEO, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, JBIAMJ, XPICXQ, None),
-            FWRKIN: GeckoWordStructAccessor(self.struct, FWRKIN, WRKINE, None),
-            RKINEJ: GeckoByteStructAccessor(self.struct, RKINEJ, KINEJN, None),
-            INEJNI: GeckoByteStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoEnumStructAccessor(
-                self.struct, EJNIBX, JNIBXY, None, NMHXEK, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            MHXEKV: GeckoEnumStructAccessor(
-                self.struct, MHXEKV, HXEKVK, QXPICX, KZILXW, None, XPICXQ, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZILXWA: GeckoEnumStructAccessor(
-                self.struct, ZILXWA, HXEKVK, ICXQIE, XWAJVD, None, ICXQIE, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WAJVDQ: GeckoWordStructAccessor(self.struct, WAJVDQ, AJVDQL, None),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, None),
-            DQLAII: GeckoByteStructAccessor(self.struct, DQLAII, QLAIID, None),
-            LAIIDN: GeckoByteStructAccessor(self.struct, LAIIDN, AIIDNI, None),
-            IIDNIB: GeckoByteStructAccessor(self.struct, IIDNIB, IDNIBX, None),
-            DNIBXT: GeckoWordStructAccessor(self.struct, DNIBXT, NIBXTI, None),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, None),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, None),
-            IACQFF: GeckoWordStructAccessor(self.struct, IACQFF, ACQFFT, None),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, ICXQIE, LASSAK
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, BYGDSB, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            YGDSBD: GeckoWordStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoByteStructAccessor(self.struct, DSBDJQ, SBDJQR, None),
-            BDJQRJ: GeckoByteStructAccessor(self.struct, BDJQRJ, DJQRJJ, None),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, QRJJJV, None, MNHTBJ, None, None, LASSAK
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, MNHTBJ, None, None, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, MNHTBJ, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JEUTOP: GeckoEnumStructAccessor(
-                self.struct, JEUTOP, EUTOPH, None, MNHTBJ, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, MNHTBJ, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, UGTYIY, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            GTYIYW: GeckoByteStructAccessor(self.struct, GTYIYW, TYIYWS, LASSAK),
-            YIYWSK: GeckoByteStructAccessor(self.struct, YIYWSK, IYWSKW, LASSAK),
-            YWSKWI: GeckoByteStructAccessor(self.struct, YWSKWI, WSKWIV, LASSAK),
-            SKWIVD: GeckoByteStructAccessor(self.struct, SKWIVD, KWIVDN, LASSAK),
-            WIVDNQ: GeckoByteStructAccessor(self.struct, WIVDNQ, IVDNQG, LASSAK),
-            VDNQGV: GeckoByteStructAccessor(self.struct, VDNQGV, DNQGVU, LASSAK),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, MNHTBJ, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, MNHTBJ, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, MNHTBJ, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            XNKMLO: GeckoEnumStructAccessor(
-                self.struct, XNKMLO, NKMLOI, None, MNHTBJ, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, MNHTBJ, None, None, LASSAK
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, MNHTBJ, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, MNHTBJ, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, GSELHB, None, SELHBQ, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, SELHBQ, None, None, LASSAK
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, LASSAK),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, LASSAK),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, LASSAK),
-            CHWDAF: GeckoByteStructAccessor(self.struct, CHWDAF, HWDAFI, LASSAK),
-            WDAFIK: GeckoByteStructAccessor(self.struct, WDAFIK, DAFIKJ, LASSAK),
-            AFIKJP: GeckoByteStructAccessor(self.struct, AFIKJP, FIKJPU, LASSAK),
-            IKJPUN: GeckoByteStructAccessor(self.struct, IKJPUN, KJPUNR, LASSAK),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, LASSAK),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, LASSAK),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-55.py
+++ b/src/geckolib/driver/packs/inyt-log-55.py
@@ -12,894 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 272
-ACMCVD = 468
-ACQFFT = 299
-AFIKJP = 342
-AHEOCT = 308
-AIIDNI = 293
-AJVDQL = "".join(chr(c) for c in [85, 76])
-AKQXPI = "".join(chr(c) for c in [72, 73])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 55])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-ASSAKQ = "".join(chr(c) for c in [85, 100, 80, 49])
-ATDZXN = 348
-AWBSIR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BBEKBD = 479
-BDJQRJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-BFEGZU = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-BJEUTO = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-BQNRXC = 332
-BQSNQL = "".join(chr(c) for c in [105, 110, 88, 69])
-BSIRYX = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-BSSUHB = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-BVWVUB = "".join(chr(c) for c in [75, 56])
-BWJYKL = 281
-BXIBHZ = 464
-BXTIAC = 296
-BXYBQS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-BYGDSB = "".join(chr(c) for c in [75, 56, 48, 48])
-CBFEGZ = 5
-CCPQIP = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-CGETIX = 458
-CHWDAF = 340
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-CPQIPO = 273
-CQBMJV = 317
-CQFFTT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-CRTFMN = "".join(chr(c) for c in [80, 50, 72])
-CTHBSK = 363
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-CVYYPI = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-CWAONP = "".join(chr(c) for c in [78, 69, 87])
-CXQIEF = "".join(chr(c) for c in [85, 100, 80, 51])
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-DGKEAK = "".join(chr(c) for c in [67, 70, 71, 53])
-DJQRJJ = 358
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-DNIBXT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-DSBDJQ = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-DUBSSU = "".join(chr(c) for c in [70, 117, 108, 108])
-DZXNQT = 448
-EAKSTS = 454
-ECVYYP = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-EFJTAC = 270
-EFXQGL = 258
-EGZUQE = 7
-EJNIBX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-EKBDFS = "".join(chr(c) for c in [76, 73])
-EKCWAO = "".join(chr(c) for c in [83, 84, 79, 80])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-EMCGET = 457
-EOCTHB = 307
-ETIXQV = 459
-EUTOPH = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EXLSXU = "".join(chr(c) for c in [70, 85, 76, 76])
-FCRTFM = "".join(chr(c) for c in [80, 49, 76])
-FEFJTA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-FEGZUQ = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FFTTID = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-FJBIAM = 350
-FJTACC = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-FMNHTB = "".join(chr(c) for c in [80, 51, 76])
-FSROGM = 55
-FTHECV = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-FTSIFJ = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-FTTIDU = 301
-FWRKIN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FYLJUI = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-FZDGKE = "".join(chr(c) for c in [67, 70, 71, 52])
-GDSBDJ = "".join(chr(c) for c in [75, 51, 48, 48])
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-GKEAKS = 453
-GQPLSP = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-GTYIYW = 324
-GVUNXN = 339
-GYOUSP = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-GZUQEX = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-HBQNRX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-HBSKSO = 303
-HBVWVU = "".join(chr(c) for c in [75, 56, 53])
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-HECVYY = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 105])
-HFTHEC = "".join(chr(c) for c in [])
-HIUSOO = "".join(chr(c) for c in [80, 50])
-HTBJEU = "".join(chr(c) for c in [66, 76, 79])
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-HUGTYI = 323
-HUOJRJ = 362
-HWDAFI = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-HXEKVK = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-HZVOAC = 466
-IACQFF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-IAMJMA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IBHZVO = 465
-IBXTIA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-IBXYBQ = 288
-ICXQIE = 2
-IDNIBX = 294
-IDUBSS = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 53])
-IFJBIA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IHBXIB = 463
-IIDNIB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-IJUGSE = 328
-IKFWRK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IKJPUN = 343
-ILXWAJ = "".join(chr(c) for c in [52, 56, 75])
-INEJNI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-IPIVLA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IPOUYN = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 51])
-IUXFEF = 267
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-IVLASS = "".join(chr(c) for c in [79, 70, 70])
-IXQVXO = 460
-IYWSKW = "".join(chr(c) for c in [72, 84, 82])
-JBIAMJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-JIGYOU = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-JJJVYF = 361
-JJVYFC = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-JMAOAW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-JMCBFE = "".join(chr(c) for c in [76, 49, 50, 48])
-JNIBXY = 287
-JPUNRJ = 344
-JQRJJJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-JRJHIU = "".join(chr(c) for c in [72, 73, 71, 72])
-JTACCP = 271
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JVDQLA = "".join(chr(c) for c in [67, 69])
-JVHFTH = 319
-JVYFCR = 320
-JWMNZM = 355
-JYKLGQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-JYMOUN = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JZTATD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-KCWAON = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 54])
-KFWRKI = 315
-KHTZBB = 477
-KINEJN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-KLGQPL = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-KMLOIJ = 326
-KPHUOJ = 306
-KQTDKH = 475
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-KSTSEM = 455
-KVKZIL = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KXSJWM = 353
-KZILXW = "".join(chr(c) for c in [49, 54, 75])
-LAIIDN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-LASSAK = "".join(chr(c) for c in [65, 76, 76])
-LGQPLS = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LHBQNR = 331
-LIUXFE = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-LJUIKF = 311
-LKXSJW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LNMHXE = "".join(chr(c) for c in [105, 110, 88, 77])
-LOIJUG = 327
-LRAHEO = 1
-LSPFTS = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-LSXUJU = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-LXWAJV = "".join(chr(c) for c in [54, 52, 75])
-MAOAWB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-MCBFEG = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-MCVDSS = 469
-MFZDGK = 451
-MHXEKV = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-MJIGYO = 277
-MJMAOA = 351
-MJVHFT = "".join(chr(c) for c in [77, 101, 110, 117])
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-MNHTBJ = "".join(chr(c) for c in [80, 52, 72])
-MNZMJI = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-MOUNBL = 313
-NBLKXS = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-NEJNIB = 285
-NHTBJE = "".join(chr(c) for c in [80, 52, 76])
-NIBXTI = 295
-NIBXYB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-NMHXEK = "".join(chr(c) for c in [75, 54, 48, 48])
-NPYYLI = 264
-NQGVUN = 338
-NQJYMO = 282
-NQLNMH = "".join(chr(c) for c in [68, 74, 83, 52])
-NQTMFZ = "".join(chr(c) for c in [67, 70, 71, 50])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-NRSJMC = "".join(chr(c) for c in [67, 80])
-NRXCHW = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-NZMJIG = 275
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OAWBSI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-OJRJHI = 261
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-ONPYYL = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-OOQNRS = 260
-OPHUGT = 322
-OUNBLK = "".join(chr(c) for c in [78, 79])
-OUSPBW = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-OUYNQJ = "".join(chr(c) for c in [67, 80, 79, 84])
-PBWJYK = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-PFTSIF = 284
-PHUGTY = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-PHUOJR = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-PICXQI = "".join(chr(c) for c in [85, 100, 80, 50])
-PIPIVL = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-PIVLAS = "".join(chr(c) for c in [83, 79, 65, 75])
-PLSPFT = 283
-POUYNQ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-PQIPOU = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-PYYLIU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-QFFTTI = 300
-QGLRAH = "".join(chr(c) for c in [79, 78])
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-QIEFXQ = 6
-QIPOUY = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-QJYMOU = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-QLAIID = 291
-QLNMHX = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-QNRSJM = "".join(chr(c) for c in [66, 76])
-QPLSPF = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-QRJJJV = 360
-QSNQLN = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-QTMFZD = 450
-QVXOIH = 461
-QXPICX = 0
-RAHEOC = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-RAZMKQ = 473
-RJHIUS = "".join(chr(c) for c in [76, 79, 87])
-RJJJVY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-RJZTAT = 346
-RKINEJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ROGMDD = 479
-RSJMCB = "".join(chr(c) for c in [79, 51])
-RTFMNH = "".join(chr(c) for c in [80, 50, 76])
-RURAZM = 472
-RXCHWD = 333
-RYXBQF = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-SAKQXP = "".join(chr(c) for c in [76, 79])
-SELHBQ = 330
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 57])
-SIFJBI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-SIRYXB = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-SJMCBF = 3
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-SKSOKP = 304
-SKWIVD = 335
-SNQLNM = "".join(chr(c) for c in [77, 73, 65])
-SOKPHU = 305
-SOOQNR = "".join(chr(c) for c in [80, 53])
-SPBWJY = 280
-SPFTSI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-SROGMD = 256
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-SSAKQX = 259
-SSRURA = 471
-SSUHBV = 357
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 56])
-SUHBVW = "".join(chr(c) for c in [75, 50, 48, 48])
-SXUJUT = 262
-TACCPQ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-TATDZX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-TBJEUT = "".join(chr(c) for c in [70, 97, 110])
-TDKHTZ = 476
-TDZXNQ = "".join(chr(c) for c in [67, 70, 71, 48])
-TFMNHT = "".join(chr(c) for c in [80, 51, 72])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-THECVY = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-TIACQF = 297
-TIDUBS = 316
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-TMFZDG = "".join(chr(c) for c in [67, 70, 71, 51])
-TOPHUG = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-TSEMCG = 456
-TSIFJB = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-TTIDUB = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-TYEKCW = 263
-TYIYWS = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-TZBBEK = 478
-UBYGDS = "".join(chr(c) for c in [75, 49, 48, 48])
-UGSELH = 329
-UGTYIY = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-UHBVWV = "".join(chr(c) for c in [75, 52, 48, 48])
-UIKFWR = 314
-UJUTYE = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-UNBLKX = "".join(chr(c) for c in [77, 69, 68])
-UNRJZT = 345
-UNXNKM = 349
-UOJRJH = "".join(chr(c) for c in [80, 49])
-UQEXLS = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-USOOQN = "".join(chr(c) for c in [80, 52])
-USPBWJ = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-UTOPHU = 321
-UTYEKC = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-UXFEFJ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UYNQJY = 274
-VDNQGV = 337
-VDSSRU = 470
-VHFTHE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-VKZILX = 290
-VOACMC = 467
-VUBYGD = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-VWVUBY = "".join(chr(c) for c in [75, 52])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VYFCRT = "".join(chr(c) for c in [78, 65])
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-WAONPY = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-WBSIRY = 354
-WDAFIK = 341
-WIVDNQ = 336
-WJYKLG = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-WMNZMJ = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-WRKINE = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-WVUBYG = "".join(chr(c) for c in [75, 53])
-XBQFYL = 309
-XCHWDA = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-XEKVKZ = "".join(chr(c) for c in [105, 110, 89, 84])
-XFEFJT = 268
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-XNKMLO = 325
-XNQTMF = 449
-XOIHBX = 462
-XPICXQ = 4
-XQGLRA = "".join(chr(c) for c in [85, 100, 66, 76])
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 52])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-XSJWMN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-XTIACQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-XUJUTY = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-XYBQSN = 289
-YBQSNQ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YEKCWA = "".join(chr(c) for c in [73, 68, 76, 69])
-YFCRTF = "".join(chr(c) for c in [80, 49, 72])
-YGDSBD = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-YIYWSK = 334
-YKLGQP = 352
-YLIUXF = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YLJUIK = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YMOUNB = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YNQJYM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-YOUSPB = 279
-YPIPIV = 257
-YXBQFY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-YYLIUX = 266
-YYPIPI = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 452
-ZILXWA = "".join(chr(c) for c in [51, 50, 75])
-ZMJIGY = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-ZMKQTD = 474
-ZTATDZ = 347
-ZUQEXL = 310
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ZXNQTM = "".join(chr(c) for c in [67, 70, 71, 49])
-AONPYY = [YEKCWA, EKCWAO, KCWAON, CWAONP, WAONPY]
-BDFSRO = [
-    ASSAKQ,
-    PICXQI,
-    CXQIEF,
-    XQIEFX,
-    IEFXQG,
-    XQGLRA,
-    RAHEOC,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-]
-BEKBDF = []
-BLKXSJ = [OUNBLK, SAKQXP, UNBLKX, AKQXPI, NBLKXS]
-DFSROG = [
-    WRKINE,
-    JMAOAW,
-    OAWBSI,
-    FTSIFJ,
-    WMNZMJ,
-    FYLJUI,
-    FWRKIN,
-    RKINEJ,
-    GYOUSP,
-    POUYNQ,
-    IAMJMA,
-    IFJBIA,
-    KLGQPL,
-    JYKLGQ,
-    IKFWRK,
-    SIFJBI,
-    AMJMAO,
-    BIAMJM,
-    LSPFTS,
-    AWBSIR,
-    QPLSPF,
-    LGQPLS,
-    MAOAWB,
-    IRYXBQ,
-    AOAWBS,
-    GQPLSP,
-    JBIAMJ,
-    TSIFJB,
-    SPFTSI,
-]
-EKVKZI = [
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-    SNQLNM,
-    NQLNMH,
-    QLNMHX,
-    LNMHXE,
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-]
-FXQGLR = [IVLASS, AKQXPI]
-GLRAHE = [IVLASS, QGLRAH]
-IGYOUS = [HFTHEC, JIGYOU, JIGYOU, JIGYOU]
-JEUTOP = [
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    SOOQNR,
-    HTBJEU,
-    NRSJMC,
-    RSJMCB,
-    JMCBFE,
-    HFTHEC,
-    HFTHEC,
-    TBJEUT,
-    HFTHEC,
-    HFTHEC,
-    BJEUTO,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FEGZUQ,
-]
-JHIUSO = [IVLASS, JRJHIU, RJHIUS]
-JUTYEK = [XUJUTY, UJUTYE]
-KBDFSR = [
-    UOJRJH,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    JMCBFE,
-    MCBFEG,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    EKBDFS,
-]
-KQXPIC = [IVLASS, SAKQXP, AKQXPI]
-OQNRSJ = [IVLASS, JRJHIU]
-QFYLJU = [HFTHEC, BQFYLJ, BQFYLJ, BQFYLJ]
-QNRXCH = [
-    VYFCRT,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    NRSJMC,
-]
-SBDJQR = [
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-]
-UBSSUH = [IDUBSS, DUBSSU]
-VDQLAI = [AJVDQL, JVDQLA]
-VLASSA = [PIPIVL, IPIVLA, PIVLAS, IVLASS]
-VYYPIP = [
-    VHFTHE,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    HFTHEC,
-    CVYYPI,
-]
-XLSXUJ = [UQEXLS, QEXLSX, EXLSXU]
-XWAJVD = [KZILXW, ZILXWA, ILXWAJ, LXWAJV]
-YWSKWI = [
-    VYFCRT,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    HFTHEC,
-    IYWSKW,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -907,280 +19,1064 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return FSROGM
+        return 55
 
     @property
     def begin(self):
-        return SROGMD
+        return 256
 
     @property
     def end(self):
-        return ROGMDD
+        return 479
 
     @property
     def all_device_keys(self):
-        return KBDFSR
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return BDFSRO
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+        ]
 
     @property
     def error_keys(self):
-        return DFSROG
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoEnumStructAccessor(
-                self.struct, MJVHFT, JVHFTH, None, VYYPIP, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VLASSA, None, None, LASSAK
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, QXPICX, KQXPIC, None, XPICXQ, LASSAK
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, SSAKQX, ICXQIE, KQXPIC, None, XPICXQ, LASSAK
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, SSAKQX, XPICXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, SSAKQX, QIEFXQ, KQXPIC, None, XPICXQ, LASSAK
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, QXPICX, FXQGLR, None, ICXQIE, LASSAK
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, EFXQGL, LRAHEO, GLRAHE, None, ICXQIE, LASSAK
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, GLRAHE, None, None, LASSAK
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, FXQGLR, None, None, LASSAK
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, GLRAHE, None, None, LASSAK
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, LASSAK),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, LASSAK),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, LASSAK),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, LASSAK),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, LASSAK),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, QXPICX, JHIUSO, None, XPICXQ, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, OJRJHI, ICXQIE, JHIUSO, None, XPICXQ, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, OJRJHI, XPICXQ, JHIUSO, None, XPICXQ, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, OJRJHI, QIEFXQ, JHIUSO, None, XPICXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, QXPICX, OQNRSJ, None, ICXQIE, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, OOQNRS, LRAHEO, GLRAHE, None, ICXQIE, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, OOQNRS, ICXQIE, GLRAHE, None, ICXQIE, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, OOQNRS, SJMCBF, GLRAHE, None, ICXQIE, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, OOQNRS, XPICXQ, GLRAHE, None, ICXQIE, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, OOQNRS, CBFEGZ, GLRAHE, None, ICXQIE, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, OOQNRS, QIEFXQ, GLRAHE, None, ICXQIE, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, OOQNRS, EGZUQE, GLRAHE, None, ICXQIE, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, ZUQEXL, None, XLSXUJ, None, None, LASSAK
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, QXPICX, JUTYEK, None, ICXQIE, LASSAK
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, TYEKCW, None, AONPYY, None, None, LASSAK
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            ONPYYL: GeckoTimeStructAccessor(self.struct, ONPYYL, NPYYLI, LASSAK),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, LASSAK),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, SXUJUT, ICXQIE, JUTYEK, None, ICXQIE, LASSAK
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, None, AONPYY, None, None, LASSAK
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            UXFEFJ: GeckoTimeStructAccessor(self.struct, UXFEFJ, XFEFJT, LASSAK),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, LASSAK),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, LASSAK),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, LASSAK),
-            CCPQIP: GeckoBoolStructAccessor(self.struct, CCPQIP, CPQIPO, QXPICX, None),
-            PQIPOU: GeckoBoolStructAccessor(self.struct, PQIPOU, CPQIPO, ICXQIE, None),
-            QIPOUY: GeckoBoolStructAccessor(self.struct, QIPOUY, CPQIPO, SJMCBF, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, CPQIPO, XPICXQ, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, CPQIPO, CBFEGZ, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, UYNQJY, ICXQIE, None),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, NQJYMO, SJMCBF, None),
-            QJYMOU: GeckoBoolStructAccessor(self.struct, QJYMOU, NQJYMO, CBFEGZ, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, NQJYMO, QIEFXQ, None),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, BLKXSJ, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, KXSJWM, CBFEGZ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, KXSJWM, QIEFXQ, None),
-            SJWMNZ: GeckoWordStructAccessor(self.struct, SJWMNZ, JWMNZM, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, UYNQJY, LRAHEO, None),
-            MNZMJI: GeckoTempStructAccessor(self.struct, MNZMJI, NZMJIG, None),
-            ZMJIGY: GeckoTempStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, OOQNRS, CBFEGZ, IGYOUS, None, XPICXQ, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, YOUSPB, ICXQIE, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, YOUSPB, QIEFXQ, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, SPBWJY, ICXQIE, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, LRAHEO, None),
-            WJYKLG: GeckoBoolStructAccessor(
-                self.struct, WJYKLG, BWJYKL, ICXQIE, LASSAK
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, YKLGQP, LRAHEO, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, UYNQJY, SJMCBF, None),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, NQJYMO, QXPICX, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, NQJYMO, LRAHEO, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, PLSPFT, ICXQIE, None),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, PLSPFT, SJMCBF, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, SJMCBF, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, XPICXQ, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, PFTSIF, CBFEGZ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, PFTSIF, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, SJMCBF, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, FJBIAM, XPICXQ, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, FJBIAM, CBFEGZ, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, FJBIAM, QIEFXQ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, ICXQIE, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MJMAOA, SJMCBF, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, YKLGQP, SJMCBF, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, KXSJWM, QXPICX, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, KXSJWM, LRAHEO, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, QXPICX, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SPBWJY, QXPICX, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, PLSPFT, QXPICX, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, PLSPFT, LRAHEO, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, PLSPFT, XPICXQ, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QXPICX, None),
-            BQFYLJ: GeckoEnumStructAccessor(
-                self.struct, BQFYLJ, XBQFYL, LRAHEO, QFYLJU, None, XPICXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, XBQFYL, SJMCBF, None),
-            YLJUIK: GeckoWordStructAccessor(self.struct, YLJUIK, LJUIKF, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, QXPICX, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, KFWRKI, QXPICX, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, KFWRKI, LRAHEO, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, MJMAOA, QXPICX, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, MJMAOA, LRAHEO, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, MJMAOA, XPICXQ, None),
-            INEJNI: GeckoWordStructAccessor(self.struct, INEJNI, NEJNIB, None),
-            EJNIBX: GeckoByteStructAccessor(self.struct, EJNIBX, JNIBXY, None),
-            NIBXYB: GeckoByteStructAccessor(self.struct, NIBXYB, IBXYBQ, None),
-            BXYBQS: GeckoEnumStructAccessor(
-                self.struct, BXYBQS, XYBQSN, None, EKVKZI, None, None, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, QXPICX, XWAJVD, None, XPICXQ, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, VKZILX, ICXQIE, VDQLAI, None, ICXQIE, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            DQLAII: GeckoWordStructAccessor(self.struct, DQLAII, QLAIID, None),
-            LAIIDN: GeckoByteStructAccessor(self.struct, LAIIDN, AIIDNI, None),
-            IIDNIB: GeckoByteStructAccessor(self.struct, IIDNIB, IDNIBX, None),
-            DNIBXT: GeckoByteStructAccessor(self.struct, DNIBXT, NIBXTI, None),
-            IBXTIA: GeckoByteStructAccessor(self.struct, IBXTIA, BXTIAC, None),
-            XTIACQ: GeckoWordStructAccessor(self.struct, XTIACQ, TIACQF, None),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, None),
-            CQFFTT: GeckoByteStructAccessor(self.struct, CQFFTT, QFFTTI, None),
-            FFTTID: GeckoWordStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, TIDUBS, None, UBSSUH, None, ICXQIE, LASSAK
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, SBDJQR, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            BDJQRJ: GeckoWordStructAccessor(self.struct, BDJQRJ, DJQRJJ, None),
-            JQRJJJ: GeckoByteStructAccessor(self.struct, JQRJJJ, QRJJJV, None),
-            RJJJVY: GeckoByteStructAccessor(self.struct, RJJJVY, JJJVYF, None),
-            JJVYFC: GeckoEnumStructAccessor(
-                self.struct, JJVYFC, JVYFCR, None, JEUTOP, None, None, LASSAK
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, JEUTOP, None, None, LASSAK
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            TOPHUG: GeckoEnumStructAccessor(
-                self.struct, TOPHUG, OPHUGT, None, JEUTOP, None, None, LASSAK
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            PHUGTY: GeckoEnumStructAccessor(
-                self.struct, PHUGTY, HUGTYI, None, JEUTOP, None, None, LASSAK
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, JEUTOP, None, None, LASSAK
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, YWSKWI, None, None, LASSAK
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, LASSAK),
-            KWIVDN: GeckoByteStructAccessor(self.struct, KWIVDN, WIVDNQ, LASSAK),
-            IVDNQG: GeckoByteStructAccessor(self.struct, IVDNQG, VDNQGV, LASSAK),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, LASSAK),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, LASSAK),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, LASSAK),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, JEUTOP, None, None, LASSAK
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, JEUTOP, None, None, LASSAK
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            MLOIJU: GeckoEnumStructAccessor(
-                self.struct, MLOIJU, LOIJUG, None, JEUTOP, None, None, LASSAK
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            OIJUGS: GeckoEnumStructAccessor(
-                self.struct, OIJUGS, IJUGSE, None, JEUTOP, None, None, LASSAK
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, JEUTOP, None, None, LASSAK
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, JEUTOP, None, None, LASSAK
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, JEUTOP, None, None, LASSAK
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, QNRXCH, None, None, LASSAK
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, QNRXCH, None, None, LASSAK
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            XCHWDA: GeckoByteStructAccessor(self.struct, XCHWDA, CHWDAF, LASSAK),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, LASSAK),
-            DAFIKJ: GeckoByteStructAccessor(self.struct, DAFIKJ, AFIKJP, LASSAK),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, LASSAK),
-            KJPUNR: GeckoByteStructAccessor(self.struct, KJPUNR, JPUNRJ, LASSAK),
-            PUNRJZ: GeckoByteStructAccessor(self.struct, PUNRJZ, UNRJZT, LASSAK),
-            NRJZTA: GeckoByteStructAccessor(self.struct, NRJZTA, RJZTAT, LASSAK),
-            JZTATD: GeckoByteStructAccessor(self.struct, JZTATD, ZTATDZ, LASSAK),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, LASSAK),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-56.py
+++ b/src/geckolib/driver/packs/inyt-log-56.py
@@ -12,913 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 267
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-ACQFFT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AFIKJP = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-AJVDQL = 290
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 451
-AMJMAO = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AOAWBS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-AWBSIR = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-AZMKQT = 470
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-BDJQRJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-BEKBDF = 476
-BFEGZU = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-BHZVOA = 462
-BIAMJM = 284
-BJEUTO = "".join(chr(c) for c in [80, 50, 76])
-BLKXSJ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-BMJVHF = 256
-BQFYLJ = 354
-BQNRXC = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-BQSNQL = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-BSIRYX = 351
-BSKSOK = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-BSSUHB = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-BVWVUB = "".join(chr(c) for c in [70, 117, 108, 108])
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-BXYBQS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-BYGDSB = "".join(chr(c) for c in [75, 52, 48, 48])
-CBFEGZ = "".join(chr(c) for c in [76, 49, 50, 48])
-CCPQIP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 55])
-CHWDAF = 331
-CMCVDS = 465
-CPQIPO = 268
-CQBMJV = 317
-CQFFTT = 295
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-CTHBSK = 307
-CVDSSR = 466
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-CXQIEF = 4
-DFSROG = 478
-DGKEAK = 449
-DJQRJJ = "".join(chr(c) for c in [75, 49, 48, 48])
-DKHTZB = 473
-DPMXFU = 56
-DQLAII = "".join(chr(c) for c in [52, 56, 75])
-DSBDJQ = "".join(chr(c) for c in [75, 52])
-DSSRUR = 467
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 51])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EJNIBX = 315
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-EKCWAO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EKVKZI = "".join(chr(c) for c in [68, 74, 83, 52])
-ELHBQN = 327
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 54])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 56])
-EUTOPH = "".join(chr(c) for c in [80, 51, 76])
-EXLSXU = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-FCRTFM = 360
-FEFJTA = 264
-FEGZUQ = 5
-FFTTID = 296
-FIKJPU = 333
-FJBIAM = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-FJTACC = 266
-FMNHTB = 320
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-FWRKIN = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-FZDGKE = 448
-GDSBDJ = "".join(chr(c) for c in [75, 56])
-GETIXQ = 455
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 50])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GQPLSP = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-GSELHB = 326
-GTYIYW = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-GVUNXN = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-GYOUSP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-GZUQEX = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-HBQNRX = 328
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HBXIBH = 460
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [76, 79, 87])
-HTBJEU = "".join(chr(c) for c in [80, 49, 76])
-HTZBBE = 474
-HUGTYI = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-HUOJRJ = 306
-HWDAFI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-HXEKVK = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-IACQFF = 294
-IAMJMA = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-IBXTIA = 291
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [67, 69])
-IDUBSS = 299
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = 283
-IGYOUS = 355
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-IIDNIB = "".join(chr(c) for c in [85, 76])
-IJUGSE = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-ILXWAJ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-INEJNI = 314
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IUXFEF = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-IVDNQG = 334
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 57])
-IYWSKW = 322
-JBIAMJ = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-JEUTOP = "".join(chr(c) for c in [80, 51, 72])
-JHIUSO = "".join(chr(c) for c in [72, 73, 71, 72])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-JJJVYF = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68])
-JMAOAW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-JMCBFE = "".join(chr(c) for c in [79, 51])
-JNIBXY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JPUNRJ = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-JQRJJJ = "".join(chr(c) for c in [75, 56, 48, 48])
-JRJHIU = "".join(chr(c) for c in [80, 49])
-JTACCP = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-JUGSEL = 325
-JUIKFW = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-JUTYEK = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-JVDQLA = "".join(chr(c) for c in [49, 54, 75])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-JWMNZM = "".join(chr(c) for c in [77, 69, 68])
-JYKLGQ = 279
-JYMOUN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JZTATD = 343
-KBDFSR = 477
-KCWAON = 262
-KEAKST = 450
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-KINEJN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KJPUNR = 340
-KLGQPL = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-KMLOIJ = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-KPHUOJ = 305
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 52])
-KVKZIL = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-KWIVDN = 324
-KXSJWM = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-KZILXW = "".join(chr(c) for c in [75, 54, 48, 48])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 280
-LHBQNR = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-LIUXFE = "".join(chr(c) for c in [78, 69, 87])
-LJUIKF = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-LKXSJW = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-LNMHXE = 289
-LOIJUG = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-LSXUJU = "".join(chr(c) for c in [70, 85, 76, 76])
-LXWAJV = "".join(chr(c) for c in [105, 110, 89, 84])
-MAOAWB = 350
-MCBFEG = 3
-MCGETI = 454
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-MFZDGK = "".join(chr(c) for c in [67, 70, 71, 48])
-MHXEKV = "".join(chr(c) for c in [105, 110, 88, 69])
-MJIGYO = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-MJMAOA = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 471
-MLOIJU = 339
-MNHTBJ = "".join(chr(c) for c in [78, 65])
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-MXFUBJ = 479
-NBLKXS = 282
-NEJNIB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NHTBJE = "".join(chr(c) for c in [80, 49, 72])
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-NIBXYB = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-NKMLOI = 338
-NMHXEK = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-NPYYLI = 263
-NQGVUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NQJYMO = 273
-NQLNMH = 288
-NQTMFZ = 347
-NRJZTA = 342
-NRXCHW = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-NXNKML = 337
-NZMJIG = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-OACMCV = 464
-OAWBSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [76, 73])
-OIHBXI = 459
-OIJUGS = 349
-OJRJHI = 362
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-ONPYYL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-OOQNRS = "".join(chr(c) for c in [80, 52])
-OPHUGT = "".join(chr(c) for c in [66, 76, 79])
-OQNRSJ = "".join(chr(c) for c in [80, 53])
-OUNBLK = "".join(chr(c) for c in [67, 80, 79, 84])
-OUSPBW = 275
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PFTSIF = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-PHUGTY = "".join(chr(c) for c in [70, 97, 110])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-PMXFUB = 256
-POUYNQ = 271
-PQIPOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PUNRJZ = 341
-PYYLIU = "".join(chr(c) for c in [73, 68, 76, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 310
-QFFTTI = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-QFYLJU = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QGVUNX = 335
-QIEFXQ = 2
-QIPOUY = 270
-QJYMOU = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-QLAIID = "".join(chr(c) for c in [54, 52, 75])
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-QNRSJM = 260
-QNRXCH = 329
-QPLSPF = 281
-QRJJJV = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-QSNQLN = 287
-QTDKHT = 472
-QTMFZD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-RJHIUS = 261
-RJJJVY = "".join(chr(c) for c in [75, 51, 48, 48])
-RJZTAT = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-RKINEJ = 311
-RSJMCB = "".join(chr(c) for c in [66, 76])
-RTFMNH = 361
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-RXCHWD = 330
-RYXBQF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 53])
-SELHBQ = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-SEMCGE = 453
-SIFJBI = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-SIRYXB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-SJMCBF = "".join(chr(c) for c in [67, 80])
-SJWMNZ = "".join(chr(c) for c in [78, 79])
-SKSOKP = 303
-SKWIVD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-SOKPHU = 304
-SOOQNR = "".join(chr(c) for c in [80, 51])
-SPBWJY = 277
-SPFTSI = 352
-SROGMD = 479
-SRURAZ = 468
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-SSUHBV = 301
-STSEMC = 452
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-TACCPQ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-TATDZX = 344
-TBJEUT = "".join(chr(c) for c in [80, 50, 72])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-TDZXNQ = 345
-TFMNHT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TIXQVX = 456
-TMFZDG = 348
-TOPHUG = "".join(chr(c) for c in [80, 52, 76])
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 53])
-TSIFJB = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-TTIDUB = 297
-TYEKCW = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-TYIYWS = 321
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-UBSSUH = 300
-UBYGDS = "".join(chr(c) for c in [75, 50, 48, 48])
-UGSELH = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-UHBVWV = 316
-UIKFWR = 309
-UJUTYE = 364
-UNBLKX = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-UNRJZT = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-UNXNKM = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-UOJRJH = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-UQEXLS = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-URAZMK = 469
-USOOQN = "".join(chr(c) for c in [80, 50])
-USPBWJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-UTOPHU = "".join(chr(c) for c in [80, 52, 72])
-UTYEKC = 365
-UYNQJY = 272
-VDNQGV = "".join(chr(c) for c in [72, 84, 82])
-VDQLAI = "".join(chr(c) for c in [51, 50, 75])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [105, 110, 88, 77])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-VUBYGD = 357
-VUNXNK = 336
-VXOIHB = 458
-VYFCRT = 358
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-WAONPY = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-WBSIRY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-WDAFIK = 332
-WIVDNQ = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-WJYKLG = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-WMNZMJ = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-WRKINE = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-WSKWIV = 323
-WVUBYG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-XCHWDA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-XEKVKZ = "".join(chr(c) for c in [77, 73, 65])
-XFEFJT = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-XIBHZV = 461
-XLSXUJ = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-XNKMLO = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-XNQTMF = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 457
-XSJWMN = 313
-XTIACQ = 293
-XUJUTY = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-XYBQSN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-YBQSNQ = 285
-YEKCWA = 367
-YFCRTF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-YGDSBD = "".join(chr(c) for c in [75, 56, 53])
-YIYWSK = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-YKLGQP = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-YLIUXF = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-YLJUIK = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-YMOUNB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-YNQJYM = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YOUSPB = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-YYLIUX = "".join(chr(c) for c in [83, 84, 79, 80])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 475
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [67, 70, 71, 49])
-ZILXWA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-ZMJIGY = 353
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-ZUQEXL = 7
-ZVOACM = 463
-ZXNQTM = 346
-AONPYY = [CWAONP, WAONPY]
-BWJYKL = [HECVYY, PBWJYK, PBWJYK, PBWJYK]
-DAFIKJ = [
-    MNHTBJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SJMCBF,
-]
-DDPMXF = [
-    NIBXYB,
-    SIRYXB,
-    YXBQFY,
-    IAMJMA,
-    GYOUSP,
-    FWRKIN,
-    JNIBXY,
-    IBXYBQ,
-    WJYKLG,
-    MOUNBL,
-    AWBSIR,
-    JMAOAW,
-    PFTSIF,
-    LSPFTS,
-    NEJNIB,
-    MJMAOA,
-    WBSIRY,
-    OAWBSI,
-    FJBIAM,
-    XBQFYL,
-    SIFJBI,
-    FTSIFJ,
-    IRYXBQ,
-    YLJUIK,
-    RYXBQF,
-    TSIFJB,
-    AOAWBS,
-    AMJMAO,
-    JBIAMJ,
-]
-DNIBXT = [IIDNIB, IDNIBX]
-DNQGVU = [
-    MNHTBJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    VDNQGV,
-]
-GMDDPM = [
-    JRJHIU,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    RSJMCB,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    BFEGZU,
-    EGZUQE,
-    GZUQEX,
-    UQEXLS,
-    XUJUTY,
-    JUTYEK,
-    TYEKCW,
-    OGMDDP,
-]
-IUSOOQ = [ASSAKQ, JHIUSO, HIUSOO]
-JJVYFC = [
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-]
-KFWRKI = [HECVYY, IKFWRK, IKFWRK, IKFWRK]
-LAIIDN = [JVDQLA, VDQLAI, DQLAII, QLAIID]
-MDDPMX = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-]
-MNZMJI = [SJWMNZ, QXPICX, JWMNZM, XPICXQ, WMNZMJ]
-NRSJMC = [ASSAKQ, JHIUSO]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-ROGMDD = []
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-SXUJUT = [EXLSXU, XLSXUJ, LSXUJU]
-UGTYIY = [
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OQNRSJ,
-    OPHUGT,
-    SJMCBF,
-    JMCBFE,
-    CBFEGZ,
-    HECVYY,
-    HECVYY,
-    PHUGTY,
-    HECVYY,
-    HECVYY,
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GZUQEX,
-]
-UXFEFJ = [PYYLIU, YYLIUX, YLIUXF, LIUXFE, IUXFEF]
-VWVUBY = [HBVWVU, BVWVUB]
-XWAJVD = [
-    NMHXEK,
-    MHXEKV,
-    HXEKVK,
-    XEKVKZ,
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -926,286 +19,1086 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return DPMXFU
+        return 56
 
     @property
     def begin(self):
-        return PMXFUB
+        return 256
 
     @property
     def end(self):
-        return MXFUBJ
+        return 479
 
     @property
     def all_device_keys(self):
-        return GMDDPM
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return MDDPMX
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+        ]
 
     @property
     def error_keys(self):
-        return DDPMXF
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, SAKQXP),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, ICXQIE, IUSOOQ, None, CXQIEF, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, RJHIUS, QIEFXQ, IUSOOQ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, RJHIUS, CXQIEF, IUSOOQ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            OOQNRS: GeckoEnumStructAccessor(
-                self.struct, OOQNRS, RJHIUS, VHFTHE, IUSOOQ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, ICXQIE, NRSJMC, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, QNRSJM, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, QNRSJM, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            JMCBFE: GeckoEnumStructAccessor(
-                self.struct, JMCBFE, QNRSJM, MCBFEG, RAHEOC, None, QIEFXQ, None
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, QNRSJM, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, QNRSJM, FEGZUQ, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, QNRSJM, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, QNRSJM, ZUQEXL, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, QEXLSX, None, SXUJUT, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UJUTYE, None, SXUJUT, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            JUTYEK: GeckoWordStructAccessor(self.struct, JUTYEK, UTYEKC, None),
-            TYEKCW: GeckoWordStructAccessor(self.struct, TYEKCW, YEKCWA, SAKQXP),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, ICXQIE, AONPYY, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, UXFEFJ, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            XFEFJT: GeckoTimeStructAccessor(self.struct, XFEFJT, FEFJTA, SAKQXP),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, SAKQXP),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, KCWAON, QIEFXQ, AONPYY, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            TACCPQ: GeckoEnumStructAccessor(
-                self.struct, TACCPQ, ACCPQI, None, UXFEFJ, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            CCPQIP: GeckoTimeStructAccessor(self.struct, CCPQIP, CPQIPO, SAKQXP),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, SAKQXP),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoBoolStructAccessor(self.struct, YNQJYM, NQJYMO, ICXQIE, None),
-            QJYMOU: GeckoBoolStructAccessor(self.struct, QJYMOU, NQJYMO, QIEFXQ, None),
-            JYMOUN: GeckoBoolStructAccessor(self.struct, JYMOUN, NQJYMO, MCBFEG, None),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, NQJYMO, CXQIEF, None),
-            MOUNBL: GeckoBoolStructAccessor(self.struct, MOUNBL, NQJYMO, FEGZUQ, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, JVHFTH, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, NBLKXS, MCBFEG, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, NBLKXS, FEGZUQ, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, NBLKXS, VHFTHE, None),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, XSJWMN, None, MNZMJI, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, FEGZUQ, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, ZMJIGY, VHFTHE, None),
-            JIGYOU: GeckoWordStructAccessor(self.struct, JIGYOU, IGYOUS, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, JVHFTH, AHEOCT, None),
-            YOUSPB: GeckoTempStructAccessor(self.struct, YOUSPB, OUSPBW, None),
-            USPBWJ: GeckoTempStructAccessor(self.struct, USPBWJ, SPBWJY, None),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, QNRSJM, FEGZUQ, BWJYKL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, JYKLGQ, QIEFXQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JYKLGQ, VHFTHE, None),
-            KLGQPL: GeckoBoolStructAccessor(self.struct, KLGQPL, LGQPLS, QIEFXQ, None),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, AHEOCT, None),
-            PLSPFT: GeckoBoolStructAccessor(
-                self.struct, PLSPFT, QPLSPF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, AHEOCT, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, JVHFTH, MCBFEG, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, NBLKXS, ICXQIE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, NBLKXS, AHEOCT, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, IFJBIA, QIEFXQ, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, IFJBIA, MCBFEG, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, BIAMJM, MCBFEG, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, BIAMJM, CXQIEF, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, BIAMJM, FEGZUQ, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, BIAMJM, VHFTHE, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, MCBFEG, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, MAOAWB, CXQIEF, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, MAOAWB, FEGZUQ, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, MAOAWB, VHFTHE, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, QIEFXQ, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, BSIRYX, MCBFEG, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, SPFTSI, MCBFEG, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, ZMJIGY, ICXQIE, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, ZMJIGY, AHEOCT, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, ICXQIE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, LGQPLS, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, IFJBIA, ICXQIE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, IFJBIA, AHEOCT, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, IFJBIA, CXQIEF, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, ICXQIE, None),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, UIKFWR, AHEOCT, KFWRKI, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, UIKFWR, MCBFEG, None),
-            WRKINE: GeckoWordStructAccessor(self.struct, WRKINE, RKINEJ, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, INEJNI, ICXQIE, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, EJNIBX, ICXQIE, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, EJNIBX, AHEOCT, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, BSIRYX, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BSIRYX, AHEOCT, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, BSIRYX, CXQIEF, None),
-            XYBQSN: GeckoWordStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoByteStructAccessor(self.struct, BQSNQL, QSNQLN, None),
-            SNQLNM: GeckoByteStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, XWAJVD, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, ICXQIE, LAIIDN, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            AIIDNI: GeckoEnumStructAccessor(
-                self.struct, AIIDNI, AJVDQL, QIEFXQ, DNIBXT, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            NIBXTI: GeckoWordStructAccessor(self.struct, NIBXTI, IBXTIA, None),
-            BXTIAC: GeckoByteStructAccessor(self.struct, BXTIAC, XTIACQ, None),
-            TIACQF: GeckoByteStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoWordStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, VWVUBY, None, QIEFXQ, SAKQXP
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            WVUBYG: GeckoEnumStructAccessor(
-                self.struct, WVUBYG, VUBYGD, None, JJVYFC, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            JVYFCR: GeckoWordStructAccessor(self.struct, JVYFCR, VYFCRT, None),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, None),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, UGTYIY, None, None, SAKQXP
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            GTYIYW: GeckoEnumStructAccessor(
-                self.struct, GTYIYW, TYIYWS, None, UGTYIY, None, None, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            YIYWSK: GeckoEnumStructAccessor(
-                self.struct, YIYWSK, IYWSKW, None, UGTYIY, None, None, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, UGTYIY, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, UGTYIY, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, DNQGVU, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NQGVUN: GeckoByteStructAccessor(self.struct, NQGVUN, QGVUNX, SAKQXP),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, SAKQXP),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, SAKQXP),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, SAKQXP),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, SAKQXP),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, SAKQXP),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, UGTYIY, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            UGSELH: GeckoEnumStructAccessor(
-                self.struct, UGSELH, GSELHB, None, UGTYIY, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            SELHBQ: GeckoEnumStructAccessor(
-                self.struct, SELHBQ, ELHBQN, None, UGTYIY, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, UGTYIY, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, UGTYIY, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, None, UGTYIY, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            XCHWDA: GeckoEnumStructAccessor(
-                self.struct, XCHWDA, CHWDAF, None, UGTYIY, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, WDAFIK, None, DAFIKJ, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, None, DAFIKJ, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            IKJPUN: GeckoByteStructAccessor(self.struct, IKJPUN, KJPUNR, SAKQXP),
-            JPUNRJ: GeckoByteStructAccessor(self.struct, JPUNRJ, PUNRJZ, SAKQXP),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, SAKQXP),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, SAKQXP),
-            ATDZXN: GeckoByteStructAccessor(self.struct, ATDZXN, TDZXNQ, SAKQXP),
-            DZXNQT: GeckoByteStructAccessor(self.struct, DZXNQT, ZXNQTM, SAKQXP),
-            XNQTMF: GeckoByteStructAccessor(self.struct, XNQTMF, NQTMFZ, SAKQXP),
-            QTMFZD: GeckoByteStructAccessor(self.struct, QTMFZD, TMFZDG, SAKQXP),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-57.py
+++ b/src/geckolib/driver/packs/inyt-log-57.py
@@ -12,921 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 462
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [51, 50, 75])
-AJVDQL = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [67, 70, 71, 49])
-AMJMAO = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 342
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-BBEKBD = 473
-BDFSRO = 475
-BDJQRJ = "".join(chr(c) for c in [75, 56, 53])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-BIAMJM = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BJEUTO = "".join(chr(c) for c in [78, 65])
-BJLOIN = 256
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BQNRXC = 326
-BQSNQL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-BVWVUB = 301
-BWJYKL = 275
-BXIBHZ = 458
-BXTIAC = "".join(chr(c) for c in [67, 69])
-BXYBQS = 315
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 452
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 293
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = 330
-DDPMXF = 479
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-DGKEAK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-DJQRJJ = "".join(chr(c) for c in [75, 56])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-DSBDJQ = "".join(chr(c) for c in [75, 50, 48, 48])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-DZXNQT = 343
-EAKSTS = 448
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = 311
-EKBDFS = 474
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-EMCGET = 451
-EOCTHB = 308
-ETIXQV = 453
-EUTOPH = "".join(chr(c) for c in [80, 49, 76])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FFTTID = 294
-FIKJPU = 331
-FJBIAM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-FMNHTB = 360
-FSROGM = 476
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-FZDGKE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-GDSBDJ = 357
-GETIXQ = "".join(chr(c) for c in [67, 70, 71, 53])
-GKEAKS = 348
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 478
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [66, 76, 79])
-GVUNXN = 334
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-HBSKSO = 363
-HBVWVU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-HBXIBH = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HTBJEU = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-HUGTYI = "".join(chr(c) for c in [80, 52, 72])
-HUOJRJ = 305
-HWDAFI = 329
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-HZVOAC = 460
-IACQFF = 291
-IAMJMA = 283
-IBHZVO = 459
-IBXTIA = "".join(chr(c) for c in [85, 76])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [54, 52, 75])
-IDUBSS = 296
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = 457
-IIDNIB = "".join(chr(c) for c in [52, 56, 75])
-IJUGSE = 338
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-ILXWAJ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-INEJNI = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 454
-IYWSKW = "".join(chr(c) for c in [65, 85, 88])
-JBIAMJ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JEUTOP = "".join(chr(c) for c in [80, 49, 72])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [75, 49, 48, 48])
-JJVYFC = "".join(chr(c) for c in [75, 56, 48, 48])
-JLOINE = 479
-JMAOAW = 284
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JQRJJJ = "".join(chr(c) for c in [75, 52])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 89, 84])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [67, 70, 71, 48])
-KFWRKI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KHTZBB = 471
-KJPUNR = 332
-KMLOIJ = 336
-KPHUOJ = 304
-KQTDKH = 469
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 449
-KVKZIL = "".join(chr(c) for c in [105, 110, 88, 69])
-KWIVDN = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [77, 73, 65])
-LAIIDN = "".join(chr(c) for c in [49, 54, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 325
-LIUXFE = 263
-LJUIKF = 354
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 287
-LOIJUG = 337
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [105, 110, 88, 77])
-MAOAWB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-MCGETI = "".join(chr(c) for c in [67, 70, 71, 52])
-MCVDSS = 463
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-MFZDGK = 346
-MHXEKV = 288
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-MNZMJI = 313
-MOUNBL = 273
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-NHTBJE = 361
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-NIBXYB = 314
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = 324
-NQJYMO = 271
-NQLNMH = 285
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 327
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-OAWBSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-OIHBXI = "".join(chr(c) for c in [67, 70, 71, 57])
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [80, 51, 72])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [80, 51, 76])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(chr(c) for c in [76, 73])
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = 290
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [75, 53])
-QSNQLN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-QTMFZD = 345
-QVXOIH = 455
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 467
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-RJZTAT = 340
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-ROGMDD = 477
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = 358
-RURAZM = 466
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 52, 48, 48])
-SELHBQ = 349
-SEMCGE = "".join(chr(c) for c in [67, 70, 71, 51])
-SIFJBI = 352
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = 321
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-SSRURA = 465
-SSUHBV = 299
-STSEMC = "".join(chr(c) for c in [67, 70, 71, 50])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-TBJEUT = 320
-TDKHTZ = 470
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-TIXQVX = "".join(chr(c) for c in [67, 70, 71, 54])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-TOPHUG = "".join(chr(c) for c in [80, 50, 76])
-TSEMCG = 450
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = 295
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [70, 97, 110])
-TZBBEK = 472
-UBJLOI = 57
-UBSSUH = 297
-UBYGDS = "".join(chr(c) for c in [70, 117, 108, 108])
-UGSELH = 339
-UGTYIY = "".join(chr(c) for c in [80, 52, 76])
-UHBVWV = 300
-UIKFWR = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = 333
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [80, 50, 72])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = 323
-VDSSRU = 464
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 461
-VUBYGD = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VUNXNK = "".join(chr(c) for c in [72, 84, 82])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VXOIHB = "".join(chr(c) for c in [67, 70, 71, 56])
-VYFCRT = "".join(chr(c) for c in [75, 51, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-WAONPY = 367
-WBSIRY = 350
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-WIVDNQ = 322
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = 309
-WSKWIV = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-WVUBYG = 316
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XCHWDA = 328
-XEKVKZ = 289
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XIBHZV = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XLSXUJ = 7
-XNKMLO = 335
-XNQTMF = 344
-XOIHBX = 456
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [67, 70, 71, 55])
-XSJWMN = 282
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [75, 54, 48, 48])
-XYBQSN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68])
-YGDSBD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-YIYWSK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YXBQFY = 351
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 347
-ZILXWA = "".join(chr(c) for c in [68, 74, 83, 52])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = 468
-ZTATDZ = 341
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-BYGDSB = [VUBYGD, UBYGDS]
-DNIBXT = [LAIIDN, AIIDNI, IIDNIB, IDNIBX]
-DPMXFU = []
-FCRTFM = [
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FUBJLO = [
-    YBQSNQ,
-    XBQFYL,
-    FYLJUI,
-    MAOAWB,
-    SPBWJY,
-    INEJNI,
-    XYBQSN,
-    BQSNQL,
-    LGQPLS,
-    BLKXSJ,
-    IRYXBQ,
-    AWBSIR,
-    IFJBIA,
-    TSIFJB,
-    IBXYBQ,
-    OAWBSI,
-    RYXBQF,
-    SIRYXB,
-    AMJMAO,
-    YLJUIK,
-    BIAMJM,
-    FJBIAM,
-    BQFYLJ,
-    IKFWRK,
-    QFYLJU,
-    JBIAMJ,
-    BSIRYX,
-    AOAWBS,
-    MJMAOA,
-]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JPUNRJ = [
-    BJEUTO,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-KINEJN = [HECVYY, RKINEJ, RKINEJ, RKINEJ]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-MCBFEG = [ASSAKQ, SOOQNR]
-MXFUBJ = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    PMXFUB,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UNXNKM = [
-    BJEUTO,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    VUNXNK,
-]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDQLAI = [
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-]
-XFUBJL = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-XTIACQ = [IBXTIA, BXTIAC]
-YWSKWI = [
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    SJMCBF,
-    GTYIYW,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    TYIYWS,
-    HECVYY,
-    HECVYY,
-    YIYWSK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    IYWSKW,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -934,290 +19,1104 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return UBJLOI
+        return 57
 
     @property
     def begin(self):
-        return BJLOIN
+        return 256
 
     @property
     def end(self):
-        return JLOINE
+        return 479
 
     @property
     def all_device_keys(self):
-        return MXFUBJ
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return XFUBJL
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return FUBJLO
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, EGZUQE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, XSJWMN, ICXQIE, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, XSJWMN, AHEOCT, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QIEFXQ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, EGZUQE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, CXQIEF, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JMAOAW, UQEXLS, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JMAOAW, VHFTHE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, WBSIRY, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, WBSIRY, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, QIEFXQ, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, EGZUQE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, SIFJBI, EGZUQE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, GYOUSP, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, GYOUSP, AHEOCT, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, LSPFTS, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IAMJMA, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, IAMJMA, AHEOCT, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, IAMJMA, CXQIEF, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, WRKINE, ICXQIE, None),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, WRKINE, AHEOCT, KINEJN, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, WRKINE, EGZUQE, None),
-            NEJNIB: GeckoWordStructAccessor(self.struct, NEJNIB, EJNIBX, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, BXYBQS, AHEOCT, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, YXBQFY, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YXBQFY, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, YXBQFY, CXQIEF, None),
-            SNQLNM: GeckoWordStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoByteStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, VDQLAI, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, ICXQIE, DNIBXT, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, QLAIID, QIEFXQ, XTIACQ, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoWordStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, BYGDSB, None, QIEFXQ, SAKQXP
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, FCRTFM, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            CRTFMN: GeckoWordStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, None),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, None),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, YWSKWI, None, None, SAKQXP
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, YWSKWI, None, None, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KWIVDN: GeckoEnumStructAccessor(
-                self.struct, KWIVDN, WIVDNQ, None, YWSKWI, None, None, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, YWSKWI, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, YWSKWI, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, UNXNKM, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, SAKQXP),
-            NKMLOI: GeckoByteStructAccessor(self.struct, NKMLOI, KMLOIJ, SAKQXP),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, SAKQXP),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, YWSKWI, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, YWSKWI, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            QNRXCH: GeckoEnumStructAccessor(
-                self.struct, QNRXCH, NRXCHW, None, YWSKWI, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, YWSKWI, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, YWSKWI, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, DAFIKJ, None, YWSKWI, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, FIKJPU, None, YWSKWI, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, JPUNRJ, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, JPUNRJ, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            NRJZTA: GeckoByteStructAccessor(self.struct, NRJZTA, RJZTAT, SAKQXP),
-            JZTATD: GeckoByteStructAccessor(self.struct, JZTATD, ZTATDZ, SAKQXP),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, SAKQXP),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, SAKQXP),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, SAKQXP),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-58.py
+++ b/src/geckolib/driver/packs/inyt-log-58.py
@@ -12,1071 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [51, 50, 75])
-AJVDQL = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 449
-AMJMAO = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-AZMKQT = 468
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-BDJQRJ = "".join(chr(c) for c in [75, 56, 53])
-BEKBDF = 474
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = 460
-BIAMJM = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BJEUTO = "".join(chr(c) for c in [45, 45, 45])
-BJLOIN = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BQNRXC = 333
-BQSNQL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-BVWVUB = 301
-BWJYKL = 275
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-BXTIAC = "".join(chr(c) for c in [67, 69])
-BXYBQS = 315
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 53])
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-CMCVDS = 463
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 293
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-CTHBSK = 307
-CVDSSR = 464
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-DDPMXF = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-DFSROG = 476
-DGKEAK = 348
-DJQRJJ = "".join(chr(c) for c in [75, 56])
-DKHTZB = 471
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-DPMXFU = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-DSBDJQ = "".join(chr(c) for c in [75, 50, 48, 48])
-DSSRUR = 465
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 256
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = 311
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-ELWUEU = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 52])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 54])
-EUHNNX = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = 479
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FFTTID = 294
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-FJBIAM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-FMNHTB = 360
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FUBJLO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-FZDGKE = 347
-GDSBDJ = 357
-GETIXQ = 453
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 48])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 50, 76])
-GVUNXN = 323
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-HBSKSO = 363
-HBVWVU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-HBXIBH = 458
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [76, 73])
-HTBJEU = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-HTZBBE = 472
-HUGTYI = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-IACQFF = 291
-IAMJMA = 283
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-IBXTIA = "".join(chr(c) for c in [85, 76])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [54, 52, 75])
-IDUBSS = 296
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-IIDNIB = "".join(chr(c) for c in [52, 56, 75])
-IJUGSE = 328
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-ILXWAJ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-INEJNI = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-INELWU = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 55])
-IYWSKW = "".join(chr(c) for c in [80, 52, 72])
-JBIAMJ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JEUTOP = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [75, 49, 48, 48])
-JJVYFC = "".join(chr(c) for c in [75, 56, 48, 48])
-JLOINE = 374
-JMAOAW = 284
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JQRJJJ = "".join(chr(c) for c in [75, 52])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 89, 84])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 341
-KBDFSR = 475
-KCWAON = 365
-KEAKST = 448
-KFWRKI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-KJPUNR = 332
-KPHUOJ = 304
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50])
-KVKZIL = "".join(chr(c) for c in [105, 110, 88, 69])
-KWIVDN = "".join(chr(c) for c in [65, 85, 88])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [77, 73, 65])
-LAIIDN = "".join(chr(c) for c in [49, 54, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 331
-LIUXFE = 263
-LJUIKF = 354
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 287
-LOIJUG = 327
-LOINEL = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [105, 110, 88, 77])
-MAOAWB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-MCGETI = 452
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-MDDPMX = 479
-MFZDGK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-MHXEKV = 288
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 469
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-MNZMJI = 313
-MOUNBL = 273
-MXFUBJ = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-NELWUE = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-NHTBJE = 361
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-NIBXYB = 314
-NKMLOI = "".join(chr(c) for c in [72, 84, 82])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = 322
-NQJYMO = 271
-NQLNMH = 285
-NQTMFZ = 345
-NRJZTA = 340
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 325
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = 462
-OAWBSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = 478
-OIHBXI = 457
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-OINELW = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [78, 65])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [80, 49, 72])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = 371
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = 290
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [75, 53])
-QSNQLN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QTDKHT = 470
-QTMFZD = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 56])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-RJZTAT = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-ROGMDD = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = 358
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-RXCHWD = "".join(chr(c) for c in [70, 97, 110])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 52, 48, 48])
-SELHBQ = 330
-SEMCGE = 451
-SIFJBI = 352
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = 477
-SRURAZ = 466
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-SSUHBV = 299
-STSEMC = 450
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = 342
-TBJEUT = 376
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-TDZXNQ = 343
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-TIXQVX = 454
-TMFZDG = 346
-TOPHUG = 320
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 51])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = 295
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 51, 72])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-UBJLOI = 373
-UBSSUH = 297
-UBYGDS = "".join(chr(c) for c in [70, 117, 108, 108])
-UEUHNN = 375
-UGSELH = 329
-UGTYIY = "".join(chr(c) for c in [80, 50, 72])
-UHBVWV = 300
-UIKFWR = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-UNXNKM = 324
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = 467
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = 321
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VUBYGD = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VXOIHB = 456
-VYFCRT = "".join(chr(c) for c in [75, 51, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-WAONPY = 367
-WBSIRY = 350
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-WEEZFE = 58
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = 309
-WSKWIV = "".join(chr(c) for c in [66, 76, 79])
-WUEUHN = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-WVUBYG = 316
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XEKVKZ = 289
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 372
-XIBHZV = 459
-XLSXUJ = 7
-XNKMLO = 326
-XNQTMF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 57])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 455
-XSJWMN = 282
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [75, 54, 48, 48])
-XYBQSN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-YGDSBD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-YIYWSK = "".join(chr(c) for c in [80, 51, 76])
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 52, 76])
-YXBQFY = 351
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 473
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-ZILXWA = "".join(chr(c) for c in [68, 74, 83, 52])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = 461
-ZXNQTM = 344
-BYGDSB = [VUBYGD, UBYGDS]
-DNIBXT = [LAIIDN, AIIDNI, IIDNIB, IDNIBX]
-EUTOPH = [BJEUTO, JEUTOP]
-FCRTFM = [
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JPUNRJ = [
-    OPHUGT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-KINEJN = [HECVYY, RKINEJ, RKINEJ, RKINEJ]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-KMLOIJ = [
-    OPHUGT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NKMLOI,
-]
-LWUEUH = [LOINEL, OINELW, INELWU, NELWUE, ELWUEU]
-MCBFEG = [ASSAKQ, SOOQNR]
-NNXWEE = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    HNNXWE,
-]
-NXWEEZ = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UHNNXW = []
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDQLAI = [
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-]
-WIVDNQ = [
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    SJMCBF,
-    WSKWIV,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SKWIVD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    KWIVDN,
-]
-XCHWDA = [
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    SJMCBF,
-    WSKWIV,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    RXCHWD,
-    HECVYY,
-    HECVYY,
-    SKWIVD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    KWIVDN,
-]
-XTIACQ = [IBXTIA, BXTIAC]
-XWEEZF = [
-    YBQSNQ,
-    XBQFYL,
-    FYLJUI,
-    MAOAWB,
-    SPBWJY,
-    INEJNI,
-    XYBQSN,
-    BQSNQL,
-    LGQPLS,
-    BLKXSJ,
-    IRYXBQ,
-    AWBSIR,
-    IFJBIA,
-    TSIFJB,
-    IBXYBQ,
-    OAWBSI,
-    RYXBQF,
-    SIRYXB,
-    AMJMAO,
-    YLJUIK,
-    BIAMJM,
-    FJBIAM,
-    BQFYLJ,
-    IKFWRK,
-    QFYLJU,
-    JBIAMJ,
-    BSIRYX,
-    AOAWBS,
-    MJMAOA,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1084,304 +19,1141 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return WEEZFE
+        return 58
 
     @property
     def begin(self):
-        return EEZFET
+        return 256
 
     @property
     def end(self):
-        return EZFETD
+        return 479
 
     @property
     def all_device_keys(self):
-        return NNXWEE
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return NXWEEZ
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return XWEEZF
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, EGZUQE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, XSJWMN, ICXQIE, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, XSJWMN, AHEOCT, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QIEFXQ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, EGZUQE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, CXQIEF, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JMAOAW, UQEXLS, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JMAOAW, VHFTHE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, WBSIRY, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, WBSIRY, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, QIEFXQ, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, EGZUQE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, SIFJBI, EGZUQE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, GYOUSP, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, GYOUSP, AHEOCT, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, LSPFTS, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IAMJMA, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, IAMJMA, AHEOCT, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, IAMJMA, CXQIEF, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, WRKINE, ICXQIE, None),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, WRKINE, AHEOCT, KINEJN, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, WRKINE, EGZUQE, None),
-            NEJNIB: GeckoWordStructAccessor(self.struct, NEJNIB, EJNIBX, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, BXYBQS, AHEOCT, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, YXBQFY, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YXBQFY, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, YXBQFY, CXQIEF, None),
-            SNQLNM: GeckoWordStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoByteStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, VDQLAI, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, ICXQIE, DNIBXT, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, QLAIID, QIEFXQ, XTIACQ, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoWordStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, BYGDSB, None, QIEFXQ, SAKQXP
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, FCRTFM, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            CRTFMN: GeckoWordStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, None),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, None),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, EUTOPH, None, None, SAKQXP
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, WIVDNQ, None, None, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, WIVDNQ, None, None, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, WIVDNQ, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, WIVDNQ, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, WIVDNQ, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, KMLOIJ, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, SAKQXP),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoEnumStructAccessor(
-                self.struct, QNRXCH, NRXCHW, None, XCHWDA, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, XNKMLO, None, XCHWDA, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, LOIJUG, None, XCHWDA, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, IJUGSE, None, XCHWDA, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, UGSELH, None, XCHWDA, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, SELHBQ, None, XCHWDA, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, LHBQNR, None, XCHWDA, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, JPUNRJ, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, BQNRXC, None, JPUNRJ, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, SAKQXP),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, SAKQXP),
-            ATDZXN: GeckoByteStructAccessor(self.struct, ATDZXN, TDZXNQ, SAKQXP),
-            DZXNQT: GeckoByteStructAccessor(self.struct, DZXNQT, ZXNQTM, SAKQXP),
-            XNQTMF: GeckoByteStructAccessor(self.struct, XNQTMF, NQTMFZ, SAKQXP),
-            QTMFZD: GeckoByteStructAccessor(self.struct, QTMFZD, TMFZDG, SAKQXP),
-            MFZDGK: GeckoByteStructAccessor(self.struct, MFZDGK, FZDGKE, SAKQXP),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, SAKQXP),
-            DDPMXF: GeckoBoolStructAccessor(self.struct, DDPMXF, JVHFTH, UQEXLS, None),
-            DPMXFU: GeckoByteStructAccessor(self.struct, DPMXFU, PMXFUB, SAKQXP),
-            MXFUBJ: GeckoByteStructAccessor(self.struct, MXFUBJ, XFUBJL, SAKQXP),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, SAKQXP),
-            BJLOIN: GeckoEnumStructAccessor(
-                self.struct, BJLOIN, JLOINE, None, LWUEUH, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            WUEUHN: GeckoBoolStructAccessor(
-                self.struct, WUEUHN, UEUHNN, ICXQIE, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            EUHNNX: GeckoBoolStructAccessor(self.struct, EUHNNX, TBJEUT, ICXQIE, None),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-59.py
+++ b/src/geckolib/driver/packs/inyt-log-59.py
@@ -12,1076 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-AHEOCT = 1
-AIIDNI = 290
-AJVDQL = "".join(chr(c) for c in [75, 54, 48, 48])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 448
-AMJMAO = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-AOAWBS = 284
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-AWBSIR = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AZMKQT = 467
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-BDJQRJ = "".join(chr(c) for c in [75, 50, 48, 48])
-BEKBDF = 473
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = 459
-BIAMJM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BJEUTO = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-BJLOIN = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 351
-BQNRXC = 331
-BQSNQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-BVWVUB = 300
-BWJYKL = 275
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-BXYBQS = 314
-BYGDSB = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 52])
-CHWDAF = "".join(chr(c) for c in [70, 97, 110])
-CMCVDS = 462
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 291
-CRTFMN = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-CTHBSK = 307
-CVDSSR = 463
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-DDPMXF = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-DFSROG = 475
-DGKEAK = 347
-DJQRJJ = "".join(chr(c) for c in [75, 52, 48, 48])
-DKHTZB = 470
-DNIBXT = "".join(chr(c) for c in [52, 56, 75])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-DPMXFU = 479
-DQLAII = "".join(chr(c) for c in [105, 110, 89, 84])
-DSBDJQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-DSSRUR = 464
-DUBSSU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 48])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-ELWUEU = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 51])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 53])
-EUHNNX = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-EUTOPH = "".join(chr(c) for c in [45, 45, 45])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = 59
-FCRTFM = "".join(chr(c) for c in [75, 51, 48, 48])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = 479
-FFTTID = 293
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-FJBIAM = 377
-FMNHTB = 358
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-FUBJLO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-FZDGKE = 346
-GETIXQ = 452
-GKEAKS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 49, 76])
-GVUNXN = 322
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-HBXIBH = 457
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-HTBJEU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-HTZBBE = 471
-HUGTYI = "".join(chr(c) for c in [78, 65])
-HUOJRJ = 305
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-IAMJMA = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [51, 50, 75])
-IDUBSS = 295
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 57])
-IIDNIB = "".join(chr(c) for c in [49, 54, 75])
-IJUGSE = 327
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-ILXWAJ = "".join(chr(c) for c in [77, 73, 65])
-INEJNI = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-INELWU = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [65, 85, 88])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 54])
-IYWSKW = "".join(chr(c) for c in [80, 51, 72])
-JBIAMJ = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-JEUTOP = 376
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [75, 53])
-JJVYFC = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JLOINE = 373
-JMAOAW = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-JMCBFE = 260
-JNIBXY = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-JPUNRJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-JQRJJJ = "".join(chr(c) for c in [75, 56, 53])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 49, 48, 48])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 340
-KBDFSR = 474
-KCWAON = 365
-KEAKST = 348
-KFWRKI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-KINEJN = 309
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-KMLOIJ = 326
-KPHUOJ = 304
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49])
-KVKZIL = 289
-KWIVDN = "".join(chr(c) for c in [66, 76, 79])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 88, 69])
-LAIIDN = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 330
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 285
-LOINEL = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-LXWAJV = "".join(chr(c) for c in [68, 74, 83, 52])
-MAOAWB = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MCGETI = 451
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MDDPMX = 478
-MFZDGK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-MHXEKV = 287
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = 283
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 468
-MLOIJU = "".join(chr(c) for c in [72, 84, 82])
-MNHTBJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-MNZMJI = 313
-MOUNBL = 273
-MXFUBJ = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NELWUE = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-NHTBJE = 360
-NIBXTI = "".join(chr(c) for c in [54, 52, 75])
-NIBXYB = 311
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = 321
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-NQTMFZ = 344
-NRJZTA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 333
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NXWEEZ = "".join(chr(c) for c in [76, 73])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = 461
-OAWBSI = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = 477
-OIHBXI = 456
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-OINELW = 374
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = 320
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = 332
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [75, 56])
-QSNQLN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QTDKHT = 469
-QTMFZD = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 55])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [75, 52])
-RJZTAT = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-ROGMDD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-RYXBQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = 357
-SELHBQ = 329
-SEMCGE = 450
-SIFJBI = 352
-SIRYXB = 350
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [80, 52, 76])
-SNQLNM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = 476
-SRURAZ = 465
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-SSUHBV = 297
-STSEMC = 449
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = 341
-TBJEUT = 361
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-TDZXNQ = 342
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [67, 69])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-TIXQVX = 453
-TMFZDG = 345
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = 294
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 50, 72])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-UBJLOI = 372
-UBSSUH = 296
-UBYGDS = 316
-UGSELH = 328
-UGTYIY = "".join(chr(c) for c in [80, 49, 72])
-UHBVWV = 299
-UHNNXW = 375
-UIKFWR = 354
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNXNKM = 323
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = 466
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDQLAI = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-VWVUBY = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-VXOIHB = 455
-VYFCRT = "".join(chr(c) for c in [75, 56, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 88, 77])
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-WIVDNQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-WSKWIV = "".join(chr(c) for c in [80, 52, 72])
-WUEUHN = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-WVUBYG = 301
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-XCHWDA = 325
-XEKVKZ = 288
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 371
-XIBHZV = 458
-XLSXUJ = 7
-XNKMLO = 324
-XNQTMF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 56])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 454
-XSJWMN = 282
-XTIACQ = "".join(chr(c) for c in [85, 76])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-XYBQSN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = 315
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-YGDSBD = "".join(chr(c) for c in [70, 117, 108, 108])
-YIYWSK = "".join(chr(c) for c in [80, 50, 76])
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 51, 76])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 472
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-ZFETDR = 256
-ZILXWA = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = 460
-ZXNQTM = 343
-EEZFET = [
-    QSNQLN,
-    QFYLJU,
-    LJUIKF,
-    OAWBSI,
-    SPBWJY,
-    EJNIBX,
-    BQSNQL,
-    SNQLNM,
-    LGQPLS,
-    BLKXSJ,
-    YXBQFY,
-    BSIRYX,
-    JBIAMJ,
-    TSIFJB,
-    XYBQSN,
-    WBSIRY,
-    XBQFYL,
-    RYXBQF,
-    JMAOAW,
-    JUIKFW,
-    AMJMAO,
-    BIAMJM,
-    FYLJUI,
-    FWRKIN,
-    YLJUIK,
-    IAMJMA,
-    IRYXBQ,
-    AWBSIR,
-    MAOAWB,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-GDSBDJ = [BYGDSB, YGDSBD]
-HWDAFI = [
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    SJMCBF,
-    KWIVDN,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    CHWDAF,
-    HECVYY,
-    HECVYY,
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    IVDNQG,
-]
-IACQFF = [XTIACQ, TIACQF]
-IBXTIA = [IIDNIB, IDNIBX, DNIBXT, NIBXTI]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-LOIJUG = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    MLOIJU,
-]
-MCBFEG = [ASSAKQ, SOOQNR]
-NEJNIB = [HECVYY, INEJNI, INEJNI, INEJNI]
-NNXWEE = []
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QLAIID = [
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-    DQLAII,
-]
-RAHEOC = [ASSAKQ, LRAHEO]
-RTFMNH = [
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TOPHUG = [EUTOPH, UTOPHU]
-UEUHNN = [INELWU, NELWUE, ELWUEU, LWUEUH, WUEUHN]
-UNRJZT = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDNQGV = [
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    SJMCBF,
-    KWIVDN,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    IVDNQG,
-]
-WEEZFE = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-XWEEZF = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    NXWEEZ,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1089,305 +19,1144 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return EZFETD
+        return 59
 
     @property
     def begin(self):
-        return ZFETDR
+        return 256
 
     @property
     def end(self):
-        return FETDRX
+        return 479
 
     @property
     def all_device_keys(self):
-        return XWEEZF
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return WEEZFE
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return EEZFET
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, JVHFTH, EGZUQE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, XSJWMN, ICXQIE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, XSJWMN, AHEOCT, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QIEFXQ, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MJMAOA, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, EGZUQE, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, AOAWBS, CXQIEF, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, AOAWBS, UQEXLS, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, AOAWBS, VHFTHE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, EGZUQE, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, SIRYXB, CXQIEF, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, SIRYXB, UQEXLS, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, SIRYXB, VHFTHE, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, QIEFXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, BQFYLJ, EGZUQE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, SIFJBI, EGZUQE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, GYOUSP, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, GYOUSP, AHEOCT, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, LSPFTS, ICXQIE, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, MJMAOA, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, MJMAOA, AHEOCT, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, MJMAOA, CXQIEF, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, KINEJN, ICXQIE, None),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, KINEJN, AHEOCT, NEJNIB, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, KINEJN, EGZUQE, None),
-            JNIBXY: GeckoWordStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, YBQSNQ, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YBQSNQ, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQFYLJ, ICXQIE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, BQFYLJ, AHEOCT, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, BQFYLJ, CXQIEF, None),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoByteStructAccessor(self.struct, HXEKVK, XEKVKZ, None),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, QLAIID, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, ICXQIE, IBXTIA, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, AIIDNI, QIEFXQ, IACQFF, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            ACQFFT: GeckoWordStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoWordStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, GDSBDJ, None, QIEFXQ, SAKQXP
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            DSBDJQ: GeckoEnumStructAccessor(
-                self.struct, DSBDJQ, SBDJQR, None, RTFMNH, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            TFMNHT: GeckoWordStructAccessor(self.struct, TFMNHT, FMNHTB, None),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, None),
-            HTBJEU: GeckoByteStructAccessor(self.struct, HTBJEU, TBJEUT, None),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, TOPHUG, None, None, SAKQXP
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, VDNQGV, None, None, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, VDNQGV, None, None, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, VDNQGV, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, VDNQGV, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, VDNQGV, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, LOIJUG, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, HWDAFI, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, KMLOIJ, None, HWDAFI, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, IJUGSE, None, HWDAFI, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, UGSELH, None, HWDAFI, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, SELHBQ, None, HWDAFI, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, LHBQNR, None, HWDAFI, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, BQNRXC, None, HWDAFI, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, UNRJZT, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, NRXCHW, None, UNRJZT, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, SAKQXP),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, SAKQXP),
-            ATDZXN: GeckoByteStructAccessor(self.struct, ATDZXN, TDZXNQ, SAKQXP),
-            DZXNQT: GeckoByteStructAccessor(self.struct, DZXNQT, ZXNQTM, SAKQXP),
-            XNQTMF: GeckoByteStructAccessor(self.struct, XNQTMF, NQTMFZ, SAKQXP),
-            QTMFZD: GeckoByteStructAccessor(self.struct, QTMFZD, TMFZDG, SAKQXP),
-            MFZDGK: GeckoByteStructAccessor(self.struct, MFZDGK, FZDGKE, SAKQXP),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, SAKQXP),
-            GKEAKS: GeckoByteStructAccessor(self.struct, GKEAKS, KEAKST, SAKQXP),
-            PMXFUB: GeckoBoolStructAccessor(self.struct, PMXFUB, JVHFTH, UQEXLS, None),
-            MXFUBJ: GeckoByteStructAccessor(self.struct, MXFUBJ, XFUBJL, SAKQXP),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, SAKQXP),
-            BJLOIN: GeckoByteStructAccessor(self.struct, BJLOIN, JLOINE, SAKQXP),
-            LOINEL: GeckoEnumStructAccessor(
-                self.struct, LOINEL, OINELW, None, UEUHNN, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            EUHNNX: GeckoBoolStructAccessor(
-                self.struct, EUHNNX, UHNNXW, ICXQIE, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            HNNXWE: GeckoBoolStructAccessor(self.struct, HNNXWE, JEUTOP, ICXQIE, None),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-60.py
+++ b/src/geckolib/driver/packs/inyt-log-60.py
@@ -12,1285 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 348
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-AFIKJP = 321
-AHEOCT = 1
-AIIDNI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AIVEMV = 371
-AJVDQL = 309
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 327
-AWBSIR = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 53])
-BBEKBD = 458
-BDFSRO = 460
-BDJQRJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-BJEUTO = 300
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-BLKXSJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BMJVHF = 256
-BQFYLJ = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-BQNRXC = "".join(chr(c) for c in [80, 51, 72])
-BQSNQL = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-BSIRYX = "".join(chr(c) for c in [72, 69, 65, 84])
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [68, 74, 83, 52])
-BVWVUB = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-BWJYKL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 344
-BXTIAC = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BXYBQS = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-BYGDSB = "".join(chr(c) for c in [49, 54, 75])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 332
-CHWDAF = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 48])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 287
-CRTFMN = 295
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 49])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-CYWONF = 374
-CZOLSI = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-DDPMXF = 464
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-DJQRJJ = "".join(chr(c) for c in [85, 76])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 56])
-DMPSCT = 60
-DNIBXT = 315
-DNQGVU = "".join(chr(c) for c in [75, 51, 48, 48])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-DQLAII = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-DRXAIV = 479
-DSBDJQ = "".join(chr(c) for c in [54, 52, 75])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50])
-DUBSSU = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-DZXNQT = 328
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 476
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-EKBDFS = 459
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-ELHBQN = "".join(chr(c) for c in [80, 49, 76])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-EMVCYW = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-EOCTHB = 308
-ETDRXA = 478
-ETIXQV = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-EUTOPH = 301
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-FCRTFM = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-FFTTID = 288
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-FJBIAM = 281
-FMNHTB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-FSROGM = 461
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-FWRKIN = 284
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-FZCZOL = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-FZDGKE = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [52, 56, 75])
-GKEAKS = 325
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 463
-GQPLSP = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-GSELHB = "".join(chr(c) for c in [78, 65])
-GTYIYW = 357
-GVUNXN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-GYOUSP = "".join(chr(c) for c in [78, 79])
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [80, 50, 76])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-HTBJEU = 299
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 57])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [65, 85, 88])
-HXEKVK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-HZVOAC = 346
-IACQFF = 285
-IAMJMA = 352
-IBHZVO = 345
-IBXTIA = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IBXYBQ = 283
-ICXQIE = 0
-IDNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IDUBSS = "".join(chr(c) for c in [105, 110, 88, 69])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IGYOUS = 313
-IHBXIB = 343
-IIDNIB = 314
-IKJPUN = 322
-ILXWAJ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-INEJNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [75, 56, 48, 48])
-IVEMVC = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 340
-IYWSKW = "".join(chr(c) for c in [75, 56, 53])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JEUTOP = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JJJVYF = 291
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-JLOINE = 468
-JMAOAW = "".join(chr(c) for c in [72, 80, 67, 68, 101, 116, 101, 99, 116, 101, 100])
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JPUNRJ = 323
-JQRJJJ = "".join(chr(c) for c in [67, 69])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-JUIKFW = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-JVHFTH = 274
-JVYFCR = 293
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JYKLGQ = 355
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [72, 84, 82])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [70, 97, 110])
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KHTZBB = 456
-KINEJN = 350
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-KLGQPL = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KMLOIJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-KPHUOJ = 304
-KQTDKH = 454
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-KWIVDN = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-KZILXW = 354
-LAIIDN = 311
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 275
-LHBQNR = "".join(chr(c) for c in [80, 50, 72])
-LIUXFE = 263
-LJUIKF = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-LKXSJW = 273
-LNMHXE = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-LOIJUG = "".join(chr(c) for c in [45, 45, 45])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 471
-LXWAJV = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-MAOAWB = 378
-MCGETI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-MCVDSS = 448
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-MFZDGK = 331
-MHXEKV = 351
-MJIGYO = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJMAOA = 377
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 54])
-MLOIJU = 376
-MNHTBJ = 297
-MNZMJI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MPSCTT = 256
-MVCYWO = 373
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-NBLKXS = 381
-NEJNIB = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-NELWUE = 470
-NFZCZO = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-NIBXTI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NIBXYB = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-NKMLOI = 361
-NMHXEK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-NNXWEE = 474
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [80, 52, 72])
-NXNKML = 360
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-NZMJIG = 282
-OACMCV = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-OAWBSI = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-OIJUGS = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-OINELW = 469
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-OLSIPM = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-ONFZCZ = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-OUNBLK = 380
-OUSPBW = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = 353
-PFTSIF = 279
-PHUGTY = "".join(chr(c) for c in [70, 117, 108, 108])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PMXFUB = 465
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PSCTTG = 479
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-QFYLJU = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-QLNMHX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [80, 51, 76])
-QPLSPF = 277
-QSNQLN = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 55])
-QTMFZD = 330
-QVXOIH = 341
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 452
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-RJZTAT = 326
-RKINEJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-ROGMDD = 462
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-RURAZM = 451
-RXAIVE = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-RXCHWD = "".join(chr(c) for c in [80, 52, 76])
-RYXBQF = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SELHBQ = "".join(chr(c) for c in [80, 49, 72])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-SIFJBI = 280
-SIPMDM = "".join(chr(c) for c in [76, 73])
-SIRYXB = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [75, 53])
-SNQLNM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SPFTSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 51])
-SSRURA = 450
-SSUHBV = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-SUHBVW = "".join(chr(c) for c in [105, 110, 88, 77])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-TDKHTZ = 455
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-TFMNHT = 296
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-TIDUBS = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-TIXQVX = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-TOPHUG = 316
-TSEMCG = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-TSIFJB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-TTIDUB = 289
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 50, 48, 48])
-TZBBEK = 457
-UBJLOI = 467
-UBSSUH = "".join(chr(c) for c in [77, 73, 65])
-UBYGDS = 290
-UEUHNN = 472
-UGSELH = 320
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-UHBVWV = "".join(chr(c) for c in [75, 54, 48, 48])
-UHNNXW = 473
-UIKFWR = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-UNRJZT = 324
-UNXNKM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 52])
-USOOQN = 261
-UTOPHU = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VCYWON = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-VDNQGV = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-VDSSRU = 449
-VEMVCY = 372
-VHFTHE = 6
-VKZILX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 347
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-VUNXNK = 358
-VWVUBY = "".join(chr(c) for c in [105, 110, 89, 84])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-WIVDNQ = "".join(chr(c) for c in [75, 49, 48, 48])
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-WMNZMJ = "".join(chr(c) for c in [67, 80, 79, 84])
-WONFZC = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WSKWIV = "".join(chr(c) for c in [75, 52])
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XAIVEM = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-XBQFYL = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-XCHWDA = "".join(chr(c) for c in [66, 76, 79])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 466
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-XNQTMF = 329
-XOIHBX = 342
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-XTIACQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-XWEEZF = 475
-XYBQSN = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-YBQSNQ = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-YEKCWA = 364
-YFCRTF = 294
-YGDSBD = "".join(chr(c) for c in [51, 50, 75])
-YIYWSK = "".join(chr(c) for c in [75, 52, 48, 48])
-YKLGQP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-YMOUNB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(chr(c) for c in [77, 69, 68])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-YWSKWI = "".join(chr(c) for c in [75, 56])
-YXBQFY = 379
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 333
-ZFETDR = 477
-ZILXWA = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-ZMKQTD = 453
-ZOLSIP = 375
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-EAKSTS = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    SJMCBF,
-    XCHWDA,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    KEAKST,
-    HECVYY,
-    HECVYY,
-    CHWDAF,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    HWDAFI,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-GETIXQ = [
-    GSELHB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-HUGTYI = [OPHUGT, PHUGTY]
-IJUGSE = [LOIJUG, OIJUGS]
-IKFWRK = [
-    IUXFEF,
-    XBQFYL,
-    BQFYLJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    QFYLJU,
-    FYLJUI,
-    YLJUIK,
-    LJUIKF,
-    JUIKFW,
-    UIKFWR,
-]
-IPMDMP = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    SIPMDM,
-]
-IRYXBQ = [BSIRYX, SIRYXB]
-LSIPMD = []
-LSPFTS = [HECVYY, PLSPFT, PLSPFT, PLSPFT]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDMPSC = [
-    IBXTIA,
-    HXEKVK,
-    KVKZIL,
-    YBQSNQ,
-    YKLGQP,
-    DQLAII,
-    NIBXTI,
-    BXTIAC,
-    SPFTSI,
-    JWMNZM,
-    LNMHXE,
-    SNQLNM,
-    NEJNIB,
-    BIAMJM,
-    IDNIBX,
-    QSNQLN,
-    NMHXEK,
-    QLNMHX,
-    BXYBQS,
-    VKZILX,
-    NIBXYB,
-    EJNIBX,
-    XEKVKZ,
-    LXWAJV,
-    EKVKZI,
-    JNIBXY,
-    NQLNMH,
-    BQSNQL,
-    XYBQSN,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PMDMPS = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QGVUNX = [
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-]
-QRJJJV = [DJQRJJ, JQRJJJ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SBDJQR = [BYGDSB, YGDSBD, GDSBDJ, DSBDJQ]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-USPBWJ = [GYOUSP, QXPICX, YOUSPB, XPICXQ, OUSPBW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDQLAI = [HECVYY, JVDQLA, JVDQLA, JVDQLA]
-WDAFIK = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    SJMCBF,
-    XCHWDA,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    CHWDAF,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    HWDAFI,
-]
-WVUBYG = [
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-ZCZOLS = [YWONFZ, WONFZC, ONFZCZ, NFZCZO, FZCZOL]
-ZTATDZ = [
-    GSELHB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JZTATD,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1298,326 +19,1227 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return DMPSCT
+        return 60
 
     @property
     def begin(self):
-        return MPSCTT
+        return 256
 
     @property
     def end(self):
-        return PSCTTG
+        return 479
 
     @property
     def all_device_keys(self):
-        return IPMDMP
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return PMDMPS
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return MDMPSC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, ONPYYL, AHEOCT, YYLIUX, None, QIEFXQ, SAKQXP
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, FJTACC, None, None, SAKQXP
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, SAKQXP),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, LKXSJW, ICXQIE, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, LKXSJW, QIEFXQ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, LKXSJW, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, LKXSJW, CXQIEF, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, LKXSJW, UQEXLS, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, JVHFTH, QIEFXQ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, EGZUQE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, UQEXLS, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, NZMJIG, VHFTHE, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, UQEXLS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, PBWJYK, VHFTHE, None),
-            WJYKLG: GeckoWordStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JVHFTH, AHEOCT, None),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, None),
-            GQPLSP: GeckoTempStructAccessor(self.struct, GQPLSP, QPLSPF, None),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, JMCBFE, UQEXLS, LSPFTS, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, AHEOCT, None),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, FJBIAM, QIEFXQ, SAKQXP
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, AHEOCT, None),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, MAOAWB, CXQIEF, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, MAOAWB, UQEXLS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, MAOAWB, VHFTHE, None),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, MAOAWB, XLSXUJ, IRYXBQ, None, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, IKFWRK, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, FWRKIN, AHEOCT, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, KINEJN, ICXQIE, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, KINEJN, AHEOCT, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, JVHFTH, EGZUQE, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, NZMJIG, ICXQIE, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NZMJIG, AHEOCT, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, IBXYBQ, QIEFXQ, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, IBXYBQ, EGZUQE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, FWRKIN, EGZUQE, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, FWRKIN, CXQIEF, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, FWRKIN, UQEXLS, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, FWRKIN, VHFTHE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, KINEJN, EGZUQE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, KINEJN, CXQIEF, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, KINEJN, UQEXLS, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, KINEJN, VHFTHE, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, MHXEKV, QIEFXQ, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, MHXEKV, EGZUQE, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, IAMJMA, EGZUQE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, PBWJYK, ICXQIE, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, PBWJYK, AHEOCT, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KZILXW, ICXQIE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, SIFJBI, ICXQIE, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, IBXYBQ, ICXQIE, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, IBXYBQ, AHEOCT, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, IBXYBQ, CXQIEF, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, ICXQIE, None),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, AJVDQL, AHEOCT, VDQLAI, None, CXQIEF, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, AJVDQL, EGZUQE, None),
-            QLAIID: GeckoWordStructAccessor(self.struct, QLAIID, LAIIDN, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, IIDNIB, ICXQIE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, ICXQIE, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, DNIBXT, AHEOCT, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, MHXEKV, ICXQIE, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, MHXEKV, AHEOCT, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, MHXEKV, CXQIEF, None),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, WVUBYG, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, ICXQIE, SBDJQR, None, CXQIEF, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, UBYGDS, QIEFXQ, QRJJJV, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            RJJJVY: GeckoWordStructAccessor(self.struct, RJJJVY, JJJVYF, None),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoWordStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoWordStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, HUGTYI, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, QGVUNX, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, IJUGSE, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, WDAFIK, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, WDAFIK, None, None, SAKQXP
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, IKJPUN, None, WDAFIK, None, None, SAKQXP
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, WDAFIK, None, None, SAKQXP
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, WDAFIK, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, RJZTAT, None, ZTATDZ, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, SAKQXP),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, SAKQXP),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, GKEAKS, None, EAKSTS, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, RJZTAT, None, EAKSTS, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            KSTSEM: GeckoEnumStructAccessor(
-                self.struct, KSTSEM, ATDZXN, None, EAKSTS, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            STSEMC: GeckoEnumStructAccessor(
-                self.struct, STSEMC, DZXNQT, None, EAKSTS, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, XNQTMF, None, EAKSTS, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, QTMFZD, None, EAKSTS, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MFZDGK, None, EAKSTS, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, CGETIX, None, GETIXQ, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, ZDGKEA, None, GETIXQ, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, SAKQXP),
-            XQVXOI: GeckoByteStructAccessor(self.struct, XQVXOI, QVXOIH, SAKQXP),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, SAKQXP),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, SAKQXP),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, SAKQXP),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, SAKQXP),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, SAKQXP),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, SAKQXP),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, SAKQXP),
-            RXAIVE: GeckoBoolStructAccessor(self.struct, RXAIVE, JVHFTH, UQEXLS, None),
-            XAIVEM: GeckoByteStructAccessor(self.struct, XAIVEM, AIVEMV, SAKQXP),
-            IVEMVC: GeckoByteStructAccessor(self.struct, IVEMVC, VEMVCY, SAKQXP),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, SAKQXP),
-            VCYWON: GeckoEnumStructAccessor(
-                self.struct, VCYWON, CYWONF, None, ZCZOLS, None, None, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            CZOLSI: GeckoBoolStructAccessor(
-                self.struct, CZOLSI, ZOLSIP, ICXQIE, SAKQXP
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            OLSIPM: GeckoBoolStructAccessor(self.struct, OLSIPM, MLOIJU, ICXQIE, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "HPCDetected": GeckoBoolStructAccessor(
+                self.struct, "HPCDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-61.py
+++ b/src/geckolib/driver/packs/inyt-log-61.py
@@ -12,1309 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 347
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-AJVDQL = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [70, 97, 110])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 52])
-BBEKBD = 457
-BDFSRO = 459
-BDJQRJ = "".join(chr(c) for c in [54, 52, 75])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-BJEUTO = 299
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-BLKXSJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BMJVHF = 256
-BQFYLJ = 379
-BQNRXC = "".join(chr(c) for c in [80, 50, 72])
-BQSNQL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-BSIRYX = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-BVWVUB = "".join(chr(c) for c in [75, 54, 48, 48])
-BWJYKL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 343
-BXTIAC = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BXYBQS = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-CHWDAF = "".join(chr(c) for c in [80, 52, 76])
-CMCVDS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 285
-CRTFMN = 294
-CTHBSK = 307
-CTTGCR = 479
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 48])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-CYWONF = 373
-CZOLSI = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-DAFIKJ = "".join(chr(c) for c in [65, 85, 88])
-DDPMXF = 463
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 55])
-DNIBXT = 314
-DNQGVU = "".join(chr(c) for c in [75, 56, 48, 48])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-DQLAII = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-DRXAIV = 478
-DSBDJQ = "".join(chr(c) for c in [51, 50, 75])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 49])
-DUBSSU = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-DZXNQT = 327
-EAKSTS = 325
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 475
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-EKBDFS = 458
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-ELHBQN = "".join(chr(c) for c in [78, 65])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-EMVCYW = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-EOCTHB = 308
-ETDRXA = 477
-ETIXQV = 332
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-EUTOPH = 300
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-FFTTID = 287
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-FJBIAM = 281
-FMNHTB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-FSROGM = 460
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-FZCZOL = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-FZDGKE = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [49, 54, 75])
-GETIXQ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-GKEAKS = 333
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 462
-GQPLSP = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-GVUNXN = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-GYOUSP = "".join(chr(c) for c in [78, 79])
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [80, 49, 76])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [105, 110, 88, 77])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-HTBJEU = 297
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 56])
-HUGTYI = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [66, 76, 79])
-HXEKVK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-HZVOAC = 345
-IACQFF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-IAMJMA = 352
-IBHZVO = 344
-IBXTIA = 315
-IBXYBQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-ICXQIE = 0
-IDNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IDUBSS = 289
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IGYOUS = 313
-IHBXIB = 342
-IIDNIB = 311
-IJUGSE = "".join(chr(c) for c in [45, 45, 45])
-IKFWRK = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-IKJPUN = 321
-ILXWAJ = 354
-INEJNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(chr(c) for c in [72, 69, 65, 84])
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-IVEMVC = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-IYWSKW = "".join(chr(c) for c in [75, 50, 48, 48])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-JLOINE = 467
-JMAOAW = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-JPUNRJ = 322
-JQRJJJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-JUIKFW = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-JVHFTH = 274
-JVYFCR = 291
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JYKLGQ = 355
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-KFWRKI = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-KHTZBB = 455
-KINEJN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-KLGQPL = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KMLOIJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-KPHUOJ = 304
-KQTDKH = 453
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-KWIVDN = "".join(chr(c) for c in [75, 52])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-LAIIDN = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 275
-LHBQNR = "".join(chr(c) for c in [80, 49, 72])
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-LKXSJW = 273
-LNMHXE = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-LOIJUG = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSIPMD = 375
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 470
-LXWAJV = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MAOAWB = 384
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-MCVDSS = 348
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MFZDGK = 330
-MHXEKV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-MJIGYO = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJMAOA = 377
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 53])
-MLOIJU = 361
-MNHTBJ = 296
-MNZMJI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MVCYWO = 372
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-NBLKXS = 381
-NEJNIB = 350
-NELWUE = 469
-NFZCZO = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NIBXTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NIBXYB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-NKMLOI = 360
-NMHXEK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-NNXWEE = 473
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-NQJYMO = 271
-NQLNMH = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [80, 51, 72])
-NXNKML = 358
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-NZMJIG = 282
-OACMCV = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-OAWBSI = 378
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-OIJUGS = 376
-OINELW = 468
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-OLSIPM = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-ONFZCZ = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-OUNBLK = 380
-OUSPBW = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = 353
-PFTSIF = 279
-PHUGTY = 316
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PMDMPS = "".join(chr(c) for c in [76, 73])
-PMXFUB = 464
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PSCTTG = 61
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-QFYLJU = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-QGVUNX = "".join(chr(c) for c in [75, 51, 48, 48])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLNMHX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [80, 50, 76])
-QPLSPF = 277
-QRJJJV = "".join(chr(c) for c in [85, 76])
-QSNQLN = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 54])
-QTMFZD = 329
-QVXOIH = 340
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 451
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [67, 69])
-RJZTAT = 324
-RKINEJ = 284
-ROGMDD = 461
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-RURAZM = 450
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-RXCHWD = "".join(chr(c) for c in [80, 51, 76])
-RYXBQF = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [52, 56, 75])
-SCTTGC = 256
-SELHBQ = 320
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-SIFJBI = 280
-SIPMDM = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-SIRYXB = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [75, 56])
-SNQLNM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SPFTSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50])
-SSRURA = 449
-SSUHBV = "".join(chr(c) for c in [77, 73, 65])
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SUHBVW = "".join(chr(c) for c in [68, 74, 83, 52])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [72, 84, 82])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TDKHTZ = 454
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TFMNHT = 295
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-TOPHUG = 301
-TSEMCG = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-TSIFJB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-TTIDUB = 288
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-TZBBEK = 456
-UBJLOI = 466
-UBSSUH = "".join(chr(c) for c in [105, 110, 88, 69])
-UEUHNN = 471
-UGTYIY = "".join(chr(c) for c in [70, 117, 108, 108])
-UHBVWV = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-UHNNXW = 472
-UIKFWR = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-UNRJZT = 323
-UNXNKM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 51])
-USOOQN = 261
-UTOPHU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VCYWON = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [75, 49, 48, 48])
-VDQLAI = 309
-VDSSRU = 448
-VEMVCY = 371
-VHFTHE = 6
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 346
-VUBYGD = "".join(chr(c) for c in [105, 110, 89, 84])
-VWVUBY = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-WAONPY = 367
-WBSIRY = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-WDAFIK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-WIVDNQ = "".join(chr(c) for c in [75, 53])
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-WMNZMJ = "".join(chr(c) for c in [67, 80, 79, 84])
-WONFZC = 374
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WSKWIV = "".join(chr(c) for c in [75, 56, 53])
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-WVUBYG = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-XAIVEM = 479
-XBQFYL = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-XCHWDA = "".join(chr(c) for c in [80, 52, 72])
-XEKVKZ = 351
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 465
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-XNQTMF = 328
-XOIHBX = 341
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-XTIACQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-XWEEZF = 474
-XYBQSN = 283
-YBQSNQ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YEKCWA = 364
-YFCRTF = 293
-YGDSBD = 290
-YIYWSK = 357
-YKLGQP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-YMOUNB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(chr(c) for c in [77, 69, 68])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-YWSKWI = "".join(chr(c) for c in [75, 52, 48, 48])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 57])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-ZDGKEA = 331
-ZFETDR = 476
-ZILXWA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-ZMKQTD = 452
-ZTATDZ = 326
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-AFIKJP = [
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    SJMCBF,
-    HWDAFI,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    DAFIKJ,
-]
-ATDZXN = [
-    ELHBQN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TATDZX,
-]
-DJQRJJ = [GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ]
-DMPSCT = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FWRKIN = [
-    IUXFEF,
-    QFYLJU,
-    FYLJUI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YLJUIK,
-    LJUIKF,
-    JUIKFW,
-    UIKFWR,
-    IKFWRK,
-    KFWRKI,
-]
-GTYIYW = [HUGTYI, UGTYIY]
-IPMDMP = []
-JJJVYF = [QRJJJV, RJJJVY]
-KSTSEM = [
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    SJMCBF,
-    HWDAFI,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    AKSTSE,
-    HECVYY,
-    HECVYY,
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    DAFIKJ,
-]
-LSPFTS = [HECVYY, PLSPFT, PLSPFT, PLSPFT]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDMPSC = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    PMDMPS,
-]
-MPSCTT = [
-    XTIACQ,
-    EKVKZI,
-    KZILXW,
-    QSNQLN,
-    YKLGQP,
-    LAIIDN,
-    BXTIAC,
-    TIACQF,
-    SPFTSI,
-    JWMNZM,
-    MHXEKV,
-    QLNMHX,
-    JNIBXY,
-    BIAMJM,
-    NIBXTI,
-    NQLNMH,
-    HXEKVK,
-    NMHXEK,
-    YBQSNQ,
-    ZILXWA,
-    BXYBQS,
-    NIBXYB,
-    KVKZIL,
-    WAJVDQ,
-    VKZILX,
-    IBXYBQ,
-    LNMHXE,
-    SNQLNM,
-    BQSNQL,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QLAIID = [HECVYY, DQLAII, DQLAII, DQLAII]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TIXQVX = [
-    ELHBQN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-UBYGDS = [
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-]
-UGSELH = [IJUGSE, JUGSEL]
-USPBWJ = [GYOUSP, QXPICX, YOUSPB, XPICXQ, OUSPBW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VUNXNK = [
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-]
-YXBQFY = [IRYXBQ, RYXBQF]
-YYLIUX = [NPYYLI, PYYLIU]
-ZOLSIP = [ONFZCZ, NFZCZO, FZCZOL, ZCZOLS, CZOLSI]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1322,327 +19,1230 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return PSCTTG
+        return 61
 
     @property
     def begin(self):
-        return SCTTGC
+        return 256
 
     @property
     def end(self):
-        return CTTGCR
+        return 479
 
     @property
     def all_device_keys(self):
-        return MDMPSC
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return DMPSCT
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return MPSCTT
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, ONPYYL, AHEOCT, YYLIUX, None, QIEFXQ, SAKQXP
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, FJTACC, None, None, SAKQXP
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, SAKQXP),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, LKXSJW, ICXQIE, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, LKXSJW, QIEFXQ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, LKXSJW, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, LKXSJW, CXQIEF, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, LKXSJW, UQEXLS, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, JVHFTH, QIEFXQ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, EGZUQE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, UQEXLS, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, NZMJIG, VHFTHE, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, UQEXLS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, PBWJYK, VHFTHE, None),
-            WJYKLG: GeckoWordStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JVHFTH, AHEOCT, None),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, None),
-            GQPLSP: GeckoTempStructAccessor(self.struct, GQPLSP, QPLSPF, None),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, JMCBFE, UQEXLS, LSPFTS, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, AHEOCT, None),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, FJBIAM, QIEFXQ, SAKQXP
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, AHEOCT, None),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, OAWBSI, UQEXLS, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, OAWBSI, VHFTHE, None),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, OAWBSI, XLSXUJ, YXBQFY, None, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FWRKIN, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, ICXQIE, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, RKINEJ, AHEOCT, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, ICXQIE, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, NEJNIB, AHEOCT, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, JVHFTH, EGZUQE, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, NZMJIG, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, NZMJIG, AHEOCT, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, XYBQSN, QIEFXQ, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, XYBQSN, EGZUQE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, RKINEJ, EGZUQE, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, RKINEJ, CXQIEF, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, RKINEJ, UQEXLS, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, RKINEJ, VHFTHE, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, NEJNIB, EGZUQE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NEJNIB, CXQIEF, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NEJNIB, UQEXLS, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NEJNIB, VHFTHE, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, XEKVKZ, QIEFXQ, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, XEKVKZ, EGZUQE, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, IAMJMA, EGZUQE, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, PBWJYK, ICXQIE, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, PBWJYK, AHEOCT, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, ILXWAJ, ICXQIE, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, SIFJBI, ICXQIE, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, XYBQSN, ICXQIE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, XYBQSN, AHEOCT, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, XYBQSN, CXQIEF, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, VDQLAI, ICXQIE, None),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, VDQLAI, AHEOCT, QLAIID, None, CXQIEF, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, VDQLAI, EGZUQE, None),
-            AIIDNI: GeckoWordStructAccessor(self.struct, AIIDNI, IIDNIB, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, ICXQIE, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, IBXTIA, ICXQIE, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, IBXTIA, AHEOCT, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, XEKVKZ, ICXQIE, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, XEKVKZ, AHEOCT, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, XEKVKZ, CXQIEF, None),
-            ACQFFT: GeckoWordStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, UBYGDS, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, ICXQIE, DJQRJJ, None, CXQIEF, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, YGDSBD, QIEFXQ, JJJVYF, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoWordStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoWordStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, GTYIYW, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, VUNXNK, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            UNXNKM: GeckoWordStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, UGSELH, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, AFIKJP, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, IKJPUN, None, AFIKJP, None, None, SAKQXP
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, AFIKJP, None, None, SAKQXP
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, AFIKJP, None, None, SAKQXP
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, RJZTAT, None, AFIKJP, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JZTATD: GeckoEnumStructAccessor(
-                self.struct, JZTATD, ZTATDZ, None, ATDZXN, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, SAKQXP),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, SAKQXP),
-            KEAKST: GeckoEnumStructAccessor(
-                self.struct, KEAKST, EAKSTS, None, KSTSEM, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            STSEMC: GeckoEnumStructAccessor(
-                self.struct, STSEMC, ZTATDZ, None, KSTSEM, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, DZXNQT, None, KSTSEM, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, XNQTMF, None, KSTSEM, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, QTMFZD, None, KSTSEM, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, MFZDGK, None, KSTSEM, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, ZDGKEA, None, KSTSEM, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, TIXQVX, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, GKEAKS, None, TIXQVX, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            XQVXOI: GeckoByteStructAccessor(self.struct, XQVXOI, QVXOIH, SAKQXP),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, SAKQXP),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, SAKQXP),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, SAKQXP),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, SAKQXP),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, SAKQXP),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, SAKQXP),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, SAKQXP),
-            CMCVDS: GeckoByteStructAccessor(self.struct, CMCVDS, MCVDSS, SAKQXP),
-            AIVEMV: GeckoBoolStructAccessor(self.struct, AIVEMV, JVHFTH, UQEXLS, None),
-            IVEMVC: GeckoByteStructAccessor(self.struct, IVEMVC, VEMVCY, SAKQXP),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, SAKQXP),
-            VCYWON: GeckoByteStructAccessor(self.struct, VCYWON, CYWONF, SAKQXP),
-            YWONFZ: GeckoEnumStructAccessor(
-                self.struct, YWONFZ, WONFZC, None, ZOLSIP, None, None, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            OLSIPM: GeckoBoolStructAccessor(
-                self.struct, OLSIPM, LSIPMD, ICXQIE, SAKQXP
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            SIPMDM: GeckoBoolStructAccessor(self.struct, SIPMDM, OIJUGS, ICXQIE, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-62.py
+++ b/src/geckolib/driver/packs/inyt-log-62.py
@@ -12,1331 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 346
-ACQFFT = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AFIKJP = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AHEOCT = 1
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-AJVDQL = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 326
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 51])
-BBEKBD = 456
-BDFSRO = 458
-BDJQRJ = "".join(chr(c) for c in [51, 50, 75])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 57])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-BJEUTO = 297
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-BLKXSJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BMJVHF = 256
-BQFYLJ = 379
-BQNRXC = "".join(chr(c) for c in [80, 49, 72])
-BQSNQL = 283
-BSIRYX = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-BVWVUB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BWJYKL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 342
-BXTIAC = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BXYBQS = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BYGDSB = "".join(chr(c) for c in [105, 110, 89, 84])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-CHWDAF = "".join(chr(c) for c in [80, 51, 76])
-CMCVDS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-CRTFMN = 293
-CTHBSK = 307
-CTTGCR = 62
-CVDSSR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-CYWONF = 372
-CZOLSI = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-DAFIKJ = "".join(chr(c) for c in [66, 76, 79])
-DDPMXF = 462
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-DJQRJJ = "".join(chr(c) for c in [52, 56, 75])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 54])
-DMPSCT = "".join(chr(c) for c in [76, 73])
-DNIBXT = 311
-DNQGVU = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-DQLAII = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-DRXAIV = 477
-DSBDJQ = 290
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 48])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-EAKSTS = 333
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 474
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-EKBDFS = 457
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-EMVCYW = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-EOCTHB = 308
-ETDRXA = 476
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-EUTOPH = 299
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-FFTTID = 285
-FIKJPU = "".join(chr(c) for c in [65, 85, 88])
-FJBIAM = 281
-FMNHTB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FSROGM = 459
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-FZCZOL = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-FZDGKE = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-GETIXQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-GKEAKS = 331
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 461
-GQPLSP = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-GSELHB = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-GTYIYW = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-GVUNXN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-GYOUSP = "".join(chr(c) for c in [78, 79])
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [78, 65])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [68, 74, 83, 52])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-HTBJEU = 296
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 55])
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [80, 52, 72])
-HXEKVK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-HZVOAC = 344
-IACQFF = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IAMJMA = 352
-IBHZVO = 343
-IBXTIA = 314
-IBXYBQ = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IDUBSS = 288
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IGYOUS = 313
-IHBXIB = 341
-IIDNIB = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IJUGSE = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-IKFWRK = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-ILXWAJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-INEJNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPMDMP = 375
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(chr(c) for c in [72, 69, 65, 84])
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [75, 52])
-IVEMVC = 479
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 332
-IYWSKW = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JJJVYF = "".join(chr(c) for c in [85, 76])
-JJVYFC = "".join(chr(c) for c in [67, 69])
-JLOINE = 466
-JMAOAW = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-JPUNRJ = 321
-JQRJJJ = "".join(chr(c) for c in [54, 52, 75])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = 376
-JUIKFW = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JVHFTH = 274
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JYKLGQ = 355
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-KFWRKI = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-KHTZBB = 454
-KINEJN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KLGQPL = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KMLOIJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-KPHUOJ = 304
-KQTDKH = 452
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 325
-KVKZIL = 351
-KWIVDN = "".join(chr(c) for c in [75, 56, 53])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LAIIDN = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 275
-LHBQNR = 320
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-LKXSJW = 273
-LNMHXE = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-LOIJUG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 469
-LXWAJV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-MAOAWB = 384
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-MCVDSS = 347
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-MFZDGK = 329
-MHXEKV = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-MJIGYO = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJMAOA = 377
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 52])
-MLOIJU = 360
-MNHTBJ = 295
-MNZMJI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MVCYWO = 371
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-NBLKXS = 381
-NEJNIB = 350
-NELWUE = 468
-NFZCZO = 374
-NHTBJE = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NIBXTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-NIBXYB = 383
-NKMLOI = 358
-NMHXEK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-NNXWEE = 472
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [75, 49, 48, 48])
-NQJYMO = 271
-NQLNMH = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [80, 50, 72])
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-NZMJIG = 282
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-OAWBSI = 378
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-OIJUGS = 361
-OINELW = 467
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-OLSIPM = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-ONFZCZ = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-OUNBLK = 380
-OUSPBW = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = 353
-PFTSIF = 279
-PHUGTY = 301
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PMDMPS = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-PMXFUB = 463
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QFYLJU = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-QGVUNX = "".join(chr(c) for c in [75, 56, 48, 48])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = 309
-QLNMHX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [80, 49, 76])
-QPLSPF = 277
-QSNQLN = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 53])
-QTMFZD = 328
-QVXOIH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 450
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-RJZTAT = 323
-RKINEJ = 284
-ROGMDD = 460
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-RURAZM = 449
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-RXCHWD = "".join(chr(c) for c in [80, 50, 76])
-RYXBQF = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [49, 54, 75])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SIFJBI = 280
-SIPMDM = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-SIRYXB = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [75, 52, 48, 48])
-SNQLNM = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SPFTSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 49])
-SSRURA = 448
-SSUHBV = "".join(chr(c) for c in [105, 110, 88, 69])
-STSEMC = "".join(chr(c) for c in [70, 97, 110])
-SUHBVW = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TDKHTZ = 453
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-TDZXNQ = "".join(chr(c) for c in [72, 84, 82])
-TFMNHT = 294
-TGCRHY = 479
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-TIXQVX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-TOPHUG = 300
-TSIFJB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-TTGCRH = 256
-TTIDUB = 287
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [70, 117, 108, 108])
-TZBBEK = 455
-UBJLOI = 465
-UBSSUH = 289
-UBYGDS = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-UEUHNN = 470
-UGSELH = "".join(chr(c) for c in [45, 45, 45])
-UGTYIY = 316
-UHBVWV = "".join(chr(c) for c in [77, 73, 65])
-UHNNXW = 471
-UIKFWR = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-UNRJZT = 322
-UNXNKM = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50])
-USOOQN = 261
-UTOPHU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VCYWON = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [75, 53])
-VDQLAI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-VDSSRU = 348
-VEMVCY = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-VHFTHE = 6
-VKZILX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 345
-VUBYGD = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-VUNXNK = "".join(chr(c) for c in [75, 51, 48, 48])
-VWVUBY = "".join(chr(c) for c in [105, 110, 88, 77])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-WAONPY = 367
-WBSIRY = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-WDAFIK = "".join(chr(c) for c in [80, 52, 76])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-WIVDNQ = "".join(chr(c) for c in [75, 56])
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-WMNZMJ = "".join(chr(c) for c in [67, 80, 79, 84])
-WONFZC = 373
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WSKWIV = "".join(chr(c) for c in [75, 50, 48, 48])
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-WVUBYG = "".join(chr(c) for c in [75, 54, 48, 48])
-XAIVEM = 478
-XBQFYL = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-XCHWDA = "".join(chr(c) for c in [80, 51, 72])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 464
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-XNQTMF = 327
-XOIHBX = 340
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-XTIACQ = 315
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = 354
-XWEEZF = 473
-XYBQSN = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-YBQSNQ = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-YEKCWA = 364
-YFCRTF = 291
-YKLGQP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-YMOUNB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(chr(c) for c in [77, 69, 68])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-YWSKWI = 357
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 56])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-ZDGKEA = 330
-ZFETDR = 475
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-ZMKQTD = 451
-ZOLSIP = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-ZTATDZ = 324
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-AIIDNI = [HECVYY, LAIIDN, LAIIDN, LAIIDN]
-DZXNQT = [
-    HBQNRX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TDZXNQ,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FWRKIN = [
-    IUXFEF,
-    QFYLJU,
-    FYLJUI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YLJUIK,
-    LJUIKF,
-    JUIKFW,
-    UIKFWR,
-    IKFWRK,
-    KFWRKI,
-]
-IKJPUN = [
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-    WDAFIK,
-    SJMCBF,
-    DAFIKJ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    AFIKJP,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    FIKJPU,
-]
-JVYFCR = [JJJVYF, JJVYFC]
-LSIPMD = [FZCZOL, ZCZOLS, CZOLSI, ZOLSIP, OLSIPM]
-LSPFTS = [HECVYY, PLSPFT, PLSPFT, PLSPFT]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDMPSC = []
-MPSCTT = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    DMPSCT,
-]
-NXNKML = [
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PSCTTG = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QRJJJV = [SBDJQR, BDJQRJ, DJQRJJ, JQRJJJ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SCTTGC = [
-    IACQFF,
-    VKZILX,
-    ILXWAJ,
-    NQLNMH,
-    YKLGQP,
-    IIDNIB,
-    TIACQF,
-    ACQFFT,
-    SPFTSI,
-    JWMNZM,
-    XEKVKZ,
-    NMHXEK,
-    IBXYBQ,
-    BIAMJM,
-    BXTIAC,
-    LNMHXE,
-    EKVKZI,
-    HXEKVK,
-    QSNQLN,
-    LXWAJV,
-    YBQSNQ,
-    BXYBQS,
-    KZILXW,
-    JVDQLA,
-    ZILXWA,
-    XYBQSN,
-    MHXEKV,
-    QLNMHX,
-    SNQLNM,
-]
-SELHBQ = [UGSELH, GSELHB]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TSEMCG = [
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-    WDAFIK,
-    SJMCBF,
-    DAFIKJ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    AFIKJP,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    FIKJPU,
-]
-USPBWJ = [GYOUSP, QXPICX, YOUSPB, XPICXQ, OUSPBW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XQVXOI = [
-    HBQNRX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-YGDSBD = [
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-]
-YIYWSK = [GTYIYW, TYIYWS]
-YXBQFY = [IRYXBQ, RYXBQF]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1344,328 +19,1233 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return CTTGCR
+        return 62
 
     @property
     def begin(self):
-        return TTGCRH
+        return 256
 
     @property
     def end(self):
-        return TGCRHY
+        return 479
 
     @property
     def all_device_keys(self):
-        return MPSCTT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return PSCTTG
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return SCTTGC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, ONPYYL, AHEOCT, YYLIUX, None, QIEFXQ, SAKQXP
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, FJTACC, None, None, SAKQXP
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, SAKQXP),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, LKXSJW, ICXQIE, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, LKXSJW, QIEFXQ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, LKXSJW, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, LKXSJW, CXQIEF, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, LKXSJW, UQEXLS, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, JVHFTH, QIEFXQ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, EGZUQE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, UQEXLS, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, NZMJIG, VHFTHE, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, UQEXLS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, PBWJYK, VHFTHE, None),
-            WJYKLG: GeckoWordStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JVHFTH, AHEOCT, None),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, None),
-            GQPLSP: GeckoTempStructAccessor(self.struct, GQPLSP, QPLSPF, None),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, JMCBFE, UQEXLS, LSPFTS, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, AHEOCT, None),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, FJBIAM, QIEFXQ, SAKQXP
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, AHEOCT, None),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, OAWBSI, UQEXLS, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, OAWBSI, VHFTHE, None),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, OAWBSI, XLSXUJ, YXBQFY, None, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FWRKIN, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, ICXQIE, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, RKINEJ, AHEOCT, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, ICXQIE, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, NEJNIB, AHEOCT, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, JVHFTH, EGZUQE, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, NZMJIG, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, NZMJIG, AHEOCT, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, QIEFXQ, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, EGZUQE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, RKINEJ, EGZUQE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, RKINEJ, CXQIEF, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, RKINEJ, UQEXLS, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, RKINEJ, VHFTHE, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NEJNIB, EGZUQE, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NEJNIB, CXQIEF, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, NEJNIB, UQEXLS, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, NEJNIB, VHFTHE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, KVKZIL, QIEFXQ, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KVKZIL, EGZUQE, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, IAMJMA, EGZUQE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, PBWJYK, ICXQIE, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, PBWJYK, AHEOCT, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, XWAJVD, ICXQIE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, SIFJBI, ICXQIE, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, BQSNQL, ICXQIE, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, BQSNQL, AHEOCT, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, BQSNQL, CXQIEF, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, QLAIID, ICXQIE, None),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, QLAIID, AHEOCT, AIIDNI, None, CXQIEF, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, QLAIID, EGZUQE, None),
-            IDNIBX: GeckoWordStructAccessor(self.struct, IDNIBX, DNIBXT, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, IBXTIA, ICXQIE, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, XTIACQ, ICXQIE, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, XTIACQ, AHEOCT, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, KVKZIL, ICXQIE, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, KVKZIL, AHEOCT, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, KVKZIL, CXQIEF, None),
-            QFFTTI: GeckoWordStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, YGDSBD, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, ICXQIE, QRJJJV, None, CXQIEF, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, DSBDJQ, QIEFXQ, JVYFCR, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            VYFCRT: GeckoWordStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoWordStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoWordStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, YIYWSK, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, NXNKML, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            XNKMLO: GeckoWordStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, None),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, IKJPUN, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, IKJPUN, None, None, SAKQXP
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, IKJPUN, None, None, SAKQXP
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, RJZTAT, None, IKJPUN, None, None, SAKQXP
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            JZTATD: GeckoEnumStructAccessor(
-                self.struct, JZTATD, ZTATDZ, None, IKJPUN, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, ATDZXN, None, DZXNQT, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, SAKQXP),
-            KEAKST: GeckoByteStructAccessor(self.struct, KEAKST, EAKSTS, SAKQXP),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, TSEMCG, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, ATDZXN, None, TSEMCG, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, XNQTMF, None, TSEMCG, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, QTMFZD, None, TSEMCG, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, MFZDGK, None, TSEMCG, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ZDGKEA, None, TSEMCG, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, GKEAKS, None, TSEMCG, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, IXQVXO, None, XQVXOI, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, EAKSTS, None, XQVXOI, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, SAKQXP),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, SAKQXP),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, SAKQXP),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, SAKQXP),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, SAKQXP),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, SAKQXP),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, SAKQXP),
-            CMCVDS: GeckoByteStructAccessor(self.struct, CMCVDS, MCVDSS, SAKQXP),
-            CVDSSR: GeckoByteStructAccessor(self.struct, CVDSSR, VDSSRU, SAKQXP),
-            VEMVCY: GeckoBoolStructAccessor(self.struct, VEMVCY, JVHFTH, UQEXLS, None),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, SAKQXP),
-            VCYWON: GeckoByteStructAccessor(self.struct, VCYWON, CYWONF, SAKQXP),
-            YWONFZ: GeckoByteStructAccessor(self.struct, YWONFZ, WONFZC, SAKQXP),
-            ONFZCZ: GeckoEnumStructAccessor(
-                self.struct, ONFZCZ, NFZCZO, None, LSIPMD, None, None, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            SIPMDM: GeckoBoolStructAccessor(
-                self.struct, SIPMDM, IPMDMP, ICXQIE, SAKQXP
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            PMDMPS: GeckoBoolStructAccessor(self.struct, PMDMPS, JUGSEL, ICXQIE, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-63.py
+++ b/src/geckolib/driver/packs/inyt-log-63.py
@@ -12,1384 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [73, 68, 76, 69])
-ACMCVD = 342
-ACQFFT = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-AFIKJP = "".join(chr(c) for c in [80, 49, 76])
-AHEOCT = "".join(chr(c) for c in [85, 100, 80, 51])
-AIIDNI = 354
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-AJVDQL = 351
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-AMJMAO = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AOAWBS = 281
-AONPYY = "".join(chr(c) for c in [70, 85, 76, 76])
-ATDZXN = 321
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-AXNCUG = 256
-AZMKQT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-BBEKBD = 452
-BDFSRO = 454
-BDJQRJ = "".join(chr(c) for c in [75, 54, 48, 48])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 53])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-BJEUTO = 293
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-BLKXSJ = 271
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-BQNRXC = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-BQSNQL = 350
-BSIRYX = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-BVWVUB = 288
-BWJYKL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BXIBHZ = 332
-BXTIAC = 309
-BXYBQS = 284
-BYGDSB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-CBFEGZ = "".join(chr(c) for c in [76, 79, 87])
-CCPQIP = "".join(chr(c) for c in [83, 84, 79, 80])
-CGETIX = 333
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-CMCVDS = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-CPQIPO = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-CQBMJV = 317
-CQFFTT = 311
-CRHYUA = "".join(chr(c) for c in [76, 73])
-CTTGCR = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-CVDSSR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CXQIEF = "".join(chr(c) for c in [79, 70, 70])
-CYWONF = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-DAFIKJ = "".join(chr(c) for c in [80, 49, 72])
-DDPMXF = 458
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 55])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-DJQRJJ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 50])
-DMPSCT = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-DNIBXT = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-DNQGVU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-DRXAIV = 473
-DSBDJQ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-DSSRUR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-DUBSSU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-DZXNQT = 322
-EAKSTS = 328
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 470
-EFJTAC = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-EFXQGL = "".join(chr(c) for c in [76, 79])
-EGZUQE = "".join(chr(c) for c in [80, 51])
-EJNIBX = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-EKBDFS = 453
-EKCWAO = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-EKVKZI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-ELHBQN = 360
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-EMCGET = 331
-EMVCYW = 476
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 53])
-ETDRXA = 472
-ETIXQV = 325
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-EUTOPH = 294
-EXLSXU = "".join(chr(c) for c in [66, 76])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-FCRTFM = "".join(chr(c) for c in [54, 52, 75])
-FEFJTA = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-FEGZUQ = "".join(chr(c) for c in [80, 50])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-FFTTID = 314
-FIKJPU = "".join(chr(c) for c in [80, 50, 72])
-FJBIAM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-FMNHTB = "".join(chr(c) for c in [67, 69])
-FSROGM = 455
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-FTTIDU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-FWRKIN = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-FXQGLR = "".join(chr(c) for c in [72, 73])
-FYLJUI = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-FZCZOL = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-FZDGKE = "".join(chr(c) for c in [72, 84, 82])
-GDSBDJ = "".join(chr(c) for c in [68, 74, 83, 52])
-GETIXQ = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-GKEAKS = 327
-GLRAHE = 4
-GMDDPM = 457
-GQPLSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-GSELHB = 358
-GTYIYW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GVUNXN = "".join(chr(c) for c in [75, 52, 48, 48])
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-GZUQEX = "".join(chr(c) for c in [80, 52])
-HBQNRX = 361
-HBSKSO = "".join(chr(c) for c in [79, 78])
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-HBXIBH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 80, 52])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 304
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-HTBJEU = 291
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 51])
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-HUOJRJ = 363
-HWDAFI = 320
-HXEKVK = 283
-HZVOAC = 340
-IACQFF = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IAMJMA = 279
-IBHZVO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-IBXTIA = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-IBXYBQ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-ICXQIE = "".join(chr(c) for c in [83, 79, 65, 75])
-IDNIBX = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IDUBSS = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IEFXQG = 259
-IFJBIA = 277
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-IIDNIB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IJUGSE = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-IKFWRK = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-IKJPUN = "".join(chr(c) for c in [80, 50, 76])
-ILXWAJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-INEJNI = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = 374
-IRYXBQ = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IUSOOQ = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-IUXFEF = 367
-IVDNQG = "".join(chr(c) for c in [70, 117, 108, 108])
-IVEMVC = 475
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IYWSKW = 300
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-JHIUSO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-JIGYOU = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JJJVYF = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-JJVYFC = 290
-JLOINE = 462
-JMAOAW = 280
-JMCBFE = 261
-JNIBXY = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-JPUNRJ = "".join(chr(c) for c in [80, 51, 76])
-JQRJJJ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-JRJHIU = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-JTACCP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-JUIKFW = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-JUTYEK = 5
-JVDQLA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [49, 54, 75])
-JWMNZM = 380
-JYKLGQ = "".join(chr(c) for c in [78, 79])
-JYMOUN = 267
-JZTATD = "".join(chr(c) for c in [65, 85, 88])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 54])
-KCWAON = 310
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KFWRKI = 379
-KHTZBB = 450
-KINEJN = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-KJPUNR = "".join(chr(c) for c in [80, 51, 72])
-KLGQPL = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-KMLOIJ = "".join(chr(c) for c in [75, 49, 48, 48])
-KPHUOJ = 307
-KQTDKH = 448
-KQXPIC = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KSTSEM = 329
-KVKZIL = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-KWIVDN = 316
-KXSJWM = 272
-KZILXW = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-LAIIDN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LHBQNR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-LIUXFE = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-LJUIKF = "".join(chr(c) for c in [72, 69, 65, 84])
-LKXSJW = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LNMHXE = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LOIJUG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-LRAHEO = "".join(chr(c) for c in [85, 100, 80, 50])
-LSIPMD = 373
-LSPFTS = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-LSXUJU = "".join(chr(c) for c in [79, 51])
-LWUEUH = 465
-LXWAJV = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-MAOAWB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-MCBFEG = "".join(chr(c) for c in [72, 73, 71, 72])
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-MCVDSS = 343
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-MDMPSC = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-MFZDGK = 326
-MHXEKV = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-MJIGYO = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-MJMAOA = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 48])
-MLOIJU = "".join(chr(c) for c in [75, 56, 48, 48])
-MNZMJI = 381
-MOUNBL = 268
-MPSCTT = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-MVCYWO = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-NBLKXS = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-NEJNIB = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-NELWUE = 464
-NFZCZO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-NIBXTI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-NKMLOI = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-NMHXEK = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-NNXWEE = 468
-NPYYLI = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-NQGVUN = 357
-NQJYMO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-NQLNMH = 383
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NRJZTA = "".join(chr(c) for c in [66, 76, 79])
-NRSJMC = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-NRXCHW = "".join(chr(c) for c in [45, 45, 45])
-NXNKML = "".join(chr(c) for c in [75, 52])
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-NZMJIG = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-OAWBSI = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-OCTHBS = 258
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 57])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-OIJUGS = "".join(chr(c) for c in [75, 51, 48, 48])
-OINELW = 463
-OJRJHI = 370
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105])
-OLSIPM = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-ONFZCZ = 479
-OOQNRS = 306
-OPHUGT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-OQNRSJ = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-OUNBLK = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-OUYNQJ = 264
-PBWJYK = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PFTSIF = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-PHUGTY = 296
-PHUOJR = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-PICXQI = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-PIVLAS = 385
-PLSPFT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PMDMPS = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-PMXFUB = 459
-POUYNQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-PQIPOU = "".join(chr(c) for c in [78, 69, 87])
-PSCTTG = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-PUNRJZ = "".join(chr(c) for c in [80, 52, 72])
-PYYLIU = 364
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QFFTTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QFYLJU = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-QGLRAH = 0
-QGVUNX = "".join(chr(c) for c in [75, 50, 48, 48])
-QIEFXQ = "".join(chr(c) for c in [85, 100, 80, 49])
-QIPOUY = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-QJYMOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-QLAIID = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-QLNMHX = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-QNRSJM = 362
-QNRXCH = 376
-QPLSPF = 353
-QRJJJV = "".join(chr(c) for c in [105, 110, 89, 84])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 49])
-QTMFZD = 324
-QVXOIH = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-QXPICX = 257
-RAHEOC = 2
-RAZMKQ = 347
-RJHIUS = 303
-RJZTAT = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-RKINEJ = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-ROGMDD = 456
-RSJMCB = 369
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-RURAZM = 346
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-RXCHWD = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-RYXBQF = 384
-SAKQXP = 386
-SBDJQR = "".join(chr(c) for c in [105, 110, 88, 77])
-SELHBQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-SIFJBI = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-SIPMDM = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-SIRYXB = 377
-SJMCBF = "".join(chr(c) for c in [80, 49])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-SKSOKP = 1
-SKWIVD = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-SOKPHU = 308
-SOOQNR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-SPBWJY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SPFTSI = 355
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 56])
-SRURAZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = 345
-SSUHBV = 285
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-SXUJUT = 3
-TACCPQ = 263
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TDKHTZ = 449
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-TFMNHT = "".join(chr(c) for c in [85, 76])
-TGCRHY = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-THBSKS = "".join(chr(c) for c in [85, 100, 66, 76])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-TIXQVX = "".join(chr(c) for c in [70, 97, 110])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-TOPHUG = 295
-TSEMCG = 330
-TSIFJB = 275
-TTGCRH = 375
-TTIDUB = 315
-TYEKCW = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-TYIYWS = 299
-TZBBEK = 451
-UAXNCU = 63
-UBJLOI = 461
-UBSSUH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-UBYGDS = "".join(chr(c) for c in [105, 110, 88, 69])
-UEUHNN = 466
-UGSELH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UGTYIY = 297
-UHBVWV = 287
-UHNNXW = 467
-UJUTYE = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-UNBLKX = 270
-UNRJZT = "".join(chr(c) for c in [80, 52, 76])
-UNXNKM = "".join(chr(c) for c in [75, 56])
-UOJRJH = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-UQEXLS = 260
-URAZMK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-USOOQN = 305
-USPBWJ = 282
-UTOPHU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-UTYEKC = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-UXFEFJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-VCYWON = 477
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-VDSSRU = 344
-VEMVCY = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = 341
-VUBYGD = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-VUNXNK = "".join(chr(c) for c in [75, 56, 53])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-VYFCRT = "".join(chr(c) for c in [51, 50, 75])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-WAONPY = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-WBSIRY = 352
-WDAFIK = "".join(chr(c) for c in [78, 65])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-WIVDNQ = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-WJYKLG = 313
-WMNZMJ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-WONFZC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-WRKINE = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-WSKWIV = 301
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-WVUBYG = 289
-XAIVEM = 474
-XBQFYL = 378
-XEKVKZ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-XFEFJT = 262
-XFUBJL = 460
-XLSXUJ = "".join(chr(c) for c in [67, 80])
-XNCUGU = 479
-XNKMLO = "".join(chr(c) for c in [75, 53])
-XNQTMF = 323
-XOIHBX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-XPICXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-XSJWMN = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-XTIACQ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-XUJUTY = "".join(chr(c) for c in [76, 49, 50, 48])
-XWAJVD = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-XWEEZF = 469
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-YEKCWA = 7
-YFCRTF = "".join(chr(c) for c in [52, 56, 75])
-YGDSBD = "".join(chr(c) for c in [77, 73, 65])
-YIYWSK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-YKLGQP = "".join(chr(c) for c in [77, 69, 68])
-YLIUXF = 365
-YLJUIK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-YMOUNB = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-YNQJYM = 266
-YOUSPB = "".join(chr(c) for c in [67, 80, 79, 84])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = 478
-YWSKWI = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-YYLIUX = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = 371
-ZFETDR = 471
-ZILXWA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-ZMJIGY = 273
-ZMKQTD = 348
-ZOLSIP = 372
-ZUQEXL = "".join(chr(c) for c in [80, 53])
-ZVOACM = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-BFEGZU = [CXQIEF, MCBFEG, CBFEGZ]
-BSKSOK = [CXQIEF, HBSKSO]
-CRTFMN = [JVYFCR, VYFCRT, YFCRTF, FCRTFM]
-CTHBSK = [CXQIEF, FXQGLR]
-FJTACC = [FEFJTA, EFJTAC]
-GCRHYU = []
-HYUAXN = [
-    QIEFXQ,
-    LRAHEO,
-    AHEOCT,
-    HEOCTH,
-    EOCTHB,
-    THBSKS,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    OQNRSJ,
-    NRSJMC,
-]
-IPOUYN = [ACCPQI, CCPQIP, CPQIPO, PQIPOU, QIPOUY]
-IXQVXO = [
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    ZUQEXL,
-    NRJZTA,
-    XLSXUJ,
-    LSXUJU,
-    XUJUTY,
-    HECVYY,
-    HECVYY,
-    TIXQVX,
-    HECVYY,
-    HECVYY,
-    RJZTAT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TYEKCW,
-    JZTATD,
-]
-JBIAMJ = [HECVYY, FJBIAM, FJBIAM, FJBIAM]
-JUGSEL = [
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-]
-LGQPLS = [JYKLGQ, EFXQGL, YKLGQP, FXQGLR, KLGQPL]
-MNHTBJ = [TFMNHT, FMNHTB]
-NIBXYB = [
-    ACCPQI,
-    FWRKIN,
-    WRKINE,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RKINEJ,
-    KINEJN,
-    INEJNI,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-]
-ONPYYL = [CWAONP, WAONPY, AONPYY]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QEXLSX = [CXQIEF, MCBFEG]
-RHYUAX = [
-    SJMCBF,
-    FEGZUQ,
-    EGZUQE,
-    GZUQEX,
-    ZUQEXL,
-    EXLSXU,
-    XLSXUJ,
-    LSXUJU,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    NPYYLI,
-    YYLIUX,
-    LIUXFE,
-    CRHYUA,
-]
-RJJJVY = [
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-]
-SCTTGC = [PMDMPS, MDMPSC, DMPSCT, MPSCTT, PSCTTG]
-TIACQF = [HECVYY, XTIACQ, XTIACQ, XTIACQ]
-UIKFWR = [LJUIKF, JUIKFW]
-VDNQGV = [WIVDNQ, IVDNQG]
-XCHWDA = [NRXCHW, RXCHWD]
-XIBHZV = [
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XLSXUJ,
-]
-XQGLRA = [CXQIEF, EFXQGL, FXQGLR]
-XQIEFX = [XPICXQ, PICXQI, ICXQIE, CXQIEF]
-YUAXNC = [
-    IDUBSS,
-    JVDQLA,
-    QLAIID,
-    KVKZIL,
-    PFTSIF,
-    IACQFF,
-    TIDUBS,
-    DUBSSU,
-    BIAMJM,
-    GYOUSP,
-    XWAJVD,
-    ZILXWA,
-    QLNMHX,
-    AWBSIR,
-    FTTIDU,
-    KZILXW,
-    WAJVDQ,
-    LXWAJV,
-    XEKVKZ,
-    LAIIDN,
-    MHXEKV,
-    LNMHXE,
-    VDQLAI,
-    DNIBXT,
-    DQLAII,
-    NMHXEK,
-    ILXWAJ,
-    VKZILX,
-    EKVKZI,
-]
-ZDGKEA = [
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    FZDGKE,
-]
-ZTATDZ = [
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    ZUQEXL,
-    NRJZTA,
-    XLSXUJ,
-    LSXUJU,
-    XUJUTY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RJZTAT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TYEKCW,
-    JZTATD,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1397,332 +19,1246 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return UAXNCU
+        return 63
 
     @property
     def begin(self):
-        return AXNCUG
+        return 256
 
     @property
     def end(self):
-        return XNCUGU
+        return 479
 
     @property
     def all_device_keys(self):
-        return RHYUAX
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return HYUAXN
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return YUAXNC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, XQIEFX, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, QGLRAH, XQGLRA, None, GLRAHE, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, IEFXQG, RAHEOC, XQGLRA, None, GLRAHE, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            AHEOCT: GeckoEnumStructAccessor(
-                self.struct, AHEOCT, IEFXQG, GLRAHE, XQGLRA, None, GLRAHE, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, IEFXQG, VHFTHE, XQGLRA, None, GLRAHE, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, OCTHBS, QGLRAH, CTHBSK, None, RAHEOC, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, OCTHBS, SKSOKP, BSKSOK, None, RAHEOC, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, BSKSOK, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, CTHBSK, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, BSKSOK, None, None, AKQXPI
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, BSKSOK, None, None, AKQXPI
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, AKQXPI),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, AKQXPI),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, AKQXPI),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, AKQXPI),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, AKQXPI),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, AKQXPI),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, QGLRAH, BFEGZU, None, GLRAHE, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, RAHEOC, BFEGZU, None, GLRAHE, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, JMCBFE, GLRAHE, BFEGZU, None, GLRAHE, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, VHFTHE, BFEGZU, None, GLRAHE, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, UQEXLS, QGLRAH, QEXLSX, None, RAHEOC, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, UQEXLS, SKSOKP, BSKSOK, None, RAHEOC, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, UQEXLS, RAHEOC, BSKSOK, None, RAHEOC, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, UQEXLS, SXUJUT, BSKSOK, None, RAHEOC, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UQEXLS, GLRAHE, BSKSOK, None, RAHEOC, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, UQEXLS, JUTYEK, BSKSOK, None, RAHEOC, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, UQEXLS, VHFTHE, BSKSOK, None, RAHEOC, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, UQEXLS, YEKCWA, BSKSOK, None, RAHEOC, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, ONPYYL, None, None, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, ONPYYL, None, None, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YYLIUX: GeckoWordStructAccessor(self.struct, YYLIUX, YLIUXF, None),
-            LIUXFE: GeckoWordStructAccessor(self.struct, LIUXFE, IUXFEF, AKQXPI),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, QGLRAH, FJTACC, None, RAHEOC, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, IPOUYN, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            POUYNQ: GeckoTimeStructAccessor(self.struct, POUYNQ, OUYNQJ, AKQXPI),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, AKQXPI),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, XFEFJT, RAHEOC, FJTACC, None, RAHEOC, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, IPOUYN, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            YMOUNB: GeckoTimeStructAccessor(self.struct, YMOUNB, MOUNBL, AKQXPI),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, AKQXPI),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, AKQXPI),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, AKQXPI),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, XFEFJT, SKSOKP, FJTACC, None, RAHEOC, AKQXPI
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, IPOUYN, None, None, AKQXPI
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            WMNZMJ: GeckoTimeStructAccessor(self.struct, WMNZMJ, MNZMJI, AKQXPI),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, QGLRAH, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, ZMJIGY, RAHEOC, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, ZMJIGY, SXUJUT, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, ZMJIGY, GLRAHE, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, ZMJIGY, JUTYEK, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, JVHFTH, RAHEOC, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, SXUJUT, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, USPBWJ, JUTYEK, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, USPBWJ, VHFTHE, None),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, LGQPLS, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, JUTYEK, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, QPLSPF, VHFTHE, None),
-            LSPFTS: GeckoWordStructAccessor(self.struct, LSPFTS, SPFTSI, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, JVHFTH, SKSOKP, None),
-            FTSIFJ: GeckoTempStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoTempStructAccessor(self.struct, SIFJBI, IFJBIA, None),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, UQEXLS, JUTYEK, JBIAMJ, None, GLRAHE, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, RAHEOC, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, VHFTHE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, RAHEOC, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, SKSOKP, None),
-            OAWBSI: GeckoBoolStructAccessor(
-                self.struct, OAWBSI, AOAWBS, RAHEOC, AKQXPI
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, SKSOKP, None),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, QGLRAH, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QGLRAH, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, XBQFYL, GLRAHE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, XBQFYL, JUTYEK, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, XBQFYL, VHFTHE, None),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, XBQFYL, YEKCWA, UIKFWR, None, RAHEOC, AKQXPI
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, NIBXYB, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, QGLRAH, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, BXYBQS, SKSOKP, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, QGLRAH, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, SKSOKP, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, NQLNMH, QGLRAH, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, JVHFTH, SXUJUT, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, USPBWJ, QGLRAH, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, USPBWJ, SKSOKP, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, HXEKVK, RAHEOC, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, HXEKVK, SXUJUT, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, BXYBQS, SXUJUT, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, BXYBQS, GLRAHE, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, BXYBQS, JUTYEK, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, BXYBQS, VHFTHE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, BQSNQL, SXUJUT, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, BQSNQL, GLRAHE, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, BQSNQL, JUTYEK, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, BQSNQL, VHFTHE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, RAHEOC, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, AJVDQL, SXUJUT, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, WBSIRY, SXUJUT, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, QPLSPF, QGLRAH, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, QPLSPF, SKSOKP, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, AIIDNI, QGLRAH, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, JMAOAW, QGLRAH, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, HXEKVK, QGLRAH, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, HXEKVK, SKSOKP, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, HXEKVK, GLRAHE, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, QGLRAH, None),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, BXTIAC, SKSOKP, TIACQF, None, GLRAHE, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, BXTIAC, SXUJUT, None),
-            ACQFFT: GeckoWordStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, FFTTID, QGLRAH, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, TTIDUB, QGLRAH, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, TTIDUB, SKSOKP, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, AJVDQL, QGLRAH, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, AJVDQL, SKSOKP, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, AJVDQL, GLRAHE, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, RJJJVY, None, None, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, QGLRAH, CRTFMN, None, GLRAHE, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, JJVYFC, RAHEOC, MNHTBJ, None, RAHEOC, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NHTBJE: GeckoWordStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoWordStructAccessor(self.struct, HUGTYI, UGTYIY, None),
-            GTYIYW: GeckoByteStructAccessor(self.struct, GTYIYW, TYIYWS, None),
-            YIYWSK: GeckoByteStructAccessor(self.struct, YIYWSK, IYWSKW, None),
-            YWSKWI: GeckoWordStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, VDNQGV, None, RAHEOC, AKQXPI
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, JUGSEL, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGSELH: GeckoWordStructAccessor(self.struct, UGSELH, GSELHB, None),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, None),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, None),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, XCHWDA, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, ZTATDZ, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, ATDZXN, None, ZTATDZ, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, None, ZTATDZ, None, None, AKQXPI
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, XNQTMF, None, ZTATDZ, None, None, AKQXPI
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, None, ZTATDZ, None, None, AKQXPI
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, MFZDGK, None, ZDGKEA, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, AKQXPI),
-            KEAKST: GeckoByteStructAccessor(self.struct, KEAKST, EAKSTS, AKQXPI),
-            AKSTSE: GeckoByteStructAccessor(self.struct, AKSTSE, KSTSEM, AKQXPI),
-            STSEMC: GeckoByteStructAccessor(self.struct, STSEMC, TSEMCG, AKQXPI),
-            SEMCGE: GeckoByteStructAccessor(self.struct, SEMCGE, EMCGET, AKQXPI),
-            MCGETI: GeckoByteStructAccessor(self.struct, MCGETI, CGETIX, AKQXPI),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, IXQVXO, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            XQVXOI: GeckoEnumStructAccessor(
-                self.struct, XQVXOI, MFZDGK, None, IXQVXO, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, GKEAKS, None, IXQVXO, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            VXOIHB: GeckoEnumStructAccessor(
-                self.struct, VXOIHB, EAKSTS, None, IXQVXO, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, KSTSEM, None, IXQVXO, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            OIHBXI: GeckoEnumStructAccessor(
-                self.struct, OIHBXI, TSEMCG, None, IXQVXO, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, EMCGET, None, IXQVXO, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            HBXIBH: GeckoEnumStructAccessor(
-                self.struct, HBXIBH, BXIBHZ, None, XIBHZV, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, CGETIX, None, XIBHZV, None, None, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, AKQXPI),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, AKQXPI),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, AKQXPI),
-            CMCVDS: GeckoByteStructAccessor(self.struct, CMCVDS, MCVDSS, AKQXPI),
-            CVDSSR: GeckoByteStructAccessor(self.struct, CVDSSR, VDSSRU, AKQXPI),
-            DSSRUR: GeckoByteStructAccessor(self.struct, DSSRUR, SSRURA, AKQXPI),
-            SRURAZ: GeckoByteStructAccessor(self.struct, SRURAZ, RURAZM, AKQXPI),
-            URAZMK: GeckoByteStructAccessor(self.struct, URAZMK, RAZMKQ, AKQXPI),
-            AZMKQT: GeckoByteStructAccessor(self.struct, AZMKQT, ZMKQTD, AKQXPI),
-            NFZCZO: GeckoBoolStructAccessor(self.struct, NFZCZO, JVHFTH, JUTYEK, None),
-            FZCZOL: GeckoByteStructAccessor(self.struct, FZCZOL, ZCZOLS, AKQXPI),
-            CZOLSI: GeckoByteStructAccessor(self.struct, CZOLSI, ZOLSIP, AKQXPI),
-            OLSIPM: GeckoByteStructAccessor(self.struct, OLSIPM, LSIPMD, AKQXPI),
-            SIPMDM: GeckoEnumStructAccessor(
-                self.struct, SIPMDM, IPMDMP, None, SCTTGC, None, None, AKQXPI
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            CTTGCR: GeckoBoolStructAccessor(
-                self.struct, CTTGCR, TTGCRH, QGLRAH, AKQXPI
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            TGCRHY: GeckoBoolStructAccessor(self.struct, TGCRHY, QNRXCH, QGLRAH, None),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-64.py
+++ b/src/geckolib/driver/packs/inyt-log-64.py
@@ -12,1458 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-AFIKJP = 320
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AIVEMV = 473
-AJVDQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = 327
-AOAWBS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-AONPYY = 310
-ATDZXN = "".join(chr(c) for c in [65, 85, 88])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-AZMKQT = 346
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 51])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 53])
-BDJQRJ = "".join(chr(c) for c in [68, 74, 83, 52])
-BEKBDF = 451
-BFEGZU = 261
-BHZVOA = 332
-BIAMJM = 277
-BJEUTO = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BJLOIN = 460
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 384
-BQNRXC = 360
-BQSNQL = 284
-BSIRYX = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BSKSOK = 258
-BSSUHB = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-BWJYKL = 282
-BXIBHZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-BXTIAC = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BXYBQS = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-BYGDSB = 289
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-CHWDAF = "".join(chr(c) for c in [45, 45, 45])
-CMCVDS = 341
-CPQIPO = 263
-CQBMJV = 317
-CRHYUA = 375
-CRTFMN = "".join(chr(c) for c in [51, 50, 75])
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-CUGUCY = 256
-CVDSSR = 342
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYWONF = 476
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-DDPMXF = "".join(chr(c) for c in [67, 70, 71, 57])
-DFSROG = 453
-DGKEAK = 326
-DJQRJJ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-DKHTZB = 448
-DMPSCT = 374
-DNIBXT = 354
-DNQGVU = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-DPMXFU = 457
-DQLAII = 351
-DRXAIV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-DSBDJQ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-DSSRUR = 343
-DUBSSU = 315
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EAKSTS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 52])
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-ELHBQN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-ELWUEU = 463
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-EMVCYW = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-EUHNNX = 465
-EUTOPH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = 469
-FCRTFM = "".join(chr(c) for c in [49, 54, 75])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = 470
-FFTTID = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-FIKJPU = "".join(chr(c) for c in [78, 65])
-FJBIAM = 275
-FJTACC = 262
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 54])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-FTTIDU = 311
-FUBJLO = 459
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 378
-FZCZOL = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-FZDGKE = 324
-GCRHYU = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-GDSBDJ = "".join(chr(c) for c in [105, 110, 88, 69])
-GETIXQ = 331
-GKEAKS = "".join(chr(c) for c in [72, 84, 82])
-GLRAHE = 259
-GMDDPM = "".join(chr(c) for c in [67, 70, 71, 56])
-GQPLSP = "".join(chr(c) for c in [77, 69, 68])
-GSELHB = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-GTYIYW = 296
-GVUNXN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-GYOUSP = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-HBQNRX = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = 285
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = 466
-HTBJEU = "".join(chr(c) for c in [67, 69])
-HTZBBE = 449
-HUGTYI = 295
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-HXEKVK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-IACQFF = 309
-IAMJMA = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IBHZVO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-IBXTIA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IBXYBQ = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-ICXQIE = 1
-IDNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-IDUBSS = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IGYOUS = 273
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-IIDNIB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [75, 56, 48, 48])
-IKFWRK = "".join(chr(c) for c in [72, 69, 65, 84])
-IKJPUN = "".join(chr(c) for c in [80, 49, 72])
-ILXWAJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-INEJNI = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-INELWU = 462
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 352
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-IVEMVC = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-IYWSKW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-JBIAMJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JEUTOP = 291
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-JJVYFC = "".join(chr(c) for c in [105, 110, 89, 84])
-JLOINE = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-JMAOAW = 279
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-JPUNRJ = "".join(chr(c) for c in [80, 50, 72])
-JQRJJJ = "".join(chr(c) for c in [105, 110, 88, 77])
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JUIKFW = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-JUTYEK = 3
-JVDQLA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-JVHFTH = 274
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYMOUN = 266
-JZTATD = "".join(chr(c) for c in [80, 52, 76])
-KBDFSR = 452
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KFWRKI = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 49])
-KINEJN = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-KJPUNR = "".join(chr(c) for c in [80, 49, 76])
-KLGQPL = 313
-KMLOIJ = "".join(chr(c) for c in [75, 52])
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KVKZIL = 283
-KWIVDN = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-KZILXW = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(chr(c) for c in [78, 79])
-LHBQNR = 358
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-LKXSJW = 270
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-LOIJUG = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-LOINEL = 461
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LWUEUH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-LXWAJV = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-MAOAWB = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = 369
-MCGETI = 330
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-MDDPMX = 456
-MDMPSC = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-MFZDGK = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-MHXEKV = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-MJIGYO = 381
-MJMAOA = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 347
-MLOIJU = "".join(chr(c) for c in [75, 53])
-MNHTBJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-MVCYWO = 475
-MXFUBJ = 458
-NBLKXS = 268
-NCUGUC = 64
-NEJNIB = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-NELWUE = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-NFZCZO = 478
-NHTBJE = "".join(chr(c) for c in [85, 76])
-NIBXTI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-NIBXYB = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-NKMLOI = "".join(chr(c) for c in [75, 56])
-NMHXEK = 383
-NNXWEE = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = "".join(chr(c) for c in [70, 117, 108, 108])
-NQJYMO = 264
-NQLNMH = 350
-NQTMFZ = 322
-NRJZTA = "".join(chr(c) for c in [80, 51, 76])
-NRSJMC = 306
-NRXCHW = 361
-NXNKML = "".join(chr(c) for c in [75, 52, 48, 48])
-NXWEEZ = 467
-NZMJIG = 380
-OACMCV = 340
-OAWBSI = 280
-OCTHBS = 2
-OGMDDP = 455
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-OIJUGS = "".join(chr(c) for c in [75, 49, 48, 48])
-OINELW = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 371
-ONFZCZ = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = 294
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PHUGTY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PMDMPS = 373
-PMXFUB = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-PUNRJZ = "".join(chr(c) for c in [80, 50, 76])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-QPLSPF = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QRJJJV = "".join(chr(c) for c in [75, 54, 48, 48])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-QTDKHT = 348
-QTMFZD = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-QVXOIH = "".join(chr(c) for c in [70, 97, 110])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAZMKQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-RHYUAX = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-RJZTAT = "".join(chr(c) for c in [80, 52, 72])
-RKINEJ = 379
-ROGMDD = "".join(chr(c) for c in [67, 70, 71, 55])
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [52, 56, 75])
-RURAZM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-RXAIVE = 472
-RXCHWD = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SAKQXP = 386
-SBDJQR = "".join(chr(c) for c in [77, 73, 65])
-SCTTGC = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-SEMCGE = 329
-SIFJBI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SIPMDM = 372
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = 300
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(chr(c) for c in [67, 80, 79, 84])
-SPFTSI = 353
-SROGMD = 454
-SRURAZ = 344
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-SSUHBV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-STSEMC = 328
-SUHBVW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 48])
-TDRXAI = 471
-TFMNHT = "".join(chr(c) for c in [54, 52, 75])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-TIDUBS = 314
-TIXQVX = 333
-TMFZDG = 323
-TOPHUG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TSEMCG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-TSIFJB = 355
-TTGCRH = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-TTIDUB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TYIYWS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50])
-UBJLOI = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-UBSSUH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-UEUHNN = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-UGSELH = "".join(chr(c) for c in [75, 51, 48, 48])
-UGTYIY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-UGUCYR = 479
-UHBVWV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UHNNXW = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-UIKFWR = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = "".join(chr(c) for c in [80, 51, 72])
-UNXNKM = "".join(chr(c) for c in [75, 50, 48, 48])
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = 345
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-UTOPHU = 293
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VDNQGV = 316
-VDQLAI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-VDSSRU = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-VEMVCY = 474
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-VUBYGD = 288
-VUNXNK = 357
-VWVUBY = 287
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = 281
-WEEZFE = 468
-WIVDNQ = 301
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = 477
-WRKINE = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-WSKWIV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-WUEUHN = 464
-WVUBYG = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-XAIVEM = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-XBQFYL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = 376
-XEKVKZ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-XLSXUJ = 260
-XNKMLO = "".join(chr(c) for c in [75, 56, 53])
-XNQTMF = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-XOIHBX = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = 325
-XSJWMN = 271
-XTIACQ = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-XWEEZF = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-YEKCWA = 5
-YFCRTF = 290
-YGDSBD = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YIYWSK = 297
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YUAXNC = "".join(chr(c) for c in [76, 73])
-YWONFZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-YWSKWI = 299
-YXBQFY = 377
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 450
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = 479
-ZDGKEA = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-ZFETDR = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ZILXWA = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-ZOLSIP = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-ZTATDZ = "".join(chr(c) for c in [66, 76, 79])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-ZXNQTM = 321
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-AMJMAO = [HECVYY, IAMJMA, IAMJMA, IAMJMA]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-AXNCUG = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-CQFFTT = [HECVYY, ACQFFT, ACQFFT, ACQFFT]
-FMNHTB = [FCRTFM, CRTFMN, RTFMNH, TFMNHT]
-FWRKIN = [IKFWRK, KFWRKI]
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-HYUAXN = []
-HZVOAC = [
-    FIKJPU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-JVYFCR = [
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-]
-KEAKST = [
-    FIKJPU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GKEAKS,
-]
-LSXUJU = [FXQGLR, FEGZUQ]
-OKPHUO = [FXQGLR, SOKPHU]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PLSPFT = [LGQPLS, LRAHEO, GQPLSP, RAHEOC, QPLSPF]
-QGVUNX = [DNQGVU, NQGVUN]
-SELHBQ = [
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-TBJEUT = [NHTBJE, HTBJEU]
-TDZXNQ = [
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-    EXLSXU,
-    ZTATDZ,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TATDZX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    ATDZXN,
-]
-TGCRHY = [MPSCTT, PSCTTG, SCTTGC, CTTGCR, TTGCRH]
-UAXNCU = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    YUAXNC,
-]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VXOIHB = [
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-    EXLSXU,
-    ZTATDZ,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    QVXOIH,
-    HECVYY,
-    HECVYY,
-    TATDZX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    ATDZXN,
-]
-WDAFIK = [CHWDAF, HWDAFI]
-XNCUGU = [
-    BSSUHB,
-    QLAIID,
-    IIDNIB,
-    ZILXWA,
-    SIFJBI,
-    QFFTTI,
-    UBSSUH,
-    SSUHBV,
-    MJMAOA,
-    USPBWJ,
-    JVDQLA,
-    XWAJVD,
-    MHXEKV,
-    SIRYXB,
-    IDUBSS,
-    LXWAJV,
-    VDQLAI,
-    AJVDQL,
-    VKZILX,
-    IDNIBX,
-    EKVKZI,
-    HXEKVK,
-    LAIIDN,
-    BXTIAC,
-    AIIDNI,
-    XEKVKZ,
-    WAJVDQ,
-    ILXWAJ,
-    KZILXW,
-]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-XYBQSN = [
-    PQIPOU,
-    KINEJN,
-    INEJNI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-]
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1471,334 +19,1252 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return NCUGUC
+        return 64
 
     @property
     def begin(self):
-        return CUGUCY
+        return 256
 
     @property
     def end(self):
-        return UGUCYR
+        return 479
 
     @property
     def all_device_keys(self):
-        return UAXNCU
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return AXNCUG
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return XNCUGU
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, OCTHBS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, JUTYEK, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, HEOCTH, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, YEKCWA, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, OCTHBS, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, JUTYEK, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, YEKCWA, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, BWJYKL, VHFTHE, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, PLSPFT, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, YEKCWA, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, VHFTHE, None),
-            FTSIFJ: GeckoWordStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, JVHFTH, ICXQIE, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, XLSXUJ, YEKCWA, AMJMAO, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, ICXQIE, None),
-            BSIRYX: GeckoBoolStructAccessor(
-                self.struct, BSIRYX, WBSIRY, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, XPICXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, XPICXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, HEOCTH, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FYLJUI, YEKCWA, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FYLJUI, VHFTHE, None),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, FYLJUI, CWAONP, FWRKIN, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, XYBQSN, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, XPICXQ, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, ICXQIE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, NQLNMH, XPICXQ, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, NQLNMH, ICXQIE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NMHXEK, XPICXQ, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, JVHFTH, JUTYEK, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, BWJYKL, XPICXQ, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, BWJYKL, ICXQIE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, KVKZIL, OCTHBS, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KVKZIL, JUTYEK, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, BQSNQL, JUTYEK, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, BQSNQL, HEOCTH, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, BQSNQL, YEKCWA, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, BQSNQL, VHFTHE, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, NQLNMH, JUTYEK, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, NQLNMH, HEOCTH, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, NQLNMH, YEKCWA, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, NQLNMH, VHFTHE, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, DQLAII, OCTHBS, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, DQLAII, JUTYEK, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, IRYXBQ, JUTYEK, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, SPFTSI, XPICXQ, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, SPFTSI, ICXQIE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, XPICXQ, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, OAWBSI, XPICXQ, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, KVKZIL, XPICXQ, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, KVKZIL, ICXQIE, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, KVKZIL, HEOCTH, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, IACQFF, XPICXQ, None),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, IACQFF, ICXQIE, CQFFTT, None, HEOCTH, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, IACQFF, JUTYEK, None),
-            FFTTID: GeckoWordStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, TIDUBS, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, DUBSSU, XPICXQ, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, DUBSSU, ICXQIE, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, DQLAII, XPICXQ, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, DQLAII, ICXQIE, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, DQLAII, HEOCTH, None),
-            UHBVWV: GeckoWordStructAccessor(self.struct, UHBVWV, HBVWVU, None),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, JVYFCR, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, XPICXQ, FMNHTB, None, HEOCTH, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, YFCRTF, OCTHBS, TBJEUT, None, OCTHBS, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            BJEUTO: GeckoWordStructAccessor(self.struct, BJEUTO, JEUTOP, None),
-            EUTOPH: GeckoByteStructAccessor(self.struct, EUTOPH, UTOPHU, None),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, None),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, None),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoWordStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, None),
-            KWIVDN: GeckoWordStructAccessor(self.struct, KWIVDN, WIVDNQ, None),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, QGVUNX, None, OCTHBS, AKQXPI
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, SELHBQ, None, None, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ELHBQN: GeckoWordStructAccessor(self.struct, ELHBQN, LHBQNR, None),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, None),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, None),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, WDAFIK, None, None, AKQXPI
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, TDZXNQ, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, None, TDZXNQ, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, NQTMFZ, None, TDZXNQ, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, None, TDZXNQ, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, FZDGKE, None, TDZXNQ, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, None, KEAKST, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            EAKSTS: GeckoByteStructAccessor(self.struct, EAKSTS, AKSTSE, AKQXPI),
-            KSTSEM: GeckoByteStructAccessor(self.struct, KSTSEM, STSEMC, AKQXPI),
-            TSEMCG: GeckoByteStructAccessor(self.struct, TSEMCG, SEMCGE, AKQXPI),
-            EMCGET: GeckoByteStructAccessor(self.struct, EMCGET, MCGETI, AKQXPI),
-            CGETIX: GeckoByteStructAccessor(self.struct, CGETIX, GETIXQ, AKQXPI),
-            ETIXQV: GeckoByteStructAccessor(self.struct, ETIXQV, TIXQVX, AKQXPI),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, XQVXOI, None, VXOIHB, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, DGKEAK, None, VXOIHB, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            OIHBXI: GeckoEnumStructAccessor(
-                self.struct, OIHBXI, AKSTSE, None, VXOIHB, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, STSEMC, None, VXOIHB, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            HBXIBH: GeckoEnumStructAccessor(
-                self.struct, HBXIBH, SEMCGE, None, VXOIHB, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            BXIBHZ: GeckoEnumStructAccessor(
-                self.struct, BXIBHZ, MCGETI, None, VXOIHB, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            XIBHZV: GeckoEnumStructAccessor(
-                self.struct, XIBHZV, GETIXQ, None, VXOIHB, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, BHZVOA, None, HZVOAC, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            ZVOACM: GeckoEnumStructAccessor(
-                self.struct, ZVOACM, TIXQVX, None, HZVOAC, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            VOACMC: GeckoByteStructAccessor(self.struct, VOACMC, OACMCV, AKQXPI),
-            ACMCVD: GeckoByteStructAccessor(self.struct, ACMCVD, CMCVDS, AKQXPI),
-            MCVDSS: GeckoByteStructAccessor(self.struct, MCVDSS, CVDSSR, AKQXPI),
-            VDSSRU: GeckoByteStructAccessor(self.struct, VDSSRU, DSSRUR, AKQXPI),
-            SSRURA: GeckoByteStructAccessor(self.struct, SSRURA, SRURAZ, AKQXPI),
-            RURAZM: GeckoByteStructAccessor(self.struct, RURAZM, URAZMK, AKQXPI),
-            RAZMKQ: GeckoByteStructAccessor(self.struct, RAZMKQ, AZMKQT, AKQXPI),
-            ZMKQTD: GeckoByteStructAccessor(self.struct, ZMKQTD, MKQTDK, AKQXPI),
-            KQTDKH: GeckoByteStructAccessor(self.struct, KQTDKH, QTDKHT, AKQXPI),
-            CZOLSI: GeckoBoolStructAccessor(self.struct, CZOLSI, JVHFTH, YEKCWA, None),
-            ZOLSIP: GeckoByteStructAccessor(self.struct, ZOLSIP, OLSIPM, AKQXPI),
-            LSIPMD: GeckoByteStructAccessor(self.struct, LSIPMD, SIPMDM, AKQXPI),
-            IPMDMP: GeckoByteStructAccessor(self.struct, IPMDMP, PMDMPS, AKQXPI),
-            MDMPSC: GeckoEnumStructAccessor(
-                self.struct, MDMPSC, DMPSCT, None, TGCRHY, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            GCRHYU: GeckoBoolStructAccessor(
-                self.struct, GCRHYU, CRHYUA, XPICXQ, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            RHYUAX: GeckoBoolStructAccessor(self.struct, RHYUAX, XCHWDA, XPICXQ, None),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-65.py
+++ b/src/geckolib/driver/packs/inyt-log-65.py
@@ -12,1568 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-ACQFFT = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-AFIKJP = 358
-AIIDNI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-AJVDQL = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-AOAWBS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-AOESVZ = 479
-AONPYY = 310
-ATDZXN = "".join(chr(c) for c in [78, 65])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-AXNCUG = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-AZMKQT = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-BBEKBD = 346
-BDFSRO = 348
-BDJQRJ = 285
-BEKBDF = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-BFEGZU = 261
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-BIAMJM = 277
-BJEUTO = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 55])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 384
-BQNRXC = "".join(chr(c) for c in [75, 53])
-BQSNQL = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-BSIRYX = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BSKSOK = 258
-BSSUHB = 309
-BVWVUB = 311
-BWJYKL = 282
-BXIBHZ = 331
-BXTIAC = 351
-BXYBQS = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-BYGDSB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = 326
-CHWDAF = "".join(chr(c) for c in [75, 51, 48, 48])
-CMCVDS = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-CPQIPO = 263
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-CRHYUA = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-CRTFMN = "".join(chr(c) for c in [68, 74, 83, 52])
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-CUGUCY = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-CVDSSR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-CYWONF = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-CZOLSI = 474
-DAFIKJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-DDPMXF = 451
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 48])
-DGKEAK = "".join(chr(c) for c in [65, 85, 88])
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-DKHTZB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-DMPSCT = 478
-DNIBXT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-DNQGVU = 296
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 52])
-DQLAII = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-DRXAIV = 466
-DSBDJQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-DSSRUR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-DUBSSU = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-DZXNQT = "".join(chr(c) for c in [80, 49, 76])
-EAKSTS = 321
-EAOESV = 256
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 463
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-EKBDFS = 347
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-ELHBQN = "".join(chr(c) for c in [75, 56, 53])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-EMCGET = 324
-EMVCYW = 469
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = 465
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EUTOPH = "".join(chr(c) for c in [49, 54, 75])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-FCRTFM = "".join(chr(c) for c in [77, 73, 65])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-FIKJPU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-FJBIAM = 275
-FJTACC = 262
-FMNHTB = "".join(chr(c) for c in [75, 54, 48, 48])
-FSROGM = 448
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-FTTIDU = 387
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 54])
-FWRKIN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 378
-FZCZOL = 473
-FZDGKE = "".join(chr(c) for c in [66, 76, 79])
-GCRHYU = 372
-GDSBDJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-GETIXQ = "".join(chr(c) for c in [72, 84, 82])
-GLRAHE = 259
-GMDDPM = 450
-GQPLSP = "".join(chr(c) for c in [77, 69, 68])
-GSELHB = "".join(chr(c) for c in [75, 50, 48, 48])
-GTYIYW = "".join(chr(c) for c in [67, 69])
-GUCYRA = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GYOUSP = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-HBQNRX = "".join(chr(c) for c in [75, 52])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-HTBJEU = "".join(chr(c) for c in [105, 110, 89, 84])
-HTZBBE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-HYUAXN = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-HZVOAC = 325
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IBHZVO = 333
-IBXTIA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-IBXYBQ = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-ICXQIE = 1
-IDNIBX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-IDUBSS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IGYOUS = 273
-IHBXIB = 330
-IIDNIB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IKFWRK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-IKJPUN = 360
-ILXWAJ = 383
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-INELWU = "".join(chr(c) for c in [67, 70, 71, 57])
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 352
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = 295
-IVEMVC = 468
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = 327
-IYWSKW = 291
-JBIAMJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JEUTOP = 290
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-JJVYFC = 289
-JLOINE = 455
-JMAOAW = 279
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-JPUNRJ = 361
-JQRJJJ = 287
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-JUIKFW = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-JUTYEK = 3
-JVDQLA = 283
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYMOUN = 266
-KBDFSR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KFWRKI = "".join(chr(c) for c in [72, 69, 65, 84])
-KHTZBB = 344
-KINEJN = 379
-KJPUNR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-KLGQPL = 313
-KMLOIJ = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = 342
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = 322
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KWIVDN = 294
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-LAIIDN = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(chr(c) for c in [78, 79])
-LHBQNR = "".join(chr(c) for c in [75, 56])
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-LKXSJW = 270
-LOIJUG = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 56])
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LWUEUH = 458
-LXWAJV = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-MAOAWB = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = 369
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 51])
-MDMPSC = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-MEAOES = 65
-MFZDGK = "".join(chr(c) for c in [80, 52, 76])
-MHXEKV = 390
-MJIGYO = 381
-MJMAOA = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-MLOIJU = 316
-MNHTBJ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-MVCYWO = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 53])
-NBLKXS = 268
-NCUGUC = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-NELWUE = 457
-NFZCZO = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-NHTBJE = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-NIBXTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-NIBXYB = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-NKMLOI = 301
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-NNXWEE = 461
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NQJYMO = 264
-NQLNMH = "".join(chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87])
-NQTMFZ = "".join(chr(c) for c in [80, 51, 72])
-NRJZTA = "".join(chr(c) for c in [45, 45, 45])
-NRSJMC = 306
-NRXCHW = "".join(chr(c) for c in [75, 49, 48, 48])
-NXNKML = 300
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-NZMJIG = 380
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-OAWBSI = 280
-OCTHBS = 2
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 50])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-OIJUGS = "".join(chr(c) for c in [70, 117, 108, 108])
-OINELW = 456
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 475
-ONFZCZ = 472
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = "".join(chr(c) for c in [54, 52, 75])
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PMDMPS = 477
-PMXFUB = 452
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = 479
-PUNRJZ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = 354
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = 297
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-QLNMHX = "".join(chr(c) for c in [71, 69, 67, 75, 79, 55, 53, 48, 48, 87])
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-QPLSPF = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-QSNQLN = 389
-QTDKHT = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-QTMFZD = "".join(chr(c) for c in [80, 51, 76])
-QVXOIH = 328
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = "".join(chr(c) for c in [76, 73])
-RAZMKQ = 340
-RHYUAX = 373
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = 288
-RJZTAT = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-RKINEJ = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-ROGMDD = 449
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-RURAZM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-RXCHWD = "".join(chr(c) for c in [75, 56, 48, 48])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SAKQXP = 386
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-SCTTGC = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-SELHBQ = "".join(chr(c) for c in [75, 52, 48, 48])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-SIFJBI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SIPMDM = 476
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-SNQLNM = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(chr(c) for c in [67, 80, 79, 84])
-SPFTSI = 353
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = 332
-SSUHBV = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = 320
-TDKHTZ = 343
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-TDZXNQ = "".join(chr(c) for c in [80, 49, 72])
-TFMNHT = "".join(chr(c) for c in [105, 110, 88, 77])
-TGCRHY = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TIDUBS = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-TIXQVX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TMFZDG = "".join(chr(c) for c in [80, 52, 72])
-TOPHUG = "".join(chr(c) for c in [52, 56, 75])
-TSEMCG = 323
-TSIFJB = 355
-TTGCRH = 371
-TTIDUB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TZBBEK = 345
-UAXNCU = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-UBJLOI = 454
-UBSSUH = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-UBYGDS = 315
-UCYRAP = 375
-UEUHNN = 459
-UGSELH = 357
-UGTYIY = "".join(chr(c) for c in [85, 76])
-UHBVWV = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-UHNNXW = 460
-UIKFWR = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = 376
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [51, 50, 75])
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = 470
-VDNQGV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VDQLAI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-VDSSRU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-VEMVCY = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-VHFTHE = 6
-VKZILX = 350
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VUBYGD = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-VUNXNK = 299
-VWVUBY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [105, 110, 88, 69])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = 281
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-WIVDNQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-WSKWIV = 293
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-WVUBYG = 314
-XAIVEM = 467
-XBQFYL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-XEKVKZ = 284
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = 453
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-XLSXUJ = 260
-XNCUGU = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-XNKMLO = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-XNQTMF = "".join(chr(c) for c in [80, 50, 76])
-XOIHBX = 329
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-XSJWMN = 271
-XTIACQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-XWEEZF = 462
-XYBQSN = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-YEKCWA = 5
-YFCRTF = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-YGDSBD = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YIYWSK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YUAXNC = 374
-YWONFZ = 471
-YWSKWI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-YXBQFY = 377
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-ZDGKEA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ZFETDR = 464
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = 341
-ZOLSIP = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = "".join(chr(c) for c in [70, 97, 110])
-ZXNQTM = "".join(chr(c) for c in [80, 50, 72])
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-AMJMAO = [HECVYY, IAMJMA, IAMJMA, IAMJMA]
-APUMEA = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    RAPUME,
-]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-ETIXQV = [
-    ATDZXN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GETIXQ,
-]
-GKEAKS = [
-    ATDZXN,
-    TDZXNQ,
-    DZXNQT,
-    ZXNQTM,
-    XNQTMF,
-    NQTMFZ,
-    QTMFZD,
-    TMFZDG,
-    MFZDGK,
-    EXLSXU,
-    FZDGKE,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ZDGKEA,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    DGKEAK,
-]
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-IJUGSE = [LOIJUG, OIJUGS]
-JZTATD = [NRJZTA, RJZTAT]
-LNMHXE = [SNQLNM, NQLNMH, QLNMHX]
-LSXUJU = [FXQGLR, FEGZUQ]
-OKPHUO = [FXQGLR, SOKPHU]
-PHUGTY = [EUTOPH, UTOPHU, TOPHUG, OPHUGT]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PLSPFT = [LGQPLS, LRAHEO, GQPLSP, RAHEOC, QPLSPF]
-PUMEAO = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-SRURAZ = [
-    ATDZXN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-SUHBVW = [HECVYY, SSUHBV, SSUHBV, SSUHBV]
-TBJEUT = [
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-]
-TYIYWS = [UGTYIY, GTYIYW]
-UGUCYR = [UAXNCU, AXNCUG, XNCUGU, NCUGUC, CUGUCY]
-UMEAOE = [
-    YGDSBD,
-    XTIACQ,
-    ACQFFT,
-    QLAIID,
-    SIFJBI,
-    UHBVWV,
-    BYGDSB,
-    GDSBDJ,
-    MJMAOA,
-    USPBWJ,
-    NIBXTI,
-    IIDNIB,
-    LXWAJV,
-    SIRYXB,
-    VUBYGD,
-    AIIDNI,
-    IBXTIA,
-    DNIBXT,
-    VDQLAI,
-    CQFFTT,
-    AJVDQL,
-    XWAJVD,
-    TIACQF,
-    IDUBSS,
-    IACQFF,
-    WAJVDQ,
-    FFTTID,
-    IDNIBX,
-    LAIIDN,
-    DQLAII,
-]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VOACMC = [
-    ATDZXN,
-    TDZXNQ,
-    DZXNQT,
-    ZXNQTM,
-    XNQTMF,
-    NQTMFZ,
-    QTMFZD,
-    TMFZDG,
-    MFZDGK,
-    EXLSXU,
-    FZDGKE,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    ZVOACM,
-    HECVYY,
-    HECVYY,
-    ZDGKEA,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    DGKEAK,
-]
-WDAFIK = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-]
-WRKINE = [KFWRKI, FWRKIN]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-YBQSNQ = [
-    PQIPOU,
-    INEJNI,
-    NEJNIB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-]
-YRAPUM = []
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1581,340 +19,1272 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return MEAOES
+        return 65
 
     @property
     def begin(self):
-        return EAOESV
+        return 256
 
     @property
     def end(self):
-        return AOESVZ
+        return 479
 
     @property
     def all_device_keys(self):
-        return APUMEA
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return PUMEAO
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return UMEAOE
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, OCTHBS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, JUTYEK, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, HEOCTH, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, YEKCWA, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, OCTHBS, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, JUTYEK, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, YEKCWA, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, BWJYKL, VHFTHE, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, PLSPFT, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, YEKCWA, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, VHFTHE, None),
-            FTSIFJ: GeckoWordStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, JVHFTH, ICXQIE, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, XLSXUJ, YEKCWA, AMJMAO, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, ICXQIE, None),
-            BSIRYX: GeckoBoolStructAccessor(
-                self.struct, BSIRYX, WBSIRY, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, XPICXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, XPICXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FYLJUI, HEOCTH, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FYLJUI, YEKCWA, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, FYLJUI, VHFTHE, None),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, FYLJUI, CWAONP, WRKINE, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, YBQSNQ, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, LNMHXE, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            NMHXEK: GeckoWordStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, XEKVKZ, XPICXQ, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, XEKVKZ, ICXQIE, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, VKZILX, XPICXQ, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, VKZILX, ICXQIE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, ILXWAJ, XPICXQ, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, JVHFTH, JUTYEK, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, BWJYKL, XPICXQ, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, BWJYKL, ICXQIE, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, JVDQLA, OCTHBS, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, JVDQLA, JUTYEK, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, XEKVKZ, JUTYEK, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, XEKVKZ, HEOCTH, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, XEKVKZ, YEKCWA, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, XEKVKZ, VHFTHE, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, VKZILX, JUTYEK, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, VKZILX, HEOCTH, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, VKZILX, YEKCWA, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, VKZILX, VHFTHE, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, OCTHBS, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, BXTIAC, JUTYEK, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, IRYXBQ, JUTYEK, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, SPFTSI, XPICXQ, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, SPFTSI, ICXQIE, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, QFFTTI, XPICXQ, None),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, OAWBSI, XPICXQ, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, JVDQLA, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, JVDQLA, ICXQIE, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, JVDQLA, HEOCTH, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, BSSUHB, XPICXQ, None),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, BSSUHB, ICXQIE, SUHBVW, None, HEOCTH, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, BSSUHB, JUTYEK, None),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, WVUBYG, XPICXQ, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, UBYGDS, XPICXQ, None),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, UBYGDS, ICXQIE, None),
-            YGDSBD: GeckoBoolStructAccessor(self.struct, YGDSBD, BXTIAC, XPICXQ, None),
-            GDSBDJ: GeckoBoolStructAccessor(self.struct, GDSBDJ, BXTIAC, ICXQIE, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, BXTIAC, HEOCTH, None),
-            SBDJQR: GeckoWordStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, None),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, TBJEUT, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, XPICXQ, PHUGTY, None, HEOCTH, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, JEUTOP, OCTHBS, TYIYWS, None, OCTHBS, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            YIYWSK: GeckoWordStructAccessor(self.struct, YIYWSK, IYWSKW, None),
-            YWSKWI: GeckoByteStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoByteStructAccessor(self.struct, SKWIVD, KWIVDN, None),
-            WIVDNQ: GeckoByteStructAccessor(self.struct, WIVDNQ, IVDNQG, None),
-            VDNQGV: GeckoByteStructAccessor(self.struct, VDNQGV, DNQGVU, None),
-            NQGVUN: GeckoWordStructAccessor(self.struct, NQGVUN, QGVUNX, None),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoWordStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, IJUGSE, None, OCTHBS, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, WDAFIK, None, None, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DAFIKJ: GeckoWordStructAccessor(self.struct, DAFIKJ, AFIKJP, None),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, None),
-            KJPUNR: GeckoByteStructAccessor(self.struct, KJPUNR, JPUNRJ, None),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, JZTATD, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, TATDZX, None, GKEAKS, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            KEAKST: GeckoEnumStructAccessor(
-                self.struct, KEAKST, EAKSTS, None, GKEAKS, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, GKEAKS, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            STSEMC: GeckoEnumStructAccessor(
-                self.struct, STSEMC, TSEMCG, None, GKEAKS, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, EMCGET, None, GKEAKS, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, CGETIX, None, ETIXQV, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, AKQXPI),
-            XQVXOI: GeckoByteStructAccessor(self.struct, XQVXOI, QVXOIH, AKQXPI),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, AKQXPI),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, AKQXPI),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, AKQXPI),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, AKQXPI),
-            BHZVOA: GeckoEnumStructAccessor(
-                self.struct, BHZVOA, HZVOAC, None, VOACMC, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, CGETIX, None, VOACMC, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            ACMCVD: GeckoEnumStructAccessor(
-                self.struct, ACMCVD, IXQVXO, None, VOACMC, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            CMCVDS: GeckoEnumStructAccessor(
-                self.struct, CMCVDS, QVXOIH, None, VOACMC, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            MCVDSS: GeckoEnumStructAccessor(
-                self.struct, MCVDSS, XOIHBX, None, VOACMC, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            CVDSSR: GeckoEnumStructAccessor(
-                self.struct, CVDSSR, IHBXIB, None, VOACMC, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            VDSSRU: GeckoEnumStructAccessor(
-                self.struct, VDSSRU, BXIBHZ, None, VOACMC, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            DSSRUR: GeckoEnumStructAccessor(
-                self.struct, DSSRUR, SSRURA, None, SRURAZ, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, IBHZVO, None, SRURAZ, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            URAZMK: GeckoByteStructAccessor(self.struct, URAZMK, RAZMKQ, AKQXPI),
-            AZMKQT: GeckoByteStructAccessor(self.struct, AZMKQT, ZMKQTD, AKQXPI),
-            MKQTDK: GeckoByteStructAccessor(self.struct, MKQTDK, KQTDKH, AKQXPI),
-            QTDKHT: GeckoByteStructAccessor(self.struct, QTDKHT, TDKHTZ, AKQXPI),
-            DKHTZB: GeckoByteStructAccessor(self.struct, DKHTZB, KHTZBB, AKQXPI),
-            HTZBBE: GeckoByteStructAccessor(self.struct, HTZBBE, TZBBEK, AKQXPI),
-            ZBBEKB: GeckoByteStructAccessor(self.struct, ZBBEKB, BBEKBD, AKQXPI),
-            BEKBDF: GeckoByteStructAccessor(self.struct, BEKBDF, EKBDFS, AKQXPI),
-            KBDFSR: GeckoByteStructAccessor(self.struct, KBDFSR, BDFSRO, AKQXPI),
-            SCTTGC: GeckoBoolStructAccessor(self.struct, SCTTGC, JVHFTH, YEKCWA, None),
-            CTTGCR: GeckoByteStructAccessor(self.struct, CTTGCR, TTGCRH, AKQXPI),
-            TGCRHY: GeckoByteStructAccessor(self.struct, TGCRHY, GCRHYU, AKQXPI),
-            CRHYUA: GeckoByteStructAccessor(self.struct, CRHYUA, RHYUAX, AKQXPI),
-            HYUAXN: GeckoEnumStructAccessor(
-                self.struct, HYUAXN, YUAXNC, None, UGUCYR, None, None, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            GUCYRA: GeckoBoolStructAccessor(
-                self.struct, GUCYRA, UCYRAP, XPICXQ, AKQXPI
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            CYRAPU: GeckoBoolStructAccessor(self.struct, CYRAPU, UNRJZT, XPICXQ, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-66.py
+++ b/src/geckolib/driver/packs/inyt-log-66.py
@@ -12,1694 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-AFIKJP = "".join(chr(c) for c in [75, 49, 48, 48])
-AIIDNI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-AIVEMV = 464
-AJVDQL = 350
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [80, 52, 76])
-AOAWBS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-AONPYY = 310
-APUMEA = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-ATDZXN = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-BBEKBD = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-BDFSRO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-BDJQRJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BEKBDF = 343
-BFEGZU = 261
-BHZVOA = 329
-BIAMJM = 277
-BJEUTO = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BJLOIN = 451
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 384
-BQNRXC = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-BQSNQL = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        79,
-        117,
-        116,
-        108,
-        101,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-BSIRYX = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BSKSOK = 258
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-BVWVUB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-BWJYKL = 282
-BXIBHZ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-BXTIAC = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-BXYBQS = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-BYGDSB = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-CHWDAF = "".join(chr(c) for c in [75, 56])
-CMCVDS = 333
-CPQIPO = 263
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-CRHYUA = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-CRTFMN = 288
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-CUGUCY = 373
-CVDSSR = 325
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-CYWONF = 467
-CZOLSI = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-DAFIKJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-DDPMXF = "".join(chr(c) for c in [67, 70, 71, 48])
-DFSROG = 345
-DGKEAK = "".join(chr(c) for c in [80, 50, 76])
-DJQRJJ = 315
-DKHTZB = 340
-DMPSCT = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-DNIBXT = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-DNQGVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-DPMXFU = 448
-DQLAII = 383
-DRXAIV = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-DSBDJQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-DUBSSU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-DZXNQT = "".join(chr(c) for c in [45, 45, 45])
-EAKSTS = "".join(chr(c) for c in [80, 52, 72])
-EAOESV = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-EKBDFS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87, 95, 85, 76]
-)
-ELHBQN = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-ELWUEU = 454
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EMVCYW = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-EUHNNX = 456
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = 460
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = 461
-FFTTID = 351
-FIKJPU = "".join(chr(c) for c in [75, 56, 48, 48])
-FJBIAM = 275
-FJTACC = 262
-FMNHTB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-FSROGM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-FTTIDU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FUBJLO = 450
-FWRKIN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 378
-FZCZOL = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-FZDGKE = "".join(chr(c) for c in [80, 49, 76])
-GCRHYU = 478
-GDSBDJ = 311
-GETIXQ = 322
-GKEAKS = "".join(chr(c) for c in [80, 51, 72])
-GLRAHE = 259
-GMDDPM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-GQPLSP = "".join(chr(c) for c in [77, 69, 68])
-GSELHB = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-GTYIYW = "".join(chr(c) for c in [49, 54, 75])
-GUCYRA = 374
-GVUNXN = 294
-GYOUSP = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-HBXIBH = 327
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = 457
-HTBJEU = "".join(chr(c) for c in [77, 73, 65])
-HTZBBE = 341
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [75, 52])
-HXEKVK = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87, 95, 67, 69]
-)
-HYUAXN = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-HZVOAC = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-IACQFF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-IAMJMA = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IBHZVO = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-IBXTIA = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-IBXYBQ = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-ICXQIE = 1
-IDNIBX = 283
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IGYOUS = 273
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-IIDNIB = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-IJUGSE = 300
-IKFWRK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-IKJPUN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-ILXWAJ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-INELWU = 453
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = 473
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 352
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-IVEMVC = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-IYWSKW = "".join(chr(c) for c in [54, 52, 75])
-JBIAMJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JEUTOP = "".join(chr(c) for c in [105, 110, 88, 77])
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JLOINE = "".join(chr(c) for c in [67, 70, 71, 52])
-JMAOAW = 279
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-JPUNRJ = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JQRJJJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JUIKFW = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-JUTYEK = 3
-JVDQLA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-JVHFTH = 274
-JVYFCR = 285
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYMOUN = 266
-JZTATD = 360
-KBDFSR = 344
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KEAKST = "".join(chr(c) for c in [80, 51, 76])
-KFWRKI = "".join(chr(c) for c in [72, 69, 65, 84])
-KHTZBB = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KINEJN = 379
-KJPUNR = "".join(chr(c) for c in [75, 51, 48, 48])
-KLGQPL = 313
-KMLOIJ = 297
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = "".join(chr(c) for c in [66, 76, 79])
-KVKZIL = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 55, 53, 48, 48, 87, 95, 85, 76]
-)
-KWIVDN = "".join(chr(c) for c in [67, 69])
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(chr(c) for c in [78, 79])
-LHBQNR = "".join(chr(c) for c in [70, 117, 108, 108])
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-LKXSJW = 270
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-LOIJUG = 299
-LOINEL = 452
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = 472
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LWUEUH = "".join(chr(c) for c in [67, 70, 71, 55])
-LXWAJV = 284
-MAOAWB = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = 369
-MCGETI = 321
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-MDDPMX = 348
-MDMPSC = 474
-MEAOES = 375
-MFZDGK = "".join(chr(c) for c in [80, 49, 72])
-MHXEKV = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-MJIGYO = 381
-MJMAOA = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 332
-MLOIJU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-MNHTBJ = "".join(chr(c) for c in [105, 110, 88, 69])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = 475
-MVCYWO = 466
-MXFUBJ = 449
-NBLKXS = 268
-NCUGUC = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-NELWUE = "".join(chr(c) for c in [67, 70, 71, 54])
-NFZCZO = 469
-NHTBJE = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NIBXTI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-NIBXYB = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-NKMLOI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NMHXEK = 389
-NNXWEE = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = 293
-NQJYMO = 264
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-NRJZTA = 358
-NRSJMC = 306
-NRXCHW = "".join(chr(c) for c in [75, 50, 48, 48])
-NXNKML = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NXWEEZ = 458
-NZMJIG = 380
-OACMCV = 331
-OAWBSI = 280
-OCTHBS = 2
-OESVZS = "".join(chr(c) for c in [76, 73])
-OGMDDP = 347
-OIJUGS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-OINELW = "".join(chr(c) for c in [67, 70, 71, 53])
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-ONFZCZ = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = "".join(chr(c) for c in [105, 110, 89, 84])
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PMDMPS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-PMXFUB = "".join(chr(c) for c in [67, 70, 71, 49])
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        67,
-        104,
-        101,
-        99,
-        107,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = 357
-QPLSPF = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QRJJJV = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QSNQLN = 392
-QTDKHT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-QTMFZD = 320
-QVXOIH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-RAZMKQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-RHYUAX = 479
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RJZTAT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-RKINEJ = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-ROGMDD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-RURAZM = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-RXAIVE = 463
-RXCHWD = "".join(chr(c) for c in [75, 52, 48, 48])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SAKQXP = 386
-SBDJQR = 314
-SBVNAX = 479
-SCTTGC = 476
-SELHBQ = 316
-SIFJBI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SIPMDM = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = "".join(chr(c) for c in [85, 76])
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(chr(c) for c in [67, 80, 79, 84])
-SPFTSI = 353
-SROGMD = 346
-SRURAZ = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSBVNA = 256
-SSRURA = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SSUHBV = 387
-STSEMC = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SUHBVW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = 361
-TBJEUT = "".join(chr(c) for c in [68, 74, 83, 52])
-TDKHTZ = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-TDRXAI = 462
-TDZXNQ = 376
-TFMNHT = 289
-TGCRHY = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TIXQVX = 323
-TMFZDG = "".join(chr(c) for c in [78, 65])
-TOPHUG = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-TSEMCG = "".join(chr(c) for c in [65, 85, 88])
-TSIFJB = 355
-TTGCRH = 477
-TTIDUB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TYIYWS = "".join(chr(c) for c in [51, 50, 75])
-TZBBEK = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-UAXNCU = 371
-UBJLOI = "".join(chr(c) for c in [67, 70, 71, 51])
-UBSSUH = 354
-UCYRAP = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-UEUHNN = "".join(chr(c) for c in [67, 70, 71, 56])
-UGSELH = 301
-UGTYIY = 290
-UGUCYR = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-UHBVWV = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UHNNXW = "".join(chr(c) for c in [67, 70, 71, 57])
-UIKFWR = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UMEAOE = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UNXNKM = 295
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-VDNQGV = 291
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-VDSSRU = "".join(chr(c) for c in [70, 97, 110])
-VEMVCY = 465
-VHFTHE = 6
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-VUBYGD = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-VUNXNK = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VWVUBY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-VXOIHB = 326
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = 281
-WDAFIK = "".join(chr(c) for c in [75, 53])
-WEEZFE = 459
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = 468
-WSKWIV = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-WUEUHN = 455
-WVUBYG = 309
-XAIVEM = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-XBQFYL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = "".join(chr(c) for c in [75, 56, 53])
-XEKVKZ = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 55, 53, 48, 48, 87, 95, 67, 69]
-)
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = "".join(chr(c) for c in [67, 70, 71, 50])
-XIBHZV = 328
-XLSXUJ = 260
-XNCUGU = 372
-XNKMLO = 296
-XOIHBX = "".join(chr(c) for c in [72, 84, 82])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = 324
-XSJWMN = 271
-XTIACQ = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-XWEEZF = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XYBQSN = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-YEKCWA = 5
-YFCRTF = 287
-YGDSBD = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YIYWSK = "".join(chr(c) for c in [52, 56, 75])
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YRAPUM = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-YUAXNC = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-YWONFZ = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-YXBQFY = 377
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 342
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = 470
-ZDGKEA = "".join(chr(c) for c in [80, 50, 72])
-ZFETDR = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ZILXWA = 390
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-ZOLSIP = 471
-ZSSBVN = 66
-ZTATDZ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = 330
-ZXNQTM = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-AMJMAO = [HECVYY, IAMJMA, IAMJMA, IAMJMA]
-AOESVZ = []
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-DSSRUR = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    VDSSRU,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-ESVZSS = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    OESVZS,
-]
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-HBQNRX = [ELHBQN, LHBQNR]
-KQTDKH = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-LSXUJU = [FXQGLR, FEGZUQ]
-OIHBXI = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XOIHBX,
-]
-OKPHUO = [FXQGLR, SOKPHU]
-PHUGTY = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PLSPFT = [LGQPLS, LRAHEO, GQPLSP, RAHEOC, QPLSPF]
-PUMEAO = [UCYRAP, CYRAPU, YRAPUM, RAPUME, APUMEA]
-PUNRJZ = [
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-]
-SEMCGE = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-SVZSSB = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-UBYGDS = [HECVYY, VUBYGD, VUBYGD, VUBYGD]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VKZILX = [MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-VZSSBV = [
-    QRJJJV,
-    FTTIDU,
-    IDUBSS,
-    IBXTIA,
-    SIFJBI,
-    BYGDSB,
-    JQRJJJ,
-    RJJJVY,
-    MJMAOA,
-    USPBWJ,
-    CQFFTT,
-    TIACQF,
-    QLAIID,
-    SIRYXB,
-    BDJQRJ,
-    XTIACQ,
-    QFFTTI,
-    ACQFFT,
-    DNIBXT,
-    DUBSSU,
-    IIDNIB,
-    LAIIDN,
-    TTIDUB,
-    HBVWVU,
-    TIDUBS,
-    AIIDNI,
-    BSSUHB,
-    IACQFF,
-    BXTIAC,
-    NIBXTI,
-]
-WIVDNQ = [SKWIVD, KWIVDN]
-WRKINE = [KFWRKI, FWRKIN]
-XNQTMF = [DZXNQT, ZXNQTM]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-YBQSNQ = [
-    PQIPOU,
-    INEJNI,
-    NEJNIB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-]
-YWSKWI = [GTYIYW, TYIYWS, YIYWSK, IYWSKW]
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1707,344 +19,1290 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return ZSSBVN
+        return 66
 
     @property
     def begin(self):
-        return SSBVNA
+        return 256
 
     @property
     def end(self):
-        return SBVNAX
+        return 479
 
     @property
     def all_device_keys(self):
-        return ESVZSS
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return SVZSSB
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return VZSSBV
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, OCTHBS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, JUTYEK, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, HEOCTH, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, YEKCWA, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, OCTHBS, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, JUTYEK, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, YEKCWA, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, BWJYKL, VHFTHE, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, PLSPFT, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, YEKCWA, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, VHFTHE, None),
-            FTSIFJ: GeckoWordStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, JVHFTH, ICXQIE, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, XLSXUJ, YEKCWA, AMJMAO, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, ICXQIE, None),
-            BSIRYX: GeckoBoolStructAccessor(
-                self.struct, BSIRYX, WBSIRY, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, XPICXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, XPICXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FYLJUI, HEOCTH, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FYLJUI, YEKCWA, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, FYLJUI, VHFTHE, None),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, FYLJUI, CWAONP, WRKINE, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, YBQSNQ, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, QSNQLN, XPICXQ, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, QSNQLN, ICXQIE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QSNQLN, OCTHBS, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, QSNQLN, JUTYEK, None),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, NMHXEK, None, VKZILX, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            KZILXW: GeckoWordStructAccessor(self.struct, KZILXW, ZILXWA, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, LXWAJV, XPICXQ, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, LXWAJV, ICXQIE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, XPICXQ, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, AJVDQL, ICXQIE, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, DQLAII, XPICXQ, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, JVHFTH, JUTYEK, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, BWJYKL, XPICXQ, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, BWJYKL, ICXQIE, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, IDNIBX, OCTHBS, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, IDNIBX, JUTYEK, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, LXWAJV, JUTYEK, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, LXWAJV, HEOCTH, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, LXWAJV, YEKCWA, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, LXWAJV, VHFTHE, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, AJVDQL, JUTYEK, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, AJVDQL, HEOCTH, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, AJVDQL, YEKCWA, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, AJVDQL, VHFTHE, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, FFTTID, OCTHBS, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, FFTTID, JUTYEK, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, IRYXBQ, JUTYEK, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, SPFTSI, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, SPFTSI, ICXQIE, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, UBSSUH, XPICXQ, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, OAWBSI, XPICXQ, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, IDNIBX, XPICXQ, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, IDNIBX, ICXQIE, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, IDNIBX, HEOCTH, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, WVUBYG, XPICXQ, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, WVUBYG, ICXQIE, UBYGDS, None, HEOCTH, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, WVUBYG, JUTYEK, None),
-            YGDSBD: GeckoWordStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, SBDJQR, XPICXQ, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, DJQRJJ, XPICXQ, None),
-            JQRJJJ: GeckoBoolStructAccessor(self.struct, JQRJJJ, DJQRJJ, ICXQIE, None),
-            QRJJJV: GeckoBoolStructAccessor(self.struct, QRJJJV, FFTTID, XPICXQ, None),
-            RJJJVY: GeckoBoolStructAccessor(self.struct, RJJJVY, FFTTID, ICXQIE, None),
-            JJJVYF: GeckoBoolStructAccessor(self.struct, JJJVYF, FFTTID, HEOCTH, None),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, PHUGTY, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, XPICXQ, YWSKWI, None, HEOCTH, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, UGTYIY, OCTHBS, WIVDNQ, None, OCTHBS, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IVDNQG: GeckoWordStructAccessor(self.struct, IVDNQG, VDNQGV, None),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, None),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, None),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, None),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, None),
-            NKMLOI: GeckoWordStructAccessor(self.struct, NKMLOI, KMLOIJ, None),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, None),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, None),
-            JUGSEL: GeckoWordStructAccessor(self.struct, JUGSEL, UGSELH, None),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, HBQNRX, None, OCTHBS, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, PUNRJZ, None, None, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            UNRJZT: GeckoWordStructAccessor(self.struct, UNRJZT, NRJZTA, None),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, None),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, None),
-            ATDZXN: GeckoEnumStructAccessor(
-                self.struct, ATDZXN, TDZXNQ, None, XNQTMF, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, None, SEMCGE, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, SEMCGE, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, GETIXQ, None, SEMCGE, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, TIXQVX, None, SEMCGE, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, XQVXOI, None, SEMCGE, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, VXOIHB, None, OIHBXI, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            IHBXIB: GeckoByteStructAccessor(self.struct, IHBXIB, HBXIBH, AKQXPI),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, AKQXPI),
-            IBHZVO: GeckoByteStructAccessor(self.struct, IBHZVO, BHZVOA, AKQXPI),
-            HZVOAC: GeckoByteStructAccessor(self.struct, HZVOAC, ZVOACM, AKQXPI),
-            VOACMC: GeckoByteStructAccessor(self.struct, VOACMC, OACMCV, AKQXPI),
-            ACMCVD: GeckoByteStructAccessor(self.struct, ACMCVD, CMCVDS, AKQXPI),
-            MCVDSS: GeckoEnumStructAccessor(
-                self.struct, MCVDSS, CVDSSR, None, DSSRUR, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            SSRURA: GeckoEnumStructAccessor(
-                self.struct, SSRURA, VXOIHB, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            SRURAZ: GeckoEnumStructAccessor(
-                self.struct, SRURAZ, HBXIBH, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, XIBHZV, None, DSSRUR, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, BHZVOA, None, DSSRUR, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            RAZMKQ: GeckoEnumStructAccessor(
-                self.struct, RAZMKQ, ZVOACM, None, DSSRUR, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            AZMKQT: GeckoEnumStructAccessor(
-                self.struct, AZMKQT, OACMCV, None, DSSRUR, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, KQTDKH, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            QTDKHT: GeckoEnumStructAccessor(
-                self.struct, QTDKHT, CMCVDS, None, KQTDKH, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            TDKHTZ: GeckoByteStructAccessor(self.struct, TDKHTZ, DKHTZB, AKQXPI),
-            KHTZBB: GeckoByteStructAccessor(self.struct, KHTZBB, HTZBBE, AKQXPI),
-            TZBBEK: GeckoByteStructAccessor(self.struct, TZBBEK, ZBBEKB, AKQXPI),
-            BBEKBD: GeckoByteStructAccessor(self.struct, BBEKBD, BEKBDF, AKQXPI),
-            EKBDFS: GeckoByteStructAccessor(self.struct, EKBDFS, KBDFSR, AKQXPI),
-            BDFSRO: GeckoByteStructAccessor(self.struct, BDFSRO, DFSROG, AKQXPI),
-            FSROGM: GeckoByteStructAccessor(self.struct, FSROGM, SROGMD, AKQXPI),
-            ROGMDD: GeckoByteStructAccessor(self.struct, ROGMDD, OGMDDP, AKQXPI),
-            GMDDPM: GeckoByteStructAccessor(self.struct, GMDDPM, MDDPMX, AKQXPI),
-            HYUAXN: GeckoBoolStructAccessor(self.struct, HYUAXN, JVHFTH, YEKCWA, None),
-            YUAXNC: GeckoByteStructAccessor(self.struct, YUAXNC, UAXNCU, AKQXPI),
-            AXNCUG: GeckoByteStructAccessor(self.struct, AXNCUG, XNCUGU, AKQXPI),
-            NCUGUC: GeckoByteStructAccessor(self.struct, NCUGUC, CUGUCY, AKQXPI),
-            UGUCYR: GeckoEnumStructAccessor(
-                self.struct, UGUCYR, GUCYRA, None, PUMEAO, None, None, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            UMEAOE: GeckoBoolStructAccessor(
-                self.struct, UMEAOE, MEAOES, XPICXQ, AKQXPI
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            EAOESV: GeckoBoolStructAccessor(self.struct, EAOESV, TDZXNQ, XPICXQ, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                [
+                    "GENERIC",
+                    "GECKO_5000W_CE",
+                    "GECKO_7500W_CE",
+                    "GECKO_5000W_UL",
+                    "GECKO_7500W_UL",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-log-80.py
+++ b/src/geckolib/driver/packs/inyt-log-80.py
@@ -12,1644 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-AFIKJP = "".join(chr(c) for c in [75, 56, 53])
-AIIDNI = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-AJVDQL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [80, 52, 76])
-AMJMAO = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116])
-AOESVZ = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-AONPYY = 310
-APUMEA = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-ATDZXN = 358
-AWBSIR = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AXNCUG = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-AZMKQT = 328
-BBEKBD = 333
-BDFSRO = 341
-BDJQRJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BEKBDF = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-BFEGZU = 261
-BHZVOA = 337
-BIAMJM = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-BJEUTO = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 48])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-BQNRXC = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-BQSNQL = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-BSIRYX = 280
-BSKSOK = 258
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-BVNAXA = 256
-BVWVUB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-BWJYKL = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-BXIBHZ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-BXTIAC = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-BXYBQS = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-BYGDSB = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-CHWDAF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-CMCVDS = 349
-CPQIPO = 263
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-CRHYUA = 475
-CRTFMN = 288
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = 473
-CUGUCY = 479
-CVDSSR = 325
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-CYWONF = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-CZOLSI = 467
-DAFIKJ = "".join(chr(c) for c in [75, 52, 48, 48])
-DDPMXF = 345
-DFSROG = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-DGKEAK = "".join(chr(c) for c in [80, 50, 76])
-DJQRJJ = 315
-DKHTZB = 331
-DMPSCT = 471
-DNIBXT = 283
-DPMXFU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-DRXAIV = 459
-DSBDJQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-DUBSSU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-DZXNQT = 360
-EAKSTS = "".join(chr(c) for c in [80, 52, 72])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 456
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = 379
-EKBDFS = 340
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-ELHBQN = 300
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 51])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EMVCYW = 462
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = 458
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 53])
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 57])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-FFTTID = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-FIKJPU = "".join(chr(c) for c in [75, 56])
-FJBIAM = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-FJTACC = 262
-FMNHTB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-FSROGM = 342
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-FTTIDU = 351
-FUBJLO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-FWRKIN = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FZCZOL = 466
-FZDGKE = "".join(chr(c) for c in [80, 49, 76])
-GCRHYU = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-GDSBDJ = 311
-GETIXQ = 322
-GKEAKS = "".join(chr(c) for c in [80, 51, 72])
-GLRAHE = 259
-GMDDPM = 344
-GQPLSP = "".join(chr(c) for c in [78, 79])
-GSELHB = 299
-GTYIYW = "".join(chr(c) for c in [49, 54, 75])
-GUCYRA = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-GYOUSP = "".join(chr(c) for c in [70, 105, 108, 116, 82, 101, 113, 117, 101, 115, 116])
-HBQNRX = 301
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-HBXIBH = 335
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 54])
-HTBJEU = "".join(chr(c) for c in [77, 73, 65])
-HTZBBE = 332
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = 357
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-HYUAXN = 476
-HZVOAC = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-IACQFF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IAMJMA = 277
-IBHZVO = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-IBXTIA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-IBXYBQ = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-ICXQIE = 1
-IDNIBX = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-IGYOUS = 273
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-IIDNIB = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-IJUGSE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-IKFWRK = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-IKJPUN = "".join(chr(c) for c in [75, 52])
-ILXWAJ = 390
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50])
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 281
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = "".join(chr(c) for c in [52, 84, 72, 95, 71, 69, 78])
-IVEMVC = 461
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-IYWSKW = "".join(chr(c) for c in [54, 52, 75])
-JBIAMJ = 275
-JEUTOP = "".join(chr(c) for c in [105, 110, 88, 77])
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JLOINE = 448
-JMAOAW = "".join(chr(c) for c in [78, 101, 97, 114, 72, 76])
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-JPUNRJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JQRJJJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = 297
-JUIKFW = 378
-JUTYEK = 3
-JVDQLA = 350
-JVHFTH = 274
-JVYFCR = 285
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JYMOUN = 266
-JZTATD = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-KBDFSR = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KEAKST = "".join(chr(c) for c in [80, 51, 76])
-KFWRKI = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-KHTZBB = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(chr(c) for c in [75, 53])
-KLGQPL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-KMLOIJ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = "".join(chr(c) for c in [66, 76, 79])
-KVKZIL = "".join(chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87])
-KWIVDN = "".join(chr(c) for c in [50, 78, 68, 95, 71, 69, 78])
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = 313
-LHBQNR = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-LKXSJW = 270
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-LOIJUG = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 49])
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-LWUEUH = 451
-LXWAJV = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-MAOAWB = 279
-MCBFEG = 369
-MCGETI = 321
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-MDDPMX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-MDMPSC = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-MEAOES = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-MFZDGK = "".join(chr(c) for c in [80, 49, 72])
-MHXEKV = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        67,
-        104,
-        101,
-        99,
-        107,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-MJIGYO = 381
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 329
-MLOIJU = 295
-MNHTBJ = "".join(chr(c) for c in [105, 110, 88, 69])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-MVCYWO = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MXFUBJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-NBLKXS = 268
-NCUGUC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-NEJNIB = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-NELWUE = 450
-NFZCZO = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-NHTBJE = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NIBXTI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-NIBXYB = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-NKMLOI = 294
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-NNXWEE = 454
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = 8
-NQJYMO = 264
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        79,
-        117,
-        116,
-        108,
-        101,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-NRJZTA = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-NRSJMC = 306
-NRXCHW = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-NXNKML = 293
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 55])
-NZMJIG = 380
-OACMCV = 339
-OAWBSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-OCTHBS = 2
-OESVZS = 375
-OGMDDP = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-OIJUGS = 296
-OINELW = 449
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 468
-ONFZCZ = 465
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = "".join(chr(c) for c in [105, 110, 89, 84])
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(chr(c) for c in [67, 80, 79, 84])
-PFTSIF = 353
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PLSPFT = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-PMDMPS = 470
-PMXFUB = 346
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = 472
-PUMEAO = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-PUNRJZ = "".join(chr(c) for c in [75, 49, 48, 48])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-QFYLJU = 377
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 50, 53, 54, 75])
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = 383
-QLNMHX = 392
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = 316
-QPLSPF = "".join(chr(c) for c in [77, 69, 68])
-QRJJJV = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QSNQLN = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-QTDKHT = 330
-QTMFZD = 320
-QVXOIH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-RAZMKQ = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-RHYUAX = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RJZTAT = "".join(chr(c) for c in [75, 51, 48, 48])
-RKINEJ = "".join(chr(c) for c in [72, 69, 65, 84])
-ROGMDD = 343
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-RURAZM = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-RXCHWD = "".join(chr(c) for c in [70, 117, 108, 108])
-RYXBQF = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-SAKQXP = 386
-SBDJQR = 314
-SBVNAX = 80
-SCTTGC = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-SELHBQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SIFJBI = 355
-SIPMDM = 469
-SIRYXB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = "".join(chr(c) for c in [49, 83, 84, 95, 71, 69, 78])
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-SPFTSI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SROGMD = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-SRURAZ = 326
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SSUHBV = 387
-STSEMC = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SUHBVW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SVZSSB = "".join(chr(c) for c in [76, 73])
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-TBJEUT = "".join(chr(c) for c in [68, 74, 83, 52])
-TDKHTZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-TDZXNQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-TFMNHT = 289
-TGCRHY = 474
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TIXQVX = 323
-TMFZDG = "".join(chr(c) for c in [78, 65])
-TOPHUG = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-TSEMCG = "".join(chr(c) for c in [65, 85, 88])
-TSIFJB = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-TTGCRH = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-TTIDUB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TYIYWS = "".join(chr(c) for c in [51, 50, 75])
-UAXNCU = 477
-UBJLOI = 348
-UBSSUH = 354
-UCYRAP = 371
-UEUHNN = 452
-UGSELH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-UGTYIY = 290
-UGUCYR = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-UHBVWV = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UHNNXW = 453
-UIKFWR = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UMEAOE = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = "".join(chr(c) for c in [75, 56, 48, 48])
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = 327
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = 463
-VDNQGV = "".join(chr(c) for c in [53, 84, 72, 95, 71, 69, 78])
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-VDSSRU = "".join(chr(c) for c in [70, 97, 110])
-VEMVCY = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [71, 69, 67, 75, 79, 55, 53, 48, 48, 87])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VNAXAD = 479
-VOACMC = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-VUBYGD = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-VUNXNK = 291
-VWVUBY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-VXOIHB = 334
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-WDAFIK = "".join(chr(c) for c in [75, 50, 48, 48])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 56])
-WIVDNQ = "".join(chr(c) for c in [51, 82, 68, 95, 71, 69, 78])
-WJYKLG = 282
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-WRKINE = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-WSKWIV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 71, 101, 110, 101, 114, 97, 116, 105, 111, 110]
-)
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 52])
-WVUBYG = 309
-XAIVEM = 460
-XBQFYL = 352
-XEKVKZ = 389
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = 347
-XIBHZV = 336
-XLSXUJ = 260
-XNCUGU = 478
-XNKMLO = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-XNQTMF = 361
-XOIHBX = "".join(chr(c) for c in [72, 84, 82])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = 324
-XSJWMN = 271
-XTIACQ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = 284
-XWEEZF = 455
-XYBQSN = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-YBQSNQ = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-YEKCWA = 5
-YFCRTF = 287
-YGDSBD = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YIYWSK = "".join(chr(c) for c in [52, 56, 75])
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = 384
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YRAPUM = 374
-YUAXNC = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-YWONFZ = 464
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ZDGKEA = "".join(chr(c) for c in [80, 50, 72])
-ZFETDR = 457
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-ZOLSIP = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = 338
-ZXNQTM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-DNQGVU = [SKWIVD, KWIVDN, HECVYY, WIVDNQ, HECVYY, IVDNQG, HECVYY, VDNQGV]
-DSSRUR = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    VDSSRU,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-EAOESV = [RAPUME, APUMEA, PUMEAO, UMEAOE, MEAOES]
-ESVZSS = []
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-INEJNI = [RKINEJ, KINEJN]
-KZILXW = [EKVKZI, KVKZIL, VKZILX]
-LSPFTS = [GQPLSP, LRAHEO, QPLSPF, RAHEOC, PLSPFT]
-LSXUJU = [FXQGLR, FEGZUQ]
-MJMAOA = [HECVYY, AMJMAO, AMJMAO, AMJMAO]
-OIHBXI = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XOIHBX,
-]
-OKPHUO = [FXQGLR, SOKPHU]
-PHUGTY = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-SEMCGE = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-SNQLNM = [
-    PQIPOU,
-    JNIBXY,
-    NIBXYB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-    YBQSNQ,
-    BQSNQL,
-    QSNQLN,
-]
-SSBVNA = [
-    QRJJJV,
-    TTIDUB,
-    IDUBSS,
-    BXTIAC,
-    IFJBIA,
-    BYGDSB,
-    JQRJJJ,
-    RJJJVY,
-    OAWBSI,
-    SPBWJY,
-    QFFTTI,
-    IACQFF,
-    YXBQFY,
-    BDJQRJ,
-    TIACQF,
-    FFTTID,
-    CQFFTT,
-    NIBXTI,
-    DUBSSU,
-    IDNIBX,
-    AIIDNI,
-    HBVWVU,
-    TIDUBS,
-    IIDNIB,
-    BSSUHB,
-    ACQFFT,
-    XTIACQ,
-    IBXTIA,
-]
-TZBBEK = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-UBYGDS = [HECVYY, VUBYGD, VUBYGD, VUBYGD]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VZSSBV = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    SVZSSB,
-]
-XCHWDA = [NRXCHW, RXCHWD]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-YWSKWI = [GTYIYW, TYIYWS, YIYWSK, IYWSKW]
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-ZSSBVN = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-ZTATDZ = [
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1657,341 +19,1284 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return SBVNAX
+        return 80
 
     @property
     def begin(self):
-        return BVNAXA
+        return 256
 
     @property
     def end(self):
-        return VNAXAD
+        return 479
 
     @property
     def all_device_keys(self):
-        return VZSSBV
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return ZSSBVN
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return SSBVNA
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, ICXQIE, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, OCTHBS, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, JUTYEK, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, HEOCTH, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, IGYOUS, YEKCWA, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, JVHFTH, OCTHBS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, WJYKLG, JUTYEK, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, WJYKLG, YEKCWA, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, WJYKLG, VHFTHE, None),
-            KLGQPL: GeckoEnumStructAccessor(
-                self.struct, KLGQPL, LGQPLS, None, LSPFTS, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, YEKCWA, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoWordStructAccessor(self.struct, TSIFJB, SIFJBI, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, ICXQIE, None),
-            FJBIAM: GeckoTempStructAccessor(self.struct, FJBIAM, JBIAMJ, None),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, None),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, XLSXUJ, YEKCWA, MJMAOA, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, XPICXQ, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, MAOAWB, ICXQIE, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, MAOAWB, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, MAOAWB, VHFTHE, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, BSIRYX, OCTHBS, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoBoolStructAccessor(
-                self.struct, RYXBQF, IRYXBQ, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, ICXQIE, None),
-            BQFYLJ: GeckoByteStructAccessor(self.struct, BQFYLJ, QFYLJU, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, YLJUIK, XPICXQ, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, JUIKFW, XPICXQ, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, JUIKFW, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, JUIKFW, HEOCTH, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, JUIKFW, YEKCWA, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, JUIKFW, VHFTHE, None),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, JUIKFW, CWAONP, INEJNI, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            NEJNIB: GeckoEnumStructAccessor(
-                self.struct, NEJNIB, EJNIBX, None, SNQLNM, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QLNMHX, XPICXQ, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, QLNMHX, ICXQIE, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, QLNMHX, OCTHBS, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, QLNMHX, JUTYEK, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, KZILXW, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            ZILXWA: GeckoWordStructAccessor(self.struct, ZILXWA, ILXWAJ, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, XWAJVD, XPICXQ, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, XWAJVD, ICXQIE, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, JVDQLA, XPICXQ, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, JVDQLA, ICXQIE, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, QLAIID, XPICXQ, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, QLAIID, ICXQIE, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, WJYKLG, XPICXQ, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, WJYKLG, ICXQIE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, OCTHBS, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, DNIBXT, JUTYEK, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, XWAJVD, JUTYEK, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, XWAJVD, HEOCTH, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, XWAJVD, YEKCWA, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, XWAJVD, VHFTHE, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, JVDQLA, JUTYEK, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, JVDQLA, HEOCTH, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, JVDQLA, YEKCWA, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, JVDQLA, VHFTHE, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, FTTIDU, OCTHBS, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, FTTIDU, JUTYEK, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, PFTSIF, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, PFTSIF, ICXQIE, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, UBSSUH, XPICXQ, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, BSIRYX, XPICXQ, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, DNIBXT, XPICXQ, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, DNIBXT, ICXQIE, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, DNIBXT, HEOCTH, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, WVUBYG, XPICXQ, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, WVUBYG, ICXQIE, UBYGDS, None, HEOCTH, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, WVUBYG, JUTYEK, None),
-            YGDSBD: GeckoWordStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, SBDJQR, XPICXQ, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, DJQRJJ, XPICXQ, None),
-            JQRJJJ: GeckoBoolStructAccessor(self.struct, JQRJJJ, DJQRJJ, ICXQIE, None),
-            QRJJJV: GeckoBoolStructAccessor(self.struct, QRJJJV, FTTIDU, XPICXQ, None),
-            RJJJVY: GeckoBoolStructAccessor(self.struct, RJJJVY, FTTIDU, ICXQIE, None),
-            JJJVYF: GeckoBoolStructAccessor(self.struct, JJJVYF, FTTIDU, HEOCTH, None),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, PHUGTY, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, XPICXQ, YWSKWI, None, HEOCTH, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, UGTYIY, JUTYEK, DNQGVU, None, NQGVUN, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            QGVUNX: GeckoBoolStructAccessor(self.struct, QGVUNX, UGTYIY, VHFTHE, None),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, None),
-            IJUGSE: GeckoWordStructAccessor(self.struct, IJUGSE, JUGSEL, None),
-            UGSELH: GeckoByteStructAccessor(self.struct, UGSELH, GSELHB, None),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, None),
-            LHBQNR: GeckoWordStructAccessor(self.struct, LHBQNR, HBQNRX, None),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, XCHWDA, None, OCTHBS, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, ZTATDZ, None, None, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TATDZX: GeckoWordStructAccessor(self.struct, TATDZX, ATDZXN, None),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, None),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, None),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, None, SEMCGE, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, SEMCGE, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, GETIXQ, None, SEMCGE, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, TIXQVX, None, SEMCGE, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, XQVXOI, None, SEMCGE, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, VXOIHB, None, OIHBXI, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IHBXIB: GeckoByteStructAccessor(self.struct, IHBXIB, HBXIBH, AKQXPI),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, AKQXPI),
-            IBHZVO: GeckoByteStructAccessor(self.struct, IBHZVO, BHZVOA, AKQXPI),
-            HZVOAC: GeckoByteStructAccessor(self.struct, HZVOAC, ZVOACM, AKQXPI),
-            VOACMC: GeckoByteStructAccessor(self.struct, VOACMC, OACMCV, AKQXPI),
-            ACMCVD: GeckoByteStructAccessor(self.struct, ACMCVD, CMCVDS, AKQXPI),
-            MCVDSS: GeckoEnumStructAccessor(
-                self.struct, MCVDSS, CVDSSR, None, DSSRUR, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            SSRURA: GeckoEnumStructAccessor(
-                self.struct, SSRURA, SRURAZ, None, DSSRUR, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
             ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, URAZMK, None, DSSRUR, None, None, AKQXPI
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            RAZMKQ: GeckoEnumStructAccessor(
-                self.struct, RAZMKQ, AZMKQT, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, QTDKHT, None, DSSRUR, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            TDKHTZ: GeckoEnumStructAccessor(
-                self.struct, TDKHTZ, DKHTZB, None, DSSRUR, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            KHTZBB: GeckoEnumStructAccessor(
-                self.struct, KHTZBB, HTZBBE, None, TZBBEK, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            ZBBEKB: GeckoEnumStructAccessor(
-                self.struct, ZBBEKB, BBEKBD, None, TZBBEK, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            BEKBDF: GeckoByteStructAccessor(self.struct, BEKBDF, EKBDFS, AKQXPI),
-            KBDFSR: GeckoByteStructAccessor(self.struct, KBDFSR, BDFSRO, AKQXPI),
-            DFSROG: GeckoByteStructAccessor(self.struct, DFSROG, FSROGM, AKQXPI),
-            SROGMD: GeckoByteStructAccessor(self.struct, SROGMD, ROGMDD, AKQXPI),
-            OGMDDP: GeckoByteStructAccessor(self.struct, OGMDDP, GMDDPM, AKQXPI),
-            MDDPMX: GeckoByteStructAccessor(self.struct, MDDPMX, DDPMXF, AKQXPI),
-            DPMXFU: GeckoByteStructAccessor(self.struct, DPMXFU, PMXFUB, AKQXPI),
-            MXFUBJ: GeckoByteStructAccessor(self.struct, MXFUBJ, XFUBJL, AKQXPI),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, AKQXPI),
-            UGUCYR: GeckoBoolStructAccessor(self.struct, UGUCYR, JVHFTH, YEKCWA, None),
-            GUCYRA: GeckoByteStructAccessor(self.struct, GUCYRA, UCYRAP, AKQXPI),
-            CYRAPU: GeckoEnumStructAccessor(
-                self.struct, CYRAPU, YRAPUM, None, EAOESV, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            AOESVZ: GeckoBoolStructAccessor(
-                self.struct, AOESVZ, OESVZS, XPICXQ, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyt-log-81.py
+++ b/src/geckolib/driver/packs/inyt-log-81.py
@@ -12,1700 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 52])
-ACMCVD = 320
-ACQFFT = 390
-ADXLUB = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-AFIKJP = "".join(
-    chr(c) for c in [80, 97, 99, 107, 71, 101, 110, 101, 114, 97, 116, 105, 111, 110]
-)
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-AIVEMV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-AJVDQL = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-AMJMAO = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-AOAWBS = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-AOESVZ = 467
-AONPYY = "".join(chr(c) for c in [67, 80])
-APUMEA = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-ATDZXN = 293
-AWBSIR = "".join(chr(c) for c in [78, 79])
-AXADXL = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-AXNCUG = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-AZMKQT = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-BBEKBD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-BDFSRO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-BDJQRJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-BEKBDF = 334
-BFEGZU = 304
-BGJFJN = 476
-BHZVOA = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-BIAMJM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BJEUTO = "".join(chr(c) for c in [86, 83, 80, 50, 67, 111, 109, 109, 76, 111, 115, 116])
-BLKXSJ = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-BMIKGN = 479
-BMJVHF = 256
-BQFYLJ = 355
-BQNRXC = "".join(chr(c) for c in [105, 110, 89, 84])
-BQSNQL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-BSIRYX = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-BSKSOK = 258
-BSSUHB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BVNAXA = 471
-BVWVUB = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-BWJYKL = 268
-BXTIAC = "".join(chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87])
-BXYBQS = 352
-BYGDSB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-CBFEGZ = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-CCPQIP = 401
-CGETIX = "".join(chr(c) for c in [75, 50, 48, 48])
-CHWDAF = "".join(chr(c) for c in [51, 50, 75])
-CMCVDS = "".join(chr(c) for c in [78, 65])
-CPQIPO = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 53])
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-CRHYUA = 457
-CRTFMN = "".join(chr(c) for c in [86, 83, 80, 51, 69, 114, 114, 111, 114, 73, 68])
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = 455
-CUGUCY = 461
-CVDSSR = "".join(chr(c) for c in [80, 49, 76])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = 463
-CYWONF = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-CZOLSI = 449
-DDPMXF = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-DFSROG = 335
-DGKEAK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-DJQRJJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-DKHTZB = 322
-DMPSCT = 453
-DNIBXT = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-DNQGVU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-DPMXFU = 339
-DRXAIV = 342
-DSBDJQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-DSSRUR = "".join(chr(c) for c in [80, 50, 76])
-DUBSSU = 383
-DXLUBG = 474
-DZXNQT = 294
-EAKSTS = 301
-EAOESV = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 333
-EFJTAC = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 50])
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = 305
-EJNIBX = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-EKBDFS = "".join(chr(c) for c in [72, 84, 82])
-EKCWAO = "".join(chr(c) for c in [80, 53])
-EKVKZI = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-ELHBQN = "".join(chr(c) for c in [75, 54, 48, 48])
-ELWUEU = 328
-EMCGET = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-EMVCYW = 345
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ESVZSS = 468
-ETDRXA = 341
-ETIXQV = "".join(chr(c) for c in [75, 56, 53])
-EUHNNX = 330
-EUTOPH = "".join(chr(c) for c in [86, 83, 80, 52, 67, 111, 109, 109, 76, 111, 115, 116])
-EXLSXU = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-EZFETD = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-FCRTFM = 404
-FEFJTA = 398
-FEGZUQ = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-FETDRX = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-FIKJPU = "".join(chr(c) for c in [49, 83, 84, 95, 71, 69, 78])
-FJBIAM = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-FJNTTU = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-FJTACC = 399
-FLSIJU = 374
-FMNHTB = 406
-FSROGM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-FTTIDU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-FUBJLO = 325
-FWRKIN = 279
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-FZCZOL = 448
-FZDGKE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GCRHYU = "".join(chr(c) for c in [67, 70, 71, 57])
-GDSBDJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-GETIXQ = "".join(chr(c) for c in [75, 52, 48, 48])
-GJFJNT = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-GKEAKS = 300
-GLRAHE = 259
-GMDDPM = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-GQPLSP = 272
-GSELHB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-GTYIYW = 309
-GUCYRA = 462
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-GZUQEX = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-HBQNRX = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-HBXIBH = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 49])
-HNNXWE = 331
-HTBJEU = "".join(chr(c) for c in [86, 83, 80, 49, 67, 111, 109, 109, 76, 111, 115, 116])
-HTZBBE = 323
-HUGTYI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [52, 56, 75])
-HXEKVK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-HYUAXN = 458
-HZVOAC = 360
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [67, 80, 79, 84])
-IBHZVO = 358
-IBXTIA = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-IBXYBQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-ICXQIE = 1
-IDNIBX = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        67,
-        104,
-        101,
-        99,
-        107,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-IGYOUS = 264
-IHBXIB = "".join(chr(c) for c in [75, 51, 48, 48])
-IIDNIB = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-IJUZMR = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-IKJPUN = "".join(chr(c) for c in [50, 78, 68, 95, 71, 69, 78])
-ILXWAJ = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-INEJNI = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-INELWU = 327
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(chr(c) for c in [67, 70, 71, 52])
-IPOUYN = 310
-IRYXBQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IUSOOQ = 393
-IUXFEF = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-IVDNQG = 315
-IVEMVC = 344
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [75, 52])
-IYWSKW = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-JBIAMJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-JEUTOP = "".join(chr(c) for c in [86, 83, 80, 51, 67, 111, 109, 109, 76, 111, 115, 116])
-JFJNTT = 477
-JHIUSO = 370
-JIGYOU = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JJJVYF = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-JJVYFC = 387
-JLOINE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-JMAOAW = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-JMCBFE = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-JNIBXY = 281
-JNTTUV = 478
-JPUNRJ = "".join(chr(c) for c in [52, 84, 72, 95, 71, 69, 78])
-JQRJJJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 51])
-JUGSEL = "".join(chr(c) for c in [77, 73, 65])
-JUIKFW = 277
-JUZMRK = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-JVDQLA = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [86, 83, 80, 49, 69, 114, 114, 111, 114, 73, 68])
-JWMNZM = "".join(chr(c) for c in [73, 68, 76, 69])
-JYKLGQ = 270
-JYMOUN = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-JZTATD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-KCWAON = 260
-KEAKST = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-KFWRKI = "".join(chr(c) for c in [78, 101, 97, 114, 72, 76])
-KHTZBB = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-KINEJN = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-KJPUNR = "".join(chr(c) for c in [51, 82, 68, 95, 71, 69, 78])
-KLGQPL = 271
-KMLOIJ = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = 316
-KWIVDN = 314
-KZILXW = 379
-LAIIDN = 392
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LHBQNR = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-LIUXFE = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-LJUIKF = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-LKXSJW = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-LOIJUG = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-LOINEL = 326
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIJUZ = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-LSIPMD = "".join(chr(c) for c in [67, 70, 71, 51])
-LSPFTS = 380
-LSXUJU = "".join(chr(c) for c in [80, 49])
-LUBGJF = 475
-LWUEUH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-LXWAJV = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-MAOAWB = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MCBFEG = 303
-MCGETI = 357
-MCVDSS = "".join(chr(c) for c in [80, 49, 72])
-MDDPMX = 338
-MDMPSC = "".join(chr(c) for c in [67, 70, 71, 53])
-MEAOES = 466
-MFZDGK = 297
-MHXEKV = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-MJMAOA = 282
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MLOIJU = 289
-MNHTBJ = "".join(chr(c) for c in [86, 83, 80, 53, 69, 114, 114, 111, 114, 73, 68])
-MNZMJI = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-MOUNBL = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-MPSCTT = "".join(chr(c) for c in [67, 70, 71, 54])
-MRKVFC = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-MVCYWO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-MXFUBJ = 349
-NAXADX = 472
-NBLKXS = 262
-NCUGUC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-NEJNIB = 280
-NELWUE = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-NFZCZO = "".join(chr(c) for c in [67, 70, 71, 48])
-NHTBJE = 407
-NIBXTI = 389
-NIBXYB = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-NKMLOI = 288
-NMHXEK = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-NNXWEE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-NPYYLI = 3
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-NQJYMO = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-NQLNMH = 378
-NQTMFZ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NRJZTA = 8
-NRSJMC = 396
-NRXCHW = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-NTTUVR = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-NXNKML = 287
-NXWEEZ = 332
-NZMJIG = "".join(chr(c) for c in [78, 69, 87])
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-OAWBSI = 313
-OCTHBS = 2
-OESVZS = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-OGMDDP = 337
-OIHBXI = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-OIJUGS = "".join(chr(c) for c in [105, 110, 88, 69])
-OINELW = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 450
-ONFZCZ = 348
-ONPYYL = "".join(chr(c) for c in [79, 51])
-OOQNRS = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 51])
-OPHUGT = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-OQNRSJ = 395
-OUBMIK = 81
-OUNBLK = 367
-OUSPBW = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-OUYNQJ = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-PFTSIF = 381
-PHUGTY = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PLSPFT = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-PMDMPS = 452
-PMXFUB = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-POUYNQ = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-PQIPOU = 402
-PSCTTG = 454
-PUMEAO = 465
-PUNRJZ = "".join(chr(c) for c in [53, 84, 72, 95, 71, 69, 78])
-PYYLIU = "".join(chr(c) for c in [76, 49, 50, 48])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = 362
-QFFTTI = 284
-QFYLJU = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-QJYMOU = 364
-QLAIID = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        79,
-        117,
-        116,
-        108,
-        101,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 52])
-QPLSPF = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-QRJJJV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-QSNQLN = 384
-QTDKHT = 321
-QTMFZD = 296
-QVXOIH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = 464
-RAZMKQ = "".join(chr(c) for c in [66, 76, 79])
-RFLSIJ = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-RHYUAX = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = 354
-RJZTAT = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 50, 53, 54, 75])
-RKINEJ = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-RKVFCP = 375
-ROGMDD = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-RSJMCB = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 53])
-RTFMNH = 405
-RURAZM = "".join(chr(c) for c in [80, 52, 72])
-RXAIVE = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-RXCHWD = 290
-RYXBQF = 353
-SAKQXP = 386
-SBDJQR = 351
-SBVNAX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-SCTTGC = "".join(chr(c) for c in [67, 70, 71, 55])
-SELHBQ = "".join(chr(c) for c in [105, 110, 88, 77])
-SIFJBI = "".join(chr(c) for c in [70, 105, 108, 116, 82, 101, 113, 117, 101, 115, 116])
-SIJUZM = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-SIPMDM = 451
-SJMCBF = 397
-SJWMNZ = 263
-SKWIVD = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 394
-SPBWJY = 267
-SPFTSI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-SROGMD = 336
-SRURAZ = "".join(chr(c) for c in [80, 51, 76])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSBVNA = 470
-SSRURA = "".join(chr(c) for c in [80, 51, 72])
-SSUHBV = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-STSEMC = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-SUHBVW = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-SVZSSB = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-SXUJUT = 261
-TACCPQ = 400
-TATDZX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TBJEUT = 408
-TDKHTZ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-TDRXAI = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-TDZXNQ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TFMNHT = "".join(chr(c) for c in [86, 83, 80, 52, 69, 114, 114, 111, 114, 73, 68])
-TGCRHY = 456
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-TIXQVX = "".join(chr(c) for c in [75, 56])
-TMFZDG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TOPHUG = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-TSEMCG = "".join(chr(c) for c in [70, 117, 108, 108])
-TSIFJB = 273
-TTGCRH = "".join(chr(c) for c in [67, 70, 71, 56])
-TTIDUB = 350
-TTUVRF = 479
-TUVRFL = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-TYEKCW = "".join(chr(c) for c in [80, 51])
-TYIYWS = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-TZBBEK = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-UAXNCU = 459
-UBGJFJ = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-UBJLOI = "".join(chr(c) for c in [70, 97, 110])
-UBMIKG = 256
-UBSSUH = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-    ]
-)
-UBYGDS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-UCYRAP = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-UEUHNN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-UGSELH = "".join(chr(c) for c in [68, 74, 83, 52])
-UGTYIY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-UGUCYR = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-UHBVWV = 283
-UHNNXW = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-UIKFWR = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-UJUTYE = "".join(chr(c) for c in [76, 79, 87])
-UMEAOE = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-UNBLKX = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-UOJRJH = 307
-UQEXLS = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-URAZMK = "".join(chr(c) for c in [80, 52, 76])
-USOOQN = "".join(chr(c) for c in [85, 100, 83, 112, 101, 101, 100, 86, 83, 80, 50])
-USPBWJ = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-UTOPHU = "".join(chr(c) for c in [86, 83, 80, 53, 67, 111, 109, 109, 76, 111, 115, 116])
-UTYEKC = "".join(chr(c) for c in [80, 50])
-UVRFLS = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-UXFEFJ = 7
-UYNQJY = "".join(chr(c) for c in [70, 85, 76, 76])
-UZMRKV = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-VCYWON = 346
-VDNQGV = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-VDQLAI = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-VDSSRU = "".join(chr(c) for c in [80, 50, 72])
-VEMVCY = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-VFCPOU = "".join(chr(c) for c in [76, 73])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VNAXAD = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-VOACMC = 361
-VRFLSI = 371
-VUBYGD = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-VUNXNK = 285
-VWVUBY = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-VXOIHB = "".join(chr(c) for c in [75, 49, 48, 48])
-VYFCRT = 403
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-VZSSBV = 469
-WAJVDQ = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-WAONPY = "".join(chr(c) for c in [66, 76])
-WBSIRY = "".join(chr(c) for c in [77, 69, 68])
-WDAFIK = "".join(chr(c) for c in [54, 52, 75])
-WEEZFE = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-WIVDNQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-WJYKLG = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 84, 79, 80])
-WONFZC = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-WRKINE = "".join(chr(c) for c in [72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116])
-WSKWIV = 311
-WUEUHN = 329
-WVUBYG = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-XADXLU = 473
-XAIVEM = 343
-XBQFYL = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-XCHWDA = "".join(chr(c) for c in [49, 54, 75])
-XEKVKZ = "".join(chr(c) for c in [72, 69, 65, 84])
-XFEFJT = "".join(chr(c) for c in [83, 112, 101, 101, 100, 86, 83, 80, 49])
-XFUBJL = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-XIBHZV = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-XLSXUJ = 369
-XLUBGJ = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-XNCUGU = 460
-XNKMLO = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-XNQTMF = 295
-XOIHBX = "".join(chr(c) for c in [75, 56, 48, 48])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = "".join(chr(c) for c in [75, 53])
-XSJWMN = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-XTIACQ = "".join(chr(c) for c in [71, 69, 67, 75, 79, 55, 53, 48, 48, 87])
-XUJUTY = "".join(chr(c) for c in [72, 73, 71, 72])
-XWAJVD = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-XYBQSN = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-YBQSNQ = 377
-YEKCWA = "".join(chr(c) for c in [80, 52])
-YFCRTF = "".join(chr(c) for c in [86, 83, 80, 50, 69, 114, 114, 111, 114, 73, 68])
-YGDSBD = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-YKLGQP = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YLIUXF = 5
-YLJUIK = 275
-YMOUNB = 365
-YOUSPB = 266
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YRAPUM = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-YUAXNC = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-YWONFZ = 347
-YWSKWI = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YXBQFY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YYLIUX = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 324
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [67, 70, 71, 49])
-ZDGKEA = 299
-ZFETDR = 340
-ZILXWA = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-ZMJIGY = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-ZMKQTD = "".join(chr(c) for c in [65, 85, 88])
-ZOLSIP = "".join(chr(c) for c in [67, 70, 71, 50])
-ZSSBVN = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ZTATDZ = 291
-ZUQEXL = 306
-ZVOACM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-ZXNQTM = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-BJLOIN = [
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    EKCWAO,
-    RAZMKQ,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    HECVYY,
-    HECVYY,
-    UBJLOI,
-    HECVYY,
-    HECVYY,
-    AZMKQT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IUXFEF,
-    ZMKQTD,
-]
-BXIBHZ = [
-    CGETIX,
-    GETIXQ,
-    ETIXQV,
-    TIXQVX,
-    IXQVXO,
-    XQVXOI,
-    QVXOIH,
-    VXOIHB,
-    XOIHBX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-]
-CPOUBM = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-    CBFEGZ,
-    FEGZUQ,
-    GZUQEX,
-    UQEXLS,
-    EXLSXU,
-]
-CWAONP = [FXQGLR, XUJUTY]
-DAFIKJ = [XCHWDA, CHWDAF, HWDAFI, WDAFIK]
-DQLAII = [
-    JWMNZM,
-    ZILXWA,
-    ILXWAJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-]
-FCPOUB = [
-    LSXUJU,
-    UTYEKC,
-    TYEKCW,
-    YEKCWA,
-    EKCWAO,
-    WAONPY,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    YYLIUX,
-    LIUXFE,
-    IUXFEF,
-    XFEFJT,
-    EFJTAC,
-    JTACCP,
-    ACCPQI,
-    CPQIPO,
-    QIPOUY,
-    NQJYMO,
-    JYMOUN,
-    MOUNBL,
-    VFCPOU,
-]
-IKFWRK = [HECVYY, UIKFWR, UIKFWR, UIKFWR]
-JUTYEK = [FXQGLR, XUJUTY, UJUTYE]
-KBDFSR = [
-    CMCVDS,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EKBDFS,
-]
-KVFCPO = []
-KVKZIL = [XEKVKZ, EKVKZI]
-KXSJWM = [BLKXSJ, LKXSJW]
-MJIGYO = [JWMNZM, WMNZMJ, MNZMJI, NZMJIG, ZMJIGY]
-MKQTDK = [
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    EKCWAO,
-    RAZMKQ,
-    AONPYY,
-    ONPYYL,
-    PYYLIU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    AZMKQT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IUXFEF,
-    ZMKQTD,
-]
-OKPHUO = [FXQGLR, SOKPHU]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-POUBMI = [
-    EUTOPH,
-    TFMNHT,
-    JEUTOP,
-    JVYFCR,
-    DNQGVU,
-    BDJQRJ,
-    JQRJJJ,
-    VWVUBY,
-    QFYLJU,
-    IYWSKW,
-    VDNQGV,
-    NQGVUN,
-    RKINEJ,
-    UTOPHU,
-    BIAMJM,
-    GDSBDJ,
-    UBYGDS,
-    IBXYBQ,
-    BJEUTO,
-    WIVDNQ,
-    VUBYGD,
-    DSBDJQ,
-    YGDSBD,
-    HBVWVU,
-    CRTFMN,
-    HTBJEU,
-    QRJJJV,
-    YFCRTF,
-    MNHTBJ,
-    SUHBVW,
-    BSSUHB,
-    PHUGTY,
-    DJQRJJ,
-    SSUHBV,
-    JJJVYF,
-    BYGDSB,
-    WVUBYG,
-    BVWVUB,
-]
-QNRXCH = [
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-]
-SEMCGE = [STSEMC, TSEMCG]
-SIRYXB = [AWBSIR, LRAHEO, WBSIRY, RAHEOC, BSIRYX]
-SKSOKP = [FXQGLR, RAHEOC]
-TIACQF = [IBXTIA, BXTIAC, XTIACQ]
-UNRJZT = [FIKJPU, IKJPUN, HECVYY, KJPUNR, HECVYY, JPUNRJ, HECVYY, PUNRJZ]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-XWEEZF = [
-    CMCVDS,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    AONPYY,
-]
-YIYWSK = [HECVYY, TYIYWS, TYIYWS, TYIYWS]
-YNQJYM = [POUYNQ, OUYNQJ, UYNQJY]
-ZMRKVF = [LSIJUZ, SIJUZM, IJUZMR, JUZMRK, UZMRKV]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1713,361 +19,1354 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return OUBMIK
+        return 81
 
     @property
     def begin(self):
-        return UBMIKG
+        return 256
 
     @property
     def end(self):
-        return BMIKGN
+        return 479
 
     @property
     def all_device_keys(self):
-        return FCPOUB
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "SpeedVSP1",
+            "SpeedVSP2",
+            "SpeedVSP3",
+            "SpeedVSP4",
+            "SpeedVSP5",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return CPOUBM
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdSpeedVSP1",
+            "UdSpeedVSP2",
+            "UdSpeedVSP3",
+            "UdSpeedVSP4",
+            "UdSpeedVSP5",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return POUBMI
+        return [
+            "SlaveNoFloErr",
+            "VSP2ErrorID",
+            "AmbiantOHLevel2",
+            "VSP5ErrorID",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "VSP1ErrorID",
+            "SlaveRegProbeErr",
+            "VSP4CommLost",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "VSP2CommLost",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "VSP4ErrorID",
+            "SlaveP1HStuck",
+            "VSP5CommLost",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "VSP1CommLost",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "VSP3CommLost",
+            "VSP3ErrorID",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, AKQXPI),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, AKQXPI),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, AKQXPI),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, AKQXPI),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, AKQXPI),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, XPICXQ, JUTYEK, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, SXUJUT, OCTHBS, JUTYEK, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, SXUJUT, HEOCTH, JUTYEK, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, SXUJUT, VHFTHE, JUTYEK, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, XPICXQ, CWAONP, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, KCWAON, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP1": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP1", 393, "ALL"
             ),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, KCWAON, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP2": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP2", 394, "ALL"
             ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, KCWAON, NPYYLI, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP3": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP3", 395, "ALL"
             ),
-            PYYLIU: GeckoEnumStructAccessor(
-                self.struct, PYYLIU, KCWAON, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP4": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP4", 396, "ALL"
             ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, KCWAON, YLIUXF, OKPHUO, None, OCTHBS, None
+            "UdSpeedVSP5": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP5", 397, "ALL"
             ),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, KCWAON, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, KCWAON, UXFEFJ, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoByteStructAccessor(self.struct, EFJTAC, FJTACC, AKQXPI),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, AKQXPI),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, AKQXPI),
-            CPQIPO: GeckoByteStructAccessor(self.struct, CPQIPO, PQIPOU, AKQXPI),
-            QIPOUY: GeckoEnumStructAccessor(
-                self.struct, QIPOUY, IPOUYN, None, YNQJYM, None, None, AKQXPI
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, QJYMOU, None, YNQJYM, None, None, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            JYMOUN: GeckoWordStructAccessor(self.struct, JYMOUN, YMOUNB, None),
-            MOUNBL: GeckoWordStructAccessor(self.struct, MOUNBL, OUNBLK, AKQXPI),
-            UNBLKX: GeckoEnumStructAccessor(
-                self.struct, UNBLKX, NBLKXS, XPICXQ, KXSJWM, None, OCTHBS, AKQXPI
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, MJIGYO, None, None, AKQXPI
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            JIGYOU: GeckoTimeStructAccessor(self.struct, JIGYOU, IGYOUS, AKQXPI),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, AKQXPI),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, NBLKXS, OCTHBS, KXSJWM, None, OCTHBS, AKQXPI
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            USPBWJ: GeckoEnumStructAccessor(
-                self.struct, USPBWJ, SPBWJY, None, MJIGYO, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            PBWJYK: GeckoTimeStructAccessor(self.struct, PBWJYK, BWJYKL, AKQXPI),
-            WJYKLG: GeckoByteStructAccessor(self.struct, WJYKLG, JYKLGQ, AKQXPI),
-            YKLGQP: GeckoByteStructAccessor(self.struct, YKLGQP, KLGQPL, AKQXPI),
-            LGQPLS: GeckoByteStructAccessor(self.struct, LGQPLS, GQPLSP, AKQXPI),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, NBLKXS, ICXQIE, KXSJWM, None, OCTHBS, AKQXPI
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, MJIGYO, None, None, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            SPFTSI: GeckoTimeStructAccessor(self.struct, SPFTSI, PFTSIF, AKQXPI),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, TSIFJB, XPICXQ, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, TSIFJB, ICXQIE, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, TSIFJB, OCTHBS, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, TSIFJB, NPYYLI, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, TSIFJB, HEOCTH, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, TSIFJB, YLIUXF, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, JVHFTH, OCTHBS, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, NPYYLI, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MJMAOA, YLIUXF, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, MJMAOA, VHFTHE, None),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, SIRYXB, None, None, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, YLIUXF, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, RYXBQF, VHFTHE, None),
-            XBQFYL: GeckoWordStructAccessor(self.struct, XBQFYL, BQFYLJ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, JVHFTH, ICXQIE, None),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, None),
-            LJUIKF: GeckoTempStructAccessor(self.struct, LJUIKF, JUIKFW, None),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, KCWAON, YLIUXF, IKFWRK, None, HEOCTH, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, XPICXQ, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, FWRKIN, ICXQIE, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, FWRKIN, OCTHBS, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, FWRKIN, VHFTHE, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, OCTHBS, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, JNIBXY, ICXQIE, None),
-            NIBXYB: GeckoBoolStructAccessor(
-                self.struct, NIBXYB, JNIBXY, OCTHBS, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, QSNQLN, XPICXQ, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, NQLNMH, XPICXQ, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, NQLNMH, ICXQIE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NQLNMH, HEOCTH, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NQLNMH, YLIUXF, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NQLNMH, VHFTHE, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, NQLNMH, UXFEFJ, KVKZIL, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            VKZILX: GeckoEnumStructAccessor(
-                self.struct, VKZILX, KZILXW, None, DQLAII, None, None, None
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, LAIIDN, XPICXQ, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, LAIIDN, ICXQIE, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, LAIIDN, OCTHBS, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, LAIIDN, NPYYLI, None),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, TIACQF, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IACQFF: GeckoWordStructAccessor(self.struct, IACQFF, ACQFFT, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, QFFTTI, XPICXQ, None),
-            FFTTID: GeckoBoolStructAccessor(self.struct, FFTTID, QFFTTI, ICXQIE, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, TTIDUB, XPICXQ, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, TTIDUB, ICXQIE, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, DUBSSU, XPICXQ, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, DUBSSU, ICXQIE, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, MJMAOA, XPICXQ, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, MJMAOA, ICXQIE, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, UHBVWV, OCTHBS, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, UHBVWV, NPYYLI, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, QFFTTI, NPYYLI, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, QFFTTI, HEOCTH, None),
-            WVUBYG: GeckoBoolStructAccessor(self.struct, WVUBYG, QFFTTI, YLIUXF, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, QFFTTI, VHFTHE, None),
-            UBYGDS: GeckoBoolStructAccessor(self.struct, UBYGDS, TTIDUB, NPYYLI, None),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, TTIDUB, HEOCTH, None),
-            YGDSBD: GeckoBoolStructAccessor(self.struct, YGDSBD, TTIDUB, YLIUXF, None),
-            GDSBDJ: GeckoBoolStructAccessor(self.struct, GDSBDJ, TTIDUB, VHFTHE, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, SBDJQR, OCTHBS, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, SBDJQR, NPYYLI, None),
-            DJQRJJ: GeckoBoolStructAccessor(self.struct, DJQRJJ, RYXBQF, XPICXQ, None),
-            JQRJJJ: GeckoBoolStructAccessor(self.struct, JQRJJJ, RYXBQF, ICXQIE, None),
-            QRJJJV: GeckoBoolStructAccessor(self.struct, QRJJJV, RJJJVY, XPICXQ, None),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, None),
-            JVYFCR: GeckoByteStructAccessor(self.struct, JVYFCR, VYFCRT, AKQXPI),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, AKQXPI),
-            CRTFMN: GeckoByteStructAccessor(self.struct, CRTFMN, RTFMNH, AKQXPI),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, AKQXPI),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, AKQXPI),
-            HTBJEU: GeckoBoolStructAccessor(self.struct, HTBJEU, TBJEUT, XPICXQ, None),
-            BJEUTO: GeckoBoolStructAccessor(self.struct, BJEUTO, TBJEUT, ICXQIE, None),
-            JEUTOP: GeckoBoolStructAccessor(self.struct, JEUTOP, TBJEUT, OCTHBS, None),
-            EUTOPH: GeckoBoolStructAccessor(self.struct, EUTOPH, TBJEUT, NPYYLI, None),
-            UTOPHU: GeckoBoolStructAccessor(self.struct, UTOPHU, TBJEUT, HEOCTH, None),
-            TOPHUG: GeckoBoolStructAccessor(self.struct, TOPHUG, NEJNIB, XPICXQ, None),
-            OPHUGT: GeckoBoolStructAccessor(self.struct, OPHUGT, UHBVWV, XPICXQ, None),
-            PHUGTY: GeckoBoolStructAccessor(self.struct, PHUGTY, UHBVWV, ICXQIE, None),
-            HUGTYI: GeckoBoolStructAccessor(self.struct, HUGTYI, UHBVWV, HEOCTH, None),
-            UGTYIY: GeckoBoolStructAccessor(self.struct, UGTYIY, GTYIYW, XPICXQ, None),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, GTYIYW, ICXQIE, YIYWSK, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IYWSKW: GeckoBoolStructAccessor(self.struct, IYWSKW, GTYIYW, NPYYLI, None),
-            YWSKWI: GeckoWordStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoBoolStructAccessor(self.struct, SKWIVD, KWIVDN, XPICXQ, None),
-            WIVDNQ: GeckoBoolStructAccessor(self.struct, WIVDNQ, IVDNQG, XPICXQ, None),
-            VDNQGV: GeckoBoolStructAccessor(self.struct, VDNQGV, IVDNQG, ICXQIE, None),
-            DNQGVU: GeckoBoolStructAccessor(self.struct, DNQGVU, SBDJQR, XPICXQ, None),
-            NQGVUN: GeckoBoolStructAccessor(self.struct, NQGVUN, SBDJQR, ICXQIE, None),
-            QGVUNX: GeckoBoolStructAccessor(self.struct, QGVUNX, SBDJQR, HEOCTH, None),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, QNRXCH, None, None, None
+            "SpeedVSP1": GeckoByteStructAccessor(self.struct, "SpeedVSP1", 398, "ALL"),
+            "SpeedVSP2": GeckoByteStructAccessor(self.struct, "SpeedVSP2", 399, "ALL"),
+            "SpeedVSP3": GeckoByteStructAccessor(self.struct, "SpeedVSP3", 400, "ALL"),
+            "SpeedVSP4": GeckoByteStructAccessor(self.struct, "SpeedVSP4", 401, "ALL"),
+            "SpeedVSP5": GeckoByteStructAccessor(self.struct, "SpeedVSP5", 402, "ALL"),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            NRXCHW: GeckoEnumStructAccessor(
-                self.struct, NRXCHW, RXCHWD, XPICXQ, DAFIKJ, None, HEOCTH, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, RXCHWD, NPYYLI, UNRJZT, None, NRJZTA, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            RJZTAT: GeckoBoolStructAccessor(self.struct, RJZTAT, RXCHWD, VHFTHE, None),
-            JZTATD: GeckoWordStructAccessor(self.struct, JZTATD, ZTATDZ, None),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, None),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, None),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, None),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, None),
-            TMFZDG: GeckoWordStructAccessor(self.struct, TMFZDG, MFZDGK, None),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, None),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, None),
-            KEAKST: GeckoWordStructAccessor(self.struct, KEAKST, EAKSTS, None),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, SEMCGE, None, OCTHBS, AKQXPI
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, BXIBHZ, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XIBHZV: GeckoWordStructAccessor(self.struct, XIBHZV, IBHZVO, None),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, None),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, None),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, ACMCVD, None, MKQTDK, None, None, AKQXPI
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, QTDKHT, None, MKQTDK, None, None, AKQXPI
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            TDKHTZ: GeckoEnumStructAccessor(
-                self.struct, TDKHTZ, DKHTZB, None, MKQTDK, None, None, AKQXPI
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            KHTZBB: GeckoEnumStructAccessor(
-                self.struct, KHTZBB, HTZBBE, None, MKQTDK, None, None, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            TZBBEK: GeckoEnumStructAccessor(
-                self.struct, TZBBEK, ZBBEKB, None, MKQTDK, None, None, AKQXPI
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BBEKBD: GeckoEnumStructAccessor(
-                self.struct, BBEKBD, BEKBDF, None, KBDFSR, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            BDFSRO: GeckoByteStructAccessor(self.struct, BDFSRO, DFSROG, AKQXPI),
-            FSROGM: GeckoByteStructAccessor(self.struct, FSROGM, SROGMD, AKQXPI),
-            ROGMDD: GeckoByteStructAccessor(self.struct, ROGMDD, OGMDDP, AKQXPI),
-            GMDDPM: GeckoByteStructAccessor(self.struct, GMDDPM, MDDPMX, AKQXPI),
-            DDPMXF: GeckoByteStructAccessor(self.struct, DDPMXF, DPMXFU, AKQXPI),
-            PMXFUB: GeckoByteStructAccessor(self.struct, PMXFUB, MXFUBJ, AKQXPI),
-            XFUBJL: GeckoEnumStructAccessor(
-                self.struct, XFUBJL, FUBJLO, None, BJLOIN, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            JLOINE: GeckoEnumStructAccessor(
-                self.struct, JLOINE, LOINEL, None, BJLOIN, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            OINELW: GeckoEnumStructAccessor(
-                self.struct, OINELW, INELWU, None, BJLOIN, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NELWUE: GeckoEnumStructAccessor(
-                self.struct, NELWUE, ELWUEU, None, BJLOIN, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            LWUEUH: GeckoEnumStructAccessor(
-                self.struct, LWUEUH, WUEUHN, None, BJLOIN, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            UEUHNN: GeckoEnumStructAccessor(
-                self.struct, UEUHNN, EUHNNX, None, BJLOIN, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            UHNNXW: GeckoEnumStructAccessor(
-                self.struct, UHNNXW, HNNXWE, None, BJLOIN, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
             ),
-            NNXWEE: GeckoEnumStructAccessor(
-                self.struct, NNXWEE, NXWEEZ, None, XWEEZF, None, None, AKQXPI
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            WEEZFE: GeckoEnumStructAccessor(
-                self.struct, WEEZFE, EEZFET, None, XWEEZF, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            EZFETD: GeckoByteStructAccessor(self.struct, EZFETD, ZFETDR, AKQXPI),
-            FETDRX: GeckoByteStructAccessor(self.struct, FETDRX, ETDRXA, AKQXPI),
-            TDRXAI: GeckoByteStructAccessor(self.struct, TDRXAI, DRXAIV, AKQXPI),
-            RXAIVE: GeckoByteStructAccessor(self.struct, RXAIVE, XAIVEM, AKQXPI),
-            AIVEMV: GeckoByteStructAccessor(self.struct, AIVEMV, IVEMVC, AKQXPI),
-            VEMVCY: GeckoByteStructAccessor(self.struct, VEMVCY, EMVCYW, AKQXPI),
-            MVCYWO: GeckoByteStructAccessor(self.struct, MVCYWO, VCYWON, AKQXPI),
-            CYWONF: GeckoByteStructAccessor(self.struct, CYWONF, YWONFZ, AKQXPI),
-            WONFZC: GeckoByteStructAccessor(self.struct, WONFZC, ONFZCZ, AKQXPI),
-            TUVRFL: GeckoBoolStructAccessor(self.struct, TUVRFL, JVHFTH, YLIUXF, None),
-            UVRFLS: GeckoByteStructAccessor(self.struct, UVRFLS, VRFLSI, AKQXPI),
-            RFLSIJ: GeckoEnumStructAccessor(
-                self.struct, RFLSIJ, FLSIJU, None, ZMRKVF, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            MRKVFC: GeckoBoolStructAccessor(
-                self.struct, MRKVFC, RKVFCP, XPICXQ, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "VSP1ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP1ErrorID", 403, "ALL"
+            ),
+            "VSP2ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP2ErrorID", 404, "ALL"
+            ),
+            "VSP3ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP3ErrorID", 405, "ALL"
+            ),
+            "VSP4ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP4ErrorID", 406, "ALL"
+            ),
+            "VSP5ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP5ErrorID", 407, "ALL"
+            ),
+            "VSP1CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP1CommLost", 408, 0, None
+            ),
+            "VSP2CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP2CommLost", 408, 1, None
+            ),
+            "VSP3CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP3CommLost", 408, 2, None
+            ),
+            "VSP4CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP4CommLost", 408, 3, None
+            ),
+            "VSP5CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP5CommLost", 408, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/inyt-log-82.py
+++ b/src/geckolib/driver/packs/inyt-log-82.py
@@ -1,0 +1,1375 @@
+#!/usr/bin/python3
+"""
+    GeckoLogStruct - A class to manage the LogStruct for 'InYT v82'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoLogStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 82
+
+    @property
+    def begin(self):
+        return 256
+
+    @property
+    def end(self):
+        return 479
+
+    @property
+    def all_device_keys(self):
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "SpeedVSP1",
+            "SpeedVSP2",
+            "SpeedVSP3",
+            "SpeedVSP4",
+            "SpeedVSP5",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
+
+    @property
+    def user_demand_keys(self):
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdSpeedVSP1",
+            "UdSpeedVSP2",
+            "UdSpeedVSP3",
+            "UdSpeedVSP4",
+            "UdSpeedVSP5",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
+
+    @property
+    def error_keys(self):
+        return [
+            "SlaveNoFloErr",
+            "VSP2ErrorID",
+            "AmbiantOHLevel2",
+            "VSP5ErrorID",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "VSP1ErrorID",
+            "SlaveRegProbeErr",
+            "VSP4CommLost",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "VSP2CommLost",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "VSP4ErrorID",
+            "SlaveP1HStuck",
+            "VSP5CommLost",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "VSP1CommLost",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "VSP3CommLost",
+            "VSP3ErrorID",
+            "OverTemp",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
+            ),
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
+            ),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
+            ),
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
+            ),
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
+            ),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
+            ),
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
+            ),
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
+            ),
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdSpeedVSP1": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP1", 393, "ALL"
+            ),
+            "UdSpeedVSP2": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP2", 394, "ALL"
+            ),
+            "UdSpeedVSP3": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP3", 395, "ALL"
+            ),
+            "UdSpeedVSP4": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP4", 396, "ALL"
+            ),
+            "UdSpeedVSP5": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP5", 397, "ALL"
+            ),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
+            ),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
+            ),
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
+            ),
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
+            ),
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
+            ),
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
+            ),
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
+            ),
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
+            ),
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
+            ),
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
+            ),
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
+            ),
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
+            ),
+            "SpeedVSP1": GeckoByteStructAccessor(self.struct, "SpeedVSP1", 398, "ALL"),
+            "SpeedVSP2": GeckoByteStructAccessor(self.struct, "SpeedVSP2", 399, "ALL"),
+            "SpeedVSP3": GeckoByteStructAccessor(self.struct, "SpeedVSP3", 400, "ALL"),
+            "SpeedVSP4": GeckoByteStructAccessor(self.struct, "SpeedVSP4", 401, "ALL"),
+            "SpeedVSP5": GeckoByteStructAccessor(self.struct, "SpeedVSP5", 402, "ALL"),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
+            ),
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
+            ),
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
+            ),
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
+            ),
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
+            ),
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
+            ),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
+            ),
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "ColdpumpInstalled": GeckoBoolStructAccessor(
+                self.struct, "ColdpumpInstalled", 378, 2, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "VSP1ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP1ErrorID", 403, "ALL"
+            ),
+            "VSP2ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP2ErrorID", 404, "ALL"
+            ),
+            "VSP3ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP3ErrorID", 405, "ALL"
+            ),
+            "VSP4ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP4ErrorID", 406, "ALL"
+            ),
+            "VSP5ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP5ErrorID", 407, "ALL"
+            ),
+            "VSP1CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP1CommLost", 408, 0, None
+            ),
+            "VSP2CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP2CommLost", 408, 1, None
+            ),
+            "VSP3CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP3CommLost", 408, 2, None
+            ),
+            "VSP4CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP4CommLost", 408, 3, None
+            ),
+            "VSP5CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP5CommLost", 408, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+        }

--- a/src/geckolib/driver/packs/inyt-log-83.py
+++ b/src/geckolib/driver/packs/inyt-log-83.py
@@ -1,0 +1,1394 @@
+#!/usr/bin/python3
+"""
+    GeckoLogStruct - A class to manage the LogStruct for 'InYT v83'
+"""
+
+from . import (
+    GeckoByteStructAccessor,
+    GeckoWordStructAccessor,
+    GeckoTimeStructAccessor,
+    GeckoBoolStructAccessor,
+    GeckoEnumStructAccessor,
+    GeckoTempStructAccessor,
+)
+
+
+class GeckoLogStruct:
+    def __init__(self, struct_):
+        self.struct = struct_
+
+    @property
+    def version(self):
+        return 83
+
+    @property
+    def begin(self):
+        return 256
+
+    @property
+    def end(self):
+        return 479
+
+    @property
+    def all_device_keys(self):
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "SpeedVSP1",
+            "SpeedVSP2",
+            "SpeedVSP3",
+            "SpeedVSP4",
+            "SpeedVSP5",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
+
+    @property
+    def user_demand_keys(self):
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdSpeedVSP1",
+            "UdSpeedVSP2",
+            "UdSpeedVSP3",
+            "UdSpeedVSP4",
+            "UdSpeedVSP5",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
+
+    @property
+    def error_keys(self):
+        return [
+            "SlaveNoFloErr",
+            "VSP2ErrorID",
+            "AmbiantOHLevel2",
+            "VSP5ErrorID",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "VSP1ErrorID",
+            "SlaveRegProbeErr",
+            "VSP4CommLost",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "VSP2CommLost",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "VSP4ErrorID",
+            "SlaveP1HStuck",
+            "VSP5CommLost",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "VSP1CommLost",
+            "HeaterStuck",
+            "SlaveKinNoFloErr",
+            "VSP3CommLost",
+            "VSP3ErrorID",
+            "OverTemp",
+        ]
+
+    @property
+    def accessors(self):
+        return {
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
+            ),
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
+            ),
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
+            ),
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
+            ),
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
+            ),
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
+            ),
+            "GfciTestStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "GfciTestStatus",
+                409,
+                None,
+                [
+                    "NOT_SUPPORTED",
+                    "CONFIG_DISABLED",
+                    "TEST_REQUIRED",
+                    "TEST_IN_PROGRESS",
+                    "LAST_TEST_PASSED",
+                    "LAST_TEST_FAILED",
+                    "WAINTING_TEST_SUPPORTED_RESPONSE",
+                    "TEST_BY_PASSED",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
+            ),
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
+            ),
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
+            ),
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
+            ),
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "UdSpeedVSP1": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP1", 393, "ALL"
+            ),
+            "UdSpeedVSP2": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP2", 394, "ALL"
+            ),
+            "UdSpeedVSP3": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP3", 395, "ALL"
+            ),
+            "UdSpeedVSP4": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP4", 396, "ALL"
+            ),
+            "UdSpeedVSP5": GeckoByteStructAccessor(
+                self.struct, "UdSpeedVSP5", 397, "ALL"
+            ),
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
+            ),
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
+            ),
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
+            ),
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
+            ),
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
+            ),
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
+            ),
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
+            ),
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
+            ),
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
+            ),
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
+            ),
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
+            ),
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
+            ),
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
+            ),
+            "SpeedVSP1": GeckoByteStructAccessor(self.struct, "SpeedVSP1", 398, "ALL"),
+            "SpeedVSP2": GeckoByteStructAccessor(self.struct, "SpeedVSP2", 399, "ALL"),
+            "SpeedVSP3": GeckoByteStructAccessor(self.struct, "SpeedVSP3", 400, "ALL"),
+            "SpeedVSP4": GeckoByteStructAccessor(self.struct, "SpeedVSP4", 401, "ALL"),
+            "SpeedVSP5": GeckoByteStructAccessor(self.struct, "SpeedVSP5", 402, "ALL"),
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
+            ),
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
+            ),
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
+            ),
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
+            ),
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
+            ),
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
+            ),
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
+            ),
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
+            ),
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
+            ),
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
+            ),
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
+            ),
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
+            ),
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "FiltRequest": GeckoBoolStructAccessor(
+                self.struct, "FiltRequest", 273, 1, None
+            ),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
+            ),
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
+            ),
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
+            ),
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
+            ),
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
+            ),
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
+            ),
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
+            ),
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
+            ),
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
+            ),
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
+            ),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "NearHL": GeckoBoolStructAccessor(self.struct, "NearHL", 279, 0, None),
+            "HeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HeatRequest", 279, 1, None
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "ColdpumpInstalled": GeckoBoolStructAccessor(
+                self.struct, "ColdpumpInstalled", 378, 2, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "SilentModeSuspended": GeckoBoolStructAccessor(
+                self.struct, "SilentModeSuspended", 383, 1, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "VSP1ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP1ErrorID", 403, "ALL"
+            ),
+            "VSP2ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP2ErrorID", 404, "ALL"
+            ),
+            "VSP3ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP3ErrorID", 405, "ALL"
+            ),
+            "VSP4ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP4ErrorID", 406, "ALL"
+            ),
+            "VSP5ErrorID": GeckoByteStructAccessor(
+                self.struct, "VSP5ErrorID", 407, "ALL"
+            ),
+            "VSP1CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP1CommLost", 408, 0, None
+            ),
+            "VSP2CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP2CommLost", 408, 1, None
+            ),
+            "VSP3CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP3CommLost", 408, 2, None
+            ),
+            "VSP4CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP4CommLost", 408, 3, None
+            ),
+            "VSP5CommLost": GeckoBoolStructAccessor(
+                self.struct, "VSP5CommLost", 408, 4, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackGeneration": GeckoEnumStructAccessor(
+                self.struct,
+                "PackGeneration",
+                290,
+                3,
+                ["1ST_GEN", "2ND_GEN", "", "3RD_GEN", "", "4TH_GEN", "", "5TH_GEN"],
+                None,
+                8,
+                None,
+            ),
+            "PackMem256K": GeckoBoolStructAccessor(
+                self.struct, "PackMem256K", 290, 6, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                334,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 335, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 336, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 337, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 338, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 339, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 349, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+        }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-60.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-60.py
@@ -12,1041 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 120
-ACMCVD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-ACQFFT = 93
-AFIKJP = 110
-AHEOCT = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-AIIDNI = 88
-AIVEMV = 60
-AJVDQL = 85
-AKQXPI = "".join(chr(c) for c in [65, 85, 88])
-AKSTSE = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-AMJMAO = 33
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-AONPYY = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [66, 76, 85, 69])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-BBEKBD = 121
-BDJQRJ = 105
-BEKBDF = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BFEGZU = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-BHZVOA = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-BIAMJM = 1
-BJEUTO = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-BJLOIN = 127
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 66
-BQNRXC = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-BQSNQL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-BSKSOK = 50
-BSSUHB = 98
-BVWVUB = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-BWJYKL = "".join(chr(c) for c in [80, 49])
-BXIBHZ = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-BXTIAC = 91
-BXYBQS = 53
-BYGDSB = 103
-CBFEGZ = 43
-CCPQIP = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CGETIX = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-CHWDAF = 6
-CMCVDS = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-CPQIPO = 32
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-CRTFMN = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-CTHBSK = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-CVDSSR = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-CXQIEF = "".join(chr(c) for c in [79, 117, 116, 52])
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DDPMXF = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-DFSROG = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-DGKEAK = 111
-DJQRJJ = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-DNIBXT = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-DNQGVU = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-DPMXFU = 125
-DQLAII = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-DSSRUR = "".join(chr(c) for c in [73, 100, 111, 108])
-DUBSSU = 97
-DZXNQT = "".join(chr(c) for c in [67, 89, 65, 78])
-EAKSTS = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-EFJTAC = 0
-EFXQGL = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-EGZUQE = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-EKBDFS = 123
-EKCWAO = "".join(chr(c) for c in [76, 73])
-EKVKZI = "".join(chr(c) for c in [70, 50, 50])
-ELHBQN = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-ELWUEU = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-EMCGET = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-EOCTHB = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-ETDRXA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-ETIXQV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-EUHNNX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-EUTOPH = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-EXLSXU = 47
-EZFETD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-FCRTFM = 3
-FEGZUQ = 44
-FETDRX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-FFTTID = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-FIKJPU = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-FJBIAM = 63
-FJTACC = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-FMNHTB = 6
-FSROGM = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-FTTIDU = 95
-FUBJLO = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-FWRKIN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-FXQGLR = 26
-FYLJUI = 68
-GDSBDJ = 104
-GETIXQ = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-GKEAKS = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-GLRAHE = 36
-GMDDPM = 124
-GSELHB = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-GTYIYW = 72
-GVUNXN = 73
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-GZUQEX = 45
-HBQNRX = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-HBSKSO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-HBVWVU = 100
-HBXIBH = "".join(chr(c) for c in [77, 65, 65, 88])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = 38
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-HNNXWE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-HTBJEU = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-HTZBBE = 113
-HUGTYI = 82
-HUOJRJ = "".join(chr(c) for c in [79, 117, 116, 57])
-HWDAFI = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-HXEKVK = "".join(chr(c) for c in [70, 51])
-HZVOAC = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-IACQFF = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-IAMJMA = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-IBHZVO = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-IBXTIA = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-IBXYBQ = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-ICXQIE = 14
-IDNIBX = 89
-IDUBSS = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-IEFXQG = 16
-IFJBIA = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-IGYOUS = 60
-IHBXIB = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IIDNIB = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-IKFWRK = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-IKJPUN = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-INEJNI = "".join(chr(c) for c in [85, 76])
-INELWU = "".join(chr(c) for c in [52])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-IRYXBQ = 3
-IUSOOQ = 23
-IUXFEF = 81
-IVDNQG = 76
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-IYWSKW = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-JBIAMJ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-JEUTOP = 10
-JHIUSO = 22
-JIGYOU = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-JJJVYF = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-JJVYFC = 108
-JLOINE = "".join(chr(c) for c in [49])
-JMAOAW = "".join(chr(c) for c in [67])
-JMCBFE = 42
-JNIBXY = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-JPUNRJ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-JQRJJJ = 106
-JRJHIU = 21
-JTACCP = 118
-JUGSEL = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-JUIKFW = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-JUTYEK = 119
-JVDQLA = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-JWMNZM = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-JYKLGQ = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-JZTATD = "".join(chr(c) for c in [82, 69, 68])
-KBDFSR = "".join(chr(c) for c in [82, 71, 66])
-KEAKST = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-KFWRKI = 77
-KHTZBB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-KINEJN = 51
-KJPUNR = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-KLGQPL = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-KMLOIJ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KPHUOJ = "".join(chr(c) for c in [79, 117, 116, 56])
-KQTDKH = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-KSOKPH = 17
-KSTSEM = "".join(chr(c) for c in [65, 108, 112, 115])
-KVKZIL = "".join(chr(c) for c in [70, 50, 51])
-KWIVDN = 5
-KXSJWM = "".join(chr(c) for c in [76, 111])
-KZILXW = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LAIIDN = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-LIUXFE = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-LJUIKF = 70
-LKXSJW = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-LNMHXE = 83
-LOIJUG = "".join(chr(c) for c in [65, 109, 80, 109])
-LOINEL = "".join(chr(c) for c in [50])
-LRAHEO = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-LSXUJU = 48
-LWUEUH = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-LXWAJV = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-MCBFEG = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-MCGETI = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-MCVDSS = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-MDDPMX = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-MFZDGK = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-MHXEKV = "".join(chr(c) for c in [70, 50])
-MJIGYO = 59
-MJMAOA = "".join(chr(c) for c in [70])
-MJVHFT = 12
-MKQTDK = 112
-MLOIJU = 34
-MNHTBJ = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-MNZMJI = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-MOUNBL = 57
-MXFUBJ = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-NBLKXS = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-NEJNIB = "".join(chr(c) for c in [67, 69])
-NHTBJE = 116
-NIBXTI = 90
-NIBXYB = 52
-NKMLOI = 75
-NMHXEK = "".join(chr(c) for c in [70, 49])
-NNXWEE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-NPYYLI = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-NQJYMO = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-NQTMFZ = 8
-NRJZTA = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-NRSJMC = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-NRXCHW = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NXWEEZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-NZMJIG = 58
-OACMCV = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-OAWBSI = 31
-OCTHBS = 39
-OGMDDP = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-OIHBXI = "".join(chr(c) for c in [76, 65])
-OIJUGS = "".join(chr(c) for c in [50, 52, 104])
-OINELW = "".join(chr(c) for c in [51])
-OJRJHI = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-OKPHUO = 18
-ONPYYL = 54
-OQNRSJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-OUNBLK = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-OUSPBW = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-PBWJYK = 78
-PFTSIF = 30
-PHUGTY = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-PHUOJR = 19
-PICXQI = "".join(chr(c) for c in [79, 117, 116, 51])
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = 29
-PMXFUB = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-POUYNQ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PQIPOU = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-PYYLIU = 55
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-QFFTTI = 94
-QFYLJU = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-QGLRAH = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-QGVUNX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-QIEFXQ = "".join(chr(c) for c in [79, 117, 116, 53])
-QIPOUY = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-QJYMOU = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-QLAIID = 87
-QLNMHX = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-QNRSJM = 25
-QNRXCH = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-QPLSPF = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-QRJJJV = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-QSNQLN = 74
-QTDKHT = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-QTMFZD = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-QVXOIH = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-QXPICX = "".join(chr(c) for c in [79, 117, 116, 50])
-RAHEOC = 37
-RAZMKQ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-RJHIUS = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-RJJJVY = 107
-RJZTAT = "".join(chr(c) for c in [79, 70, 70])
-RKINEJ = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-RSJMCB = 41
-RTFMNH = 4
-RURAZM = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-RYXBQF = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-SBDJQR = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-SELHBQ = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-SEMCGE = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-SJMCBF = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-SKSOKP = "".join(chr(c) for c in [79, 117, 116, 54])
-SKWIVD = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-SNQLNM = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-SOKPHU = "".join(chr(c) for c in [79, 117, 116, 55])
-SOOQNR = 24
-SPBWJY = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-SPFTSI = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-SROGMD = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-SRURAZ = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-SSAKQX = "".join(chr(c) for c in [72, 84, 82, 50])
-SSRURA = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-SSUHBV = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-STSEMC = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-SUHBVW = 99
-SXUJUT = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-TACCPQ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-TATDZX = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-TBJEUT = 8
-TDKHTZ = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-TDRXAI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-TDZXNQ = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-TFMNHT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-THBSKS = 40
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 92
-TIDUBS = 96
-TIXQVX = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-TMFZDG = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-TOPHUG = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-TSEMCG = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-TSIFJB = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-TTIDUB = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-TYEKCW = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-TYIYWS = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-TZBBEK = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-UBJLOI = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-UBSSUH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-UBYGDS = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-UEUHNN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-UGSELH = 64
-UGTYIY = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-UHBVWV = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-UHNNXW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-UJUTYE = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-UNBLKX = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-UNRJZT = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-UNXNKM = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-UOJRJH = 20
-UQEXLS = 46
-URAZMK = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-USOOQN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-USPBWJ = 62
-UTOPHU = 71
-UTYEKC = 2
-UXFEFJ = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-UYNQJY = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-VDNQGV = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-VDQLAI = 86
-VDSSRU = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-VUBYGD = 102
-VUNXNK = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-VWVUBY = 101
-VXOIHB = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VYFCRT = 109
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-WAONPY = 80
-WBSIRY = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-WDAFIK = 7
-WEEZFE = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-WIVDNQ = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-WMNZMJ = 1
-WRKINE = 114
-WSKWIV = 4
-WUEUHN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-WVUBYG = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-XBQFYL = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-XCHWDA = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-XEKVKZ = "".join(chr(c) for c in [70, 50, 49])
-XFEFJT = "".join(chr(c) for c in [79, 119, 110])
-XFUBJL = 126
-XIBHZV = "".join(chr(c) for c in [80, 68, 67])
-XLSXUJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-XNKMLO = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-XOIHBX = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-XPICXQ = 13
-XQIEFX = 15
-XQVXOI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-XSJWMN = "".join(chr(c) for c in [72, 105])
-XTIACQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-XUJUTY = 49
-XWAJVD = 84
-XWEEZF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-YBQSNQ = 122
-YEKCWA = 79
-YFCRTF = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-YGDSBD = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-YIYWSK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-YKLGQP = 28
-YLIUXF = 56
-YLJUIK = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-YMOUNB = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-YNQJYM = 27
-YOUSPB = 61
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-YXBQFY = 35
-YYLIUX = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZDGKEA = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-ZFETDR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-ZILXWA = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-ZMKQTD = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        102,
-        102,
-        75,
-        101,
-        121,
-        69,
-        110,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-ZTATDZ = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-ZUQEXL = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-ZVOACM = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-ZXNQTM = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-AZMKQT = [
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    KSTSEM,
-    STSEMC,
-    TSEMCG,
-    SEMCGE,
-    EMCGET,
-    MCGETI,
-    CGETIX,
-    GETIXQ,
-    ETIXQV,
-    TIXQVX,
-    IXQVXO,
-    XQVXOI,
-    QVXOIH,
-    VXOIHB,
-    XOIHBX,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-    BXIBHZ,
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-]
-BDFSRO = [KBDFSR, ZXNQTM]
-BLKXSJ = [OUNBLK, UNBLKX, NBLKXS]
-DKHTZB = [QTDKHT, TDKHTZ, VLASSA, VLASSA]
-DRXAIV = [
-    BMJVHF,
-    QXPICX,
-    PICXQI,
-    CXQIEF,
-    QIEFXQ,
-    EFXQGL,
-    SKSOKP,
-    SOKPHU,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OQNRSJ,
-    TYEKCW,
-]
-DSBDJQ = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VKZILX, KZILXW, ZILXWA]
-EJNIBX = [INEJNI, NEJNIB]
-FEFJTA = [UXFEFJ, XFEFJT]
-FZDGKE = [TMFZDG, MFZDGK]
-GQPLSP = [KLGQPL, LGQPLS]
-IJUGSE = [JVHFTH, LOIJUG, OIJUGS]
-ILXWAJ = [NMHXEK, MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL, VKZILX, KZILXW, ZILXWA]
-JYMOUN = [NQJYMO, QJYMOU]
-KCWAON = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    EKCWAO,
-]
-KQXPIC = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    SAKQXP,
-    AKQXPI,
-]
-LHBQNR = [SELHBQ, ELHBQN]
-LSPFTS = [PIPIVL, BWJYKL]
-MAOAWB = [MJMAOA, JMAOAW]
-NELWUE = [VLASSA, JLOINE, LOINEL, OINELW, INELWU]
-NQGVUN = [VDNQGV, DNQGVU]
-NQLNMH = [FTSIFJ, SNQLNM]
-NXNKML = [VLASSA, VUNXNK, UNXNKM]
-OOQNRS = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-OPHUGT = [JVHFTH, NQJYMO, TOPHUG]
-OUYNQJ = [PQIPOU, QIPOUY, IPOUYN, POUYNQ]
-PUNRJZ = [KJPUNR, JPUNRJ]
-ROGMDD = [FSROGM, SROGMD]
-RXAIVE = [EKCWAO]
-RXCHWD = [QNRXCH, NRXCHW]
-SIFJBI = [FTSIFJ, TSIFJB]
-SIRYXB = [WBSIRY, BSIRYX]
-SJWMNZ = [KXSJWM, XSJWMN]
-UIKFWR = [FTSIFJ, JUIKFW]
-WJYKLG = [JVHFTH, BWJYKL, PIPIVL]
-XAIVEM = []
-XNQTMF = [RJZTAT, JZTATD, ZTATDZ, TATDZX, ATDZXN, TDZXNQ, DZXNQT, ZXNQTM]
-XQGLRA = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1054,347 +19,1229 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return AIVEMV
+        return 60
 
     @property
     def output_keys(self):
-        return DRXAIV
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, KQXPIC, None, None, QBMJVH
-            ),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, None, KQXPIC, None, None, QBMJVH
-            ),
-            PICXQI: GeckoEnumStructAccessor(
-                self.struct, PICXQI, ICXQIE, None, KQXPIC, None, None, QBMJVH
-            ),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, KQXPIC, None, None, QBMJVH
-            ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, None, KQXPIC, None, None, QBMJVH
-            ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, None, XQGLRA, None, None, QBMJVH
-            ),
-            QGLRAH: GeckoByteStructAccessor(self.struct, QGLRAH, GLRAHE, QBMJVH),
-            LRAHEO: GeckoByteStructAccessor(self.struct, LRAHEO, RAHEOC, QBMJVH),
-            AHEOCT: GeckoByteStructAccessor(self.struct, AHEOCT, HEOCTH, QBMJVH),
-            EOCTHB: GeckoByteStructAccessor(self.struct, EOCTHB, OCTHBS, QBMJVH),
-            CTHBSK: GeckoByteStructAccessor(self.struct, CTHBSK, THBSKS, QBMJVH),
-            HBSKSO: GeckoByteStructAccessor(self.struct, HBSKSO, BSKSOK, QBMJVH),
-            SKSOKP: GeckoEnumStructAccessor(
-                self.struct, SKSOKP, KSOKPH, None, KQXPIC, None, None, QBMJVH
-            ),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, OKPHUO, None, KQXPIC, None, None, QBMJVH
-            ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, KQXPIC, None, None, QBMJVH
-            ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, KQXPIC, None, None, QBMJVH
-            ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, KQXPIC, None, None, QBMJVH
-            ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, KQXPIC, None, None, QBMJVH
-            ),
-            HIUSOO: GeckoEnumStructAccessor(
-                self.struct, HIUSOO, IUSOOQ, None, KQXPIC, None, None, QBMJVH
-            ),
-            USOOQN: GeckoEnumStructAccessor(
-                self.struct, USOOQN, SOOQNR, None, OOQNRS, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "QuickOffKeyEnable": GeckoBoolStructAccessor(
+                self.struct, "QuickOffKeyEnable", 112, 0, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            OQNRSJ: GeckoEnumStructAccessor(
-                self.struct, OQNRSJ, QNRSJM, None, OOQNRS, None, None, QBMJVH
-            ),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, QBMJVH),
-            SJMCBF: GeckoByteStructAccessor(self.struct, SJMCBF, JMCBFE, QBMJVH),
-            MCBFEG: GeckoByteStructAccessor(self.struct, MCBFEG, CBFEGZ, QBMJVH),
-            BFEGZU: GeckoByteStructAccessor(self.struct, BFEGZU, FEGZUQ, QBMJVH),
-            EGZUQE: GeckoByteStructAccessor(self.struct, EGZUQE, GZUQEX, QBMJVH),
-            ZUQEXL: GeckoByteStructAccessor(self.struct, ZUQEXL, UQEXLS, QBMJVH),
-            QEXLSX: GeckoByteStructAccessor(self.struct, QEXLSX, EXLSXU, QBMJVH),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, QBMJVH),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, QBMJVH),
-            UJUTYE: GeckoBoolStructAccessor(
-                self.struct, UJUTYE, JUTYEK, UTYEKC, QBMJVH
-            ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, KCWAON, None, None, None
-            ),
-            CWAONP: GeckoByteStructAccessor(self.struct, CWAONP, WAONPY, None),
-            AONPYY: GeckoByteStructAccessor(self.struct, AONPYY, ONPYYL, QBMJVH),
-            NPYYLI: GeckoByteStructAccessor(self.struct, NPYYLI, PYYLIU, QBMJVH),
-            YYLIUX: GeckoByteStructAccessor(self.struct, YYLIUX, YLIUXF, QBMJVH),
-            LIUXFE: GeckoEnumStructAccessor(
-                self.struct, LIUXFE, IUXFEF, EFJTAC, FEFJTA, None, UTYEKC, QBMJVH
-            ),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, OUYNQJ, None, None, QBMJVH
-            ),
-            UYNQJY: GeckoEnumStructAccessor(
-                self.struct, UYNQJY, YNQJYM, None, JYMOUN, None, None, QBMJVH
-            ),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, MOUNBL, None, BLKXSJ, None, None, QBMJVH
-            ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, IUXFEF, UTYEKC, SJWMNZ, None, UTYEKC, QBMJVH
-            ),
-            JWMNZM: GeckoBoolStructAccessor(
-                self.struct, JWMNZM, JUTYEK, WMNZMJ, QBMJVH
-            ),
-            MNZMJI: GeckoByteStructAccessor(self.struct, MNZMJI, NZMJIG, QBMJVH),
-            ZMJIGY: GeckoByteStructAccessor(self.struct, ZMJIGY, MJIGYO, QBMJVH),
-            JIGYOU: GeckoByteStructAccessor(self.struct, JIGYOU, IGYOUS, QBMJVH),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, QBMJVH),
-            OUSPBW: GeckoByteStructAccessor(self.struct, OUSPBW, USPBWJ, QBMJVH),
-            SPBWJY: GeckoEnumStructAccessor(
-                self.struct, SPBWJY, PBWJYK, None, WJYKLG, None, None, QBMJVH
-            ),
-            JYKLGQ: GeckoEnumStructAccessor(
-                self.struct, JYKLGQ, YKLGQP, None, GQPLSP, None, None, QBMJVH
-            ),
-            QPLSPF: GeckoEnumStructAccessor(
-                self.struct, QPLSPF, PLSPFT, None, LSPFTS, None, None, QBMJVH
-            ),
-            SPFTSI: GeckoEnumStructAccessor(
-                self.struct, SPFTSI, PFTSIF, None, SIFJBI, None, None, QBMJVH
-            ),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, QBMJVH),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, QBMJVH),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, AMJMAO, None, MAOAWB, None, None, QBMJVH
-            ),
-            AOAWBS: GeckoEnumStructAccessor(
-                self.struct, AOAWBS, OAWBSI, None, LSPFTS, None, None, QBMJVH
-            ),
-            AWBSIR: GeckoEnumStructAccessor(
-                self.struct, AWBSIR, IUXFEF, IRYXBQ, SIRYXB, None, UTYEKC, QBMJVH
-            ),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoTempStructAccessor(self.struct, XBQFYL, BQFYLJ, QBMJVH),
-            QFYLJU: GeckoTempStructAccessor(self.struct, QFYLJU, FYLJUI, QBMJVH),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, UIKFWR, None, None, QBMJVH
-            ),
-            IKFWRK: GeckoByteStructAccessor(self.struct, IKFWRK, KFWRKI, QBMJVH),
-            FWRKIN: GeckoByteStructAccessor(self.struct, FWRKIN, WRKINE, QBMJVH),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoByteStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, NQLNMH, None, None, QBMJVH
-            ),
-            QLNMHX: GeckoEnumStructAccessor(
-                self.struct, QLNMHX, LNMHXE, None, ILXWAJ, None, None, QBMJVH
-            ),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, ILXWAJ, None, None, QBMJVH
-            ),
-            WAJVDQ: GeckoEnumStructAccessor(
-                self.struct, WAJVDQ, AJVDQL, None, ILXWAJ, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, VDQLAI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, ILXWAJ, None, None, QBMJVH
-            ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IIDNIB: GeckoEnumStructAccessor(
-                self.struct, IIDNIB, IDNIBX, None, ILXWAJ, None, None, QBMJVH
-            ),
-            DNIBXT: GeckoEnumStructAccessor(
-                self.struct, DNIBXT, NIBXTI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IBXTIA: GeckoEnumStructAccessor(
-                self.struct, IBXTIA, BXTIAC, None, ILXWAJ, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, TIACQF, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IACQFF: GeckoEnumStructAccessor(
-                self.struct, IACQFF, ACQFFT, None, ILXWAJ, None, None, QBMJVH
-            ),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, ILXWAJ, None, None, QBMJVH
-            ),
-            FFTTID: GeckoEnumStructAccessor(
-                self.struct, FFTTID, FTTIDU, None, ILXWAJ, None, None, QBMJVH
-            ),
-            TTIDUB: GeckoEnumStructAccessor(
-                self.struct, TTIDUB, TIDUBS, None, ILXWAJ, None, None, QBMJVH
-            ),
-            IDUBSS: GeckoEnumStructAccessor(
-                self.struct, IDUBSS, DUBSSU, None, ILXWAJ, None, None, QBMJVH
-            ),
-            UBSSUH: GeckoByteStructAccessor(self.struct, UBSSUH, BSSUHB, QBMJVH),
-            SSUHBV: GeckoByteStructAccessor(self.struct, SSUHBV, SUHBVW, QBMJVH),
-            UHBVWV: GeckoByteStructAccessor(self.struct, UHBVWV, HBVWVU, QBMJVH),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, QBMJVH),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, QBMJVH),
-            UBYGDS: GeckoByteStructAccessor(self.struct, UBYGDS, BYGDSB, QBMJVH),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, DSBDJQ, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, DSBDJQ, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, DSBDJQ, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, DSBDJQ, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoByteStructAccessor(self.struct, YFCRTF, FCRTFM, QBMJVH),
-            CRTFMN: GeckoTimeStructAccessor(self.struct, CRTFMN, RTFMNH, QBMJVH),
-            TFMNHT: GeckoTimeStructAccessor(self.struct, TFMNHT, FMNHTB, QBMJVH),
-            MNHTBJ: GeckoTimeStructAccessor(self.struct, MNHTBJ, NHTBJE, QBMJVH),
-            HTBJEU: GeckoTimeStructAccessor(self.struct, HTBJEU, TBJEUT, QBMJVH),
-            BJEUTO: GeckoTimeStructAccessor(self.struct, BJEUTO, JEUTOP, QBMJVH),
-            EUTOPH: GeckoEnumStructAccessor(
-                self.struct, EUTOPH, UTOPHU, None, OPHUGT, None, None, QBMJVH
-            ),
-            PHUGTY: GeckoBoolStructAccessor(
-                self.struct, PHUGTY, HUGTYI, EFJTAC, QBMJVH
-            ),
-            UGTYIY: GeckoBoolStructAccessor(
-                self.struct, UGTYIY, GTYIYW, UTYEKC, QBMJVH
-            ),
-            TYIYWS: GeckoBoolStructAccessor(
-                self.struct, TYIYWS, GTYIYW, EFJTAC, QBMJVH
-            ),
-            YIYWSK: GeckoBoolStructAccessor(
-                self.struct, YIYWSK, GTYIYW, WMNZMJ, QBMJVH
-            ),
-            IYWSKW: GeckoBoolStructAccessor(
-                self.struct, IYWSKW, GTYIYW, IRYXBQ, QBMJVH
-            ),
-            YWSKWI: GeckoBoolStructAccessor(
-                self.struct, YWSKWI, GTYIYW, WSKWIV, QBMJVH
-            ),
-            SKWIVD: GeckoBoolStructAccessor(
-                self.struct, SKWIVD, GTYIYW, KWIVDN, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, NQGVUN, None, None, QBMJVH
-            ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, NXNKML, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, IJUGSE, None, None, QBMJVH
-            ),
-            JUGSEL: GeckoWordStructAccessor(self.struct, JUGSEL, UGSELH, QBMJVH),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, IUXFEF, WMNZMJ, LHBQNR, None, UTYEKC, QBMJVH
-            ),
-            HBQNRX: GeckoBoolStructAccessor(
-                self.struct, HBQNRX, IUXFEF, WSKWIV, QBMJVH
-            ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, IUXFEF, KWIVDN, RXCHWD, None, UTYEKC, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, IUXFEF, CHWDAF, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, IUXFEF, WDAFIK, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, EFJTAC, QBMJVH
-            ),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, AFIKJP, WMNZMJ, QBMJVH
-            ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, AFIKJP, UTYEKC, PUNRJZ, None, UTYEKC, QBMJVH
-            ),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, AFIKJP, IRYXBQ, PUNRJZ, None, UTYEKC, QBMJVH
-            ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, AFIKJP, WSKWIV, XNQTMF, None, NQTMFZ, QBMJVH
-            ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, AFIKJP, WDAFIK, FZDGKE, None, UTYEKC, QBMJVH
-            ),
-            ZMKQTD: GeckoBoolStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, EFJTAC, QBMJVH
-            ),
-            KQTDKH: GeckoEnumStructAccessor(
-                self.struct, KQTDKH, MKQTDK, UTYEKC, DKHTZB, None, WSKWIV, QBMJVH
-            ),
-            KHTZBB: GeckoByteStructAccessor(self.struct, KHTZBB, HTZBBE, QBMJVH),
-            TZBBEK: GeckoBoolStructAccessor(
-                self.struct, TZBBEK, JUTYEK, EFJTAC, QBMJVH
-            ),
-            ZBBEKB: GeckoByteStructAccessor(self.struct, ZBBEKB, BBEKBD, QBMJVH),
-            BEKBDF: GeckoEnumStructAccessor(
-                self.struct, BEKBDF, EKBDFS, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            DFSROG: GeckoEnumStructAccessor(
-                self.struct, DFSROG, EKBDFS, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            OGMDDP: GeckoEnumStructAccessor(
-                self.struct, OGMDDP, GMDDPM, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            MDDPMX: GeckoEnumStructAccessor(
-                self.struct, MDDPMX, GMDDPM, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            DDPMXF: GeckoEnumStructAccessor(
-                self.struct, DDPMXF, DPMXFU, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            PMXFUB: GeckoEnumStructAccessor(
-                self.struct, PMXFUB, DPMXFU, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            MXFUBJ: GeckoEnumStructAccessor(
-                self.struct, MXFUBJ, XFUBJL, EFJTAC, BDFSRO, None, UTYEKC, None
-            ),
-            FUBJLO: GeckoEnumStructAccessor(
-                self.struct, FUBJLO, XFUBJL, WMNZMJ, ROGMDD, None, UTYEKC, None
-            ),
-            UBJLOI: GeckoEnumStructAccessor(
-                self.struct, UBJLOI, BJLOIN, EFJTAC, NELWUE, None, NQTMFZ, None
-            ),
-            ELWUEU: GeckoBoolStructAccessor(self.struct, ELWUEU, BJLOIN, WDAFIK, None),
-            LWUEUH: GeckoBoolStructAccessor(self.struct, LWUEUH, EKBDFS, WSKWIV, None),
-            WUEUHN: GeckoBoolStructAccessor(self.struct, WUEUHN, EKBDFS, KWIVDN, None),
-            UEUHNN: GeckoBoolStructAccessor(self.struct, UEUHNN, EKBDFS, CHWDAF, None),
-            EUHNNX: GeckoBoolStructAccessor(self.struct, EUHNNX, EKBDFS, WDAFIK, None),
-            UHNNXW: GeckoBoolStructAccessor(self.struct, UHNNXW, GMDDPM, WSKWIV, None),
-            HNNXWE: GeckoBoolStructAccessor(self.struct, HNNXWE, GMDDPM, KWIVDN, None),
-            NNXWEE: GeckoBoolStructAccessor(self.struct, NNXWEE, GMDDPM, CHWDAF, None),
-            NXWEEZ: GeckoBoolStructAccessor(self.struct, NXWEEZ, GMDDPM, WDAFIK, None),
-            XWEEZF: GeckoBoolStructAccessor(self.struct, XWEEZF, DPMXFU, WSKWIV, None),
-            WEEZFE: GeckoBoolStructAccessor(self.struct, WEEZFE, DPMXFU, KWIVDN, None),
-            EEZFET: GeckoBoolStructAccessor(self.struct, EEZFET, DPMXFU, CHWDAF, None),
-            EZFETD: GeckoBoolStructAccessor(self.struct, EZFETD, DPMXFU, WDAFIK, None),
-            ZFETDR: GeckoBoolStructAccessor(self.struct, ZFETDR, XFUBJL, WSKWIV, None),
-            FETDRX: GeckoBoolStructAccessor(self.struct, FETDRX, XFUBJL, KWIVDN, None),
-            ETDRXA: GeckoBoolStructAccessor(self.struct, ETDRXA, XFUBJL, CHWDAF, None),
-            TDRXAI: GeckoBoolStructAccessor(self.struct, TDRXAI, XFUBJL, WDAFIK, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-61.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-61.py
@@ -12,1090 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AONPYY = 80
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-AWBSIR = 31
-AZMKQT = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-BBEKBD = "".join(chr(c) for c in [73, 100, 111, 108])
-BDFSRO = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-BFEGZU = 43
-BHZVOA = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BJLOIN = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 128
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVWVUB = 95
-BWJYKL = 78
-BXIBHZ = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = 8
-CHWDAF = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-CMCVDS = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRTFMN = 105
-CTHBSK = 39
-CVDSSR = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYWONF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-CZOLSI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-DAFIKJ = "".join(chr(c) for c in [50, 52, 104])
-DFSROG = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-DGKEAK = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DZXNQT = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-EAKSTS = "".join(chr(c) for c in [82, 69, 68])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-ELWUEU = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-EMCGET = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-EMVCYW = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-EOCTHB = 38
-ETDRXA = "".join(chr(c) for c in [51])
-ETIXQV = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-EUHNNX = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EZFETD = 127
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = "".join(chr(c) for c in [50])
-FFTTID = 89
-FIKJPU = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-FZDGKE = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-GKEAKS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [65, 108, 112, 115])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = 125
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = 34
-HXEKVK = 53
-HZVOAC = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IHBXIB = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = 64
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-INELWU = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = 61
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVEMVC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = 123
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JPUNRJ = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JZTATD = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-KBDFSR = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KEAKST = "".join(chr(c) for c in [79, 70, 70])
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = "".join(chr(c) for c in [82, 71, 66])
-LRAHEO = 36
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCVDSS = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-MDDPMX = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-MFZDGK = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MVCYWO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-MXFUBJ = 113
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-NFZCZO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NNXWEE = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = 110
-NRJZTA = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-NRSJMC = 25
-NRXCHW = 130
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NXWEEZ = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OGMDDP = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-OIHBXI = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-ONFZCZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMXFUB = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PUNRJZ = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QNRXCH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-QTMFZD = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-QVXOIH = 111
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAZMKQ = "".join(chr(c) for c in [80, 68, 67])
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-RKINEJ = 115
-ROGMDD = 112
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [77, 65, 65, 88])
-RXAIVE = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-RXCHWD = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SEMCGE = "".join(chr(c) for c in [67, 89, 65, 78])
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-SRURAZ = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSRURA = "".join(chr(c) for c in [76, 65])
-SSUHBV = 93
-STSEMC = "".join(chr(c) for c in [66, 76, 85, 69])
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SXUJUT = 48
-TACCPQ = 118
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-TDRXAI = "".join(chr(c) for c in [52])
-TDZXNQ = 6
-TFMNHT = 106
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-TMFZDG = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-TOPHUG = 4
-TSEMCG = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-UBJLOI = 121
-UBSSUH = 92
-UBYGDS = 97
-UEUHNN = 124
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UHBVWV = 94
-UHNNXW = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-VEMVCY = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = "".join(chr(c) for c in [65, 109, 80, 109])
-WEEZFE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WONFZC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-WVUBYG = 96
-XAIVEM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-XBQFYL = 35
-XCHWDA = 132
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XIBHZV = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-XLSXUJ = 47
-XNKMLO = 5
-XNQTMF = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-XOIHBX = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XQVXOI = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = 126
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWONFZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-ZFETDR = "".join(chr(c) for c in [49])
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-ZOLSIP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-ZTATDZ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-ZUQEXL = 45
-ZVOACM = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-ZXNQTM = 7
-AFIKJP = [JVHFTH, WDAFIK, DAFIKJ]
-AOAWBS = [JMAOAW, MAOAWB]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DDPMXF = [GMDDPM, MDDPMX, VLASSA, VLASSA]
-DRXAIV = [VLASSA, ZFETDR, FETDRX, ETDRXA, TDRXAI]
-EFJTAC = [XFEFJT, FEFJTA]
-FSROGM = [
-    VXOIHB,
-    XOIHBX,
-    OIHBXI,
-    IHBXIB,
-    HBXIBH,
-    BXIBHZ,
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-]
-IFJBIA = [TSIFJB, SIFJBI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-IRYXBQ = [BSIRYX, SIRYXB]
-IXQVXO = [ETIXQV, TIXQVX]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-LSIPMD = [KCWAON]
-LWUEUH = [NELWUE, ELWUEU]
-MCGETI = [KEAKST, EAKSTS, AKSTSE, KSTSEM, STSEMC, TSEMCG, SEMCGE, EMCGET]
-OIJUGS = [MLOIJU, LOIJUG]
-OINELW = [LOINEL, EMCGET]
-OLSIPM = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SIPMDM = []
-SPFTSI = [PIPIVL, WJYKLG]
-TATDZX = [JZTATD, ZTATDZ]
-UNRJZT = [JPUNRJ, PUNRJZ]
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-ZDGKEA = [MFZDGK, FZDGKE]
-ZILXWA = [TSIFJB, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1103,356 +19,1255 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return IPMDMP
+        return 61
 
     @property
     def output_keys(self):
-        return OLSIPM
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "OnzenStart": GeckoTimeStructAccessor(
+                self.struct, "OnzenStart", 128, "ALL"
+            ),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 130, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 132, "ALL"),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoTimeStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoTimeStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, AFIKJP, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoWordStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, UXFEFJ, MNZMJI, UNRJZT, None, TYEKCW, QBMJVH
-            ),
-            NRJZTA: GeckoBoolStructAccessor(
-                self.struct, NRJZTA, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, UXFEFJ, XNKMLO, TATDZX, None, TYEKCW, QBMJVH
-            ),
-            ATDZXN: GeckoBoolStructAccessor(
-                self.struct, ATDZXN, UXFEFJ, TDZXNQ, QBMJVH
-            ),
-            DZXNQT: GeckoBoolStructAccessor(
-                self.struct, DZXNQT, UXFEFJ, ZXNQTM, QBMJVH
-            ),
-            XNQTMF: GeckoBoolStructAccessor(
-                self.struct, XNQTMF, NQTMFZ, FJTACC, QBMJVH
-            ),
-            QTMFZD: GeckoBoolStructAccessor(
-                self.struct, QTMFZD, NQTMFZ, MNZMJI, QBMJVH
-            ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, NQTMFZ, TYEKCW, ZDGKEA, None, TYEKCW, QBMJVH
-            ),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, NQTMFZ, RYXBQF, ZDGKEA, None, TYEKCW, QBMJVH
-            ),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, NQTMFZ, UNXNKM, MCGETI, None, CGETIX, QBMJVH
-            ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, NQTMFZ, ZXNQTM, IXQVXO, None, TYEKCW, QBMJVH
-            ),
-            SROGMD: GeckoBoolStructAccessor(
-                self.struct, SROGMD, ROGMDD, MNZMJI, QBMJVH
-            ),
-            OGMDDP: GeckoEnumStructAccessor(
-                self.struct, OGMDDP, ROGMDD, TYEKCW, DDPMXF, None, UNXNKM, QBMJVH
-            ),
-            DPMXFU: GeckoBoolStructAccessor(
-                self.struct, DPMXFU, ROGMDD, UNXNKM, QBMJVH
-            ),
-            PMXFUB: GeckoByteStructAccessor(self.struct, PMXFUB, MXFUBJ, QBMJVH),
-            XFUBJL: GeckoBoolStructAccessor(
-                self.struct, XFUBJL, UTYEKC, FJTACC, QBMJVH
-            ),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, QBMJVH),
-            BJLOIN: GeckoEnumStructAccessor(
-                self.struct, BJLOIN, JLOINE, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            INELWU: GeckoEnumStructAccessor(
-                self.struct, INELWU, JLOINE, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            WUEUHN: GeckoEnumStructAccessor(
-                self.struct, WUEUHN, UEUHNN, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            EUHNNX: GeckoEnumStructAccessor(
-                self.struct, EUHNNX, UEUHNN, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            UHNNXW: GeckoEnumStructAccessor(
-                self.struct, UHNNXW, HNNXWE, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            NNXWEE: GeckoEnumStructAccessor(
-                self.struct, NNXWEE, HNNXWE, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            NXWEEZ: GeckoEnumStructAccessor(
-                self.struct, NXWEEZ, XWEEZF, FJTACC, OINELW, None, TYEKCW, None
-            ),
-            WEEZFE: GeckoEnumStructAccessor(
-                self.struct, WEEZFE, XWEEZF, MNZMJI, LWUEUH, None, TYEKCW, None
-            ),
-            EEZFET: GeckoEnumStructAccessor(
-                self.struct, EEZFET, EZFETD, FJTACC, DRXAIV, None, CGETIX, None
-            ),
-            RXAIVE: GeckoBoolStructAccessor(self.struct, RXAIVE, EZFETD, ZXNQTM, None),
-            XAIVEM: GeckoBoolStructAccessor(self.struct, XAIVEM, JLOINE, UNXNKM, None),
-            AIVEMV: GeckoBoolStructAccessor(self.struct, AIVEMV, JLOINE, XNKMLO, None),
-            IVEMVC: GeckoBoolStructAccessor(self.struct, IVEMVC, JLOINE, TDZXNQ, None),
-            VEMVCY: GeckoBoolStructAccessor(self.struct, VEMVCY, JLOINE, ZXNQTM, None),
-            EMVCYW: GeckoBoolStructAccessor(self.struct, EMVCYW, UEUHNN, UNXNKM, None),
-            MVCYWO: GeckoBoolStructAccessor(self.struct, MVCYWO, UEUHNN, XNKMLO, None),
-            VCYWON: GeckoBoolStructAccessor(self.struct, VCYWON, UEUHNN, TDZXNQ, None),
-            CYWONF: GeckoBoolStructAccessor(self.struct, CYWONF, UEUHNN, ZXNQTM, None),
-            YWONFZ: GeckoBoolStructAccessor(self.struct, YWONFZ, HNNXWE, UNXNKM, None),
-            WONFZC: GeckoBoolStructAccessor(self.struct, WONFZC, HNNXWE, XNKMLO, None),
-            ONFZCZ: GeckoBoolStructAccessor(self.struct, ONFZCZ, HNNXWE, TDZXNQ, None),
-            NFZCZO: GeckoBoolStructAccessor(self.struct, NFZCZO, HNNXWE, ZXNQTM, None),
-            FZCZOL: GeckoBoolStructAccessor(self.struct, FZCZOL, XWEEZF, UNXNKM, None),
-            ZCZOLS: GeckoBoolStructAccessor(self.struct, ZCZOLS, XWEEZF, XNKMLO, None),
-            CZOLSI: GeckoBoolStructAccessor(self.struct, CZOLSI, XWEEZF, TDZXNQ, None),
-            ZOLSIP: GeckoBoolStructAccessor(self.struct, ZOLSIP, XWEEZF, ZXNQTM, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-62.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-62.py
@@ -12,1104 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AONPYY = 80
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-AWBSIR = 31
-AZMKQT = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-BBEKBD = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-BDFSRO = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-BFEGZU = 43
-BHZVOA = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BJLOIN = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 128
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVWVUB = 95
-BWJYKL = 78
-BXIBHZ = 111
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-CHWDAF = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-CMCVDS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRTFMN = 105
-CTHBSK = 39
-CVDSSR = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYWONF = "".join(chr(c) for c in [52])
-CZOLSI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-DFSROG = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-DMPSCT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DRXAIV = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DZXNQT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EAKSTS = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-ELWUEU = 113
-EMCGET = "".join(chr(c) for c in [82, 69, 68])
-EMVCYW = "".join(chr(c) for c in [49])
-EOCTHB = 38
-ETDRXA = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-ETIXQV = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-EUHNNX = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EZFETD = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-FFTTID = 89
-FIKJPU = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FSROGM = "".join(chr(c) for c in [73, 100, 111, 108])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-FZDGKE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-GCRHYU = 62
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(chr(c) for c in [66, 76, 85, 69])
-GKEAKS = 110
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = "".join(chr(c) for c in [82, 71, 66])
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = 157
-HXEKVK = 53
-HZVOAC = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = 158
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVEMVC = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JPUNRJ = 34
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JZTATD = 64
-KBDFSR = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KEAKST = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [77, 65, 65, 88])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-LRAHEO = 36
-LSIPMD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCGETI = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-MCVDSS = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-MDDPMX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-MDMPSC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-MFZDGK = 6
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MPSCTT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-MVCYWO = "".join(chr(c) for c in [50])
-MXFUBJ = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-NFZCZO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NRSJMC = 25
-NRXCHW = 130
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NXWEEZ = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OGMDDP = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-OIHBXI = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-OINELW = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-OLSIPM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-ONFZCZ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMDMPS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-PMXFUB = 112
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PSCTTG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-PUNRJZ = "".join(chr(c) for c in [65, 109, 80, 109])
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QNRXCH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QVXOIH = 8
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAZMKQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RKINEJ = 115
-ROGMDD = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-RXAIVE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-RXCHWD = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SCTTGC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIPMDM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-SRURAZ = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSRURA = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SSUHBV = 93
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SXUJUT = 48
-TACCPQ = 118
-TATDZX = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(chr(c) for c in [80, 68, 67])
-TDRXAI = 125
-TFMNHT = 106
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(chr(c) for c in [67, 89, 65, 78])
-TMFZDG = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-TOPHUG = 4
-TSEMCG = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UBSSUH = 92
-UBYGDS = 97
-UEUHNN = 121
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UHBVWV = 94
-UHNNXW = 123
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNRJZT = "".join(chr(c) for c in [50, 52, 104])
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(chr(c) for c in [51])
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-VEMVCY = 127
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VOACMC = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = "".join(chr(c) for c in [79, 70, 70])
-WEEZFE = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WONFZC = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-WVUBYG = 96
-XAIVEM = 126
-XBQFYL = 35
-XCHWDA = 132
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-XIBHZV = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-XLSXUJ = 47
-XNKMLO = 5
-XNQTMF = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-XOIHBX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-ZDGKEA = 7
-ZFETDR = 124
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [76, 65])
-ZOLSIP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-ZTATDZ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ZUQEXL = 45
-ZVOACM = "".join(chr(c) for c in [65, 108, 112, 115])
-ZXNQTM = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AFIKJP = [JVHFTH, WDAFIK, VLASSA, DAFIKJ]
-AOAWBS = [JMAOAW, MAOAWB]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CTTGCR = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DDPMXF = [
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-]
-EEZFET = [XWEEZF, WEEZFE]
-EFJTAC = [XFEFJT, FEFJTA]
-IFJBIA = [TSIFJB, SIFJBI]
-IHBXIB = [XOIHBX, OIHBXI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-INELWU = [JVHFTH, LOINEL, OINELW, VLASSA]
-IRYXBQ = [BSIRYX, SIRYXB]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-NNXWEE = [HNNXWE, IXQVXO]
-NRJZTA = [JVHFTH, PUNRJZ, UNRJZT]
-OIJUGS = [MLOIJU, LOIJUG]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QTMFZD = [XNQTMF, NQTMFZ]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SPFTSI = [PIPIVL, WJYKLG]
-STSEMC = [AKSTSE, KSTSEM]
-TDZXNQ = [TATDZX, ATDZXN]
-TGCRHY = []
-TTGCRH = [KCWAON]
-UBJLOI = [XFUBJL, FUBJLO, VLASSA, VLASSA]
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-XQVXOI = [WDAFIK, EMCGET, MCGETI, CGETIX, GETIXQ, ETIXQV, TIXQVX, IXQVXO]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-YWONFZ = [VLASSA, EMVCYW, MVCYWO, VCYWON, CYWONF]
-ZILXWA = [TSIFJB, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1117,363 +19,1278 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GCRHYU
+        return 62
 
     @property
     def output_keys(self):
-        return CTTGCR
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "OnzenStart": GeckoTimeStructAccessor(
+                self.struct, "OnzenStart", 128, "ALL"
+            ),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 130, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 132, "ALL"),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoTimeStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoTimeStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, AFIKJP, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoTimeStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoWordStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, UXFEFJ, MNZMJI, TDZXNQ, None, TYEKCW, QBMJVH
-            ),
-            DZXNQT: GeckoBoolStructAccessor(
-                self.struct, DZXNQT, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, UXFEFJ, XNKMLO, QTMFZD, None, TYEKCW, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, UXFEFJ, MFZDGK, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, UXFEFJ, ZDGKEA, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, GKEAKS, FJTACC, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, GKEAKS, MNZMJI, QBMJVH
-            ),
-            EAKSTS: GeckoEnumStructAccessor(
-                self.struct, EAKSTS, GKEAKS, TYEKCW, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, GKEAKS, RYXBQF, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, GKEAKS, UNXNKM, XQVXOI, None, QVXOIH, QBMJVH
-            ),
-            VXOIHB: GeckoEnumStructAccessor(
-                self.struct, VXOIHB, GKEAKS, ZDGKEA, IHBXIB, None, TYEKCW, QBMJVH
-            ),
-            DPMXFU: GeckoBoolStructAccessor(
-                self.struct, DPMXFU, PMXFUB, MNZMJI, QBMJVH
-            ),
-            MXFUBJ: GeckoEnumStructAccessor(
-                self.struct, MXFUBJ, PMXFUB, TYEKCW, UBJLOI, None, UNXNKM, QBMJVH
-            ),
-            BJLOIN: GeckoBoolStructAccessor(
-                self.struct, BJLOIN, PMXFUB, UNXNKM, QBMJVH
-            ),
-            JLOINE: GeckoEnumStructAccessor(
-                self.struct, JLOINE, PMXFUB, MFZDGK, INELWU, None, UNXNKM, QBMJVH
-            ),
-            NELWUE: GeckoByteStructAccessor(self.struct, NELWUE, ELWUEU, QBMJVH),
-            LWUEUH: GeckoBoolStructAccessor(
-                self.struct, LWUEUH, UTYEKC, FJTACC, QBMJVH
-            ),
-            WUEUHN: GeckoByteStructAccessor(self.struct, WUEUHN, UEUHNN, QBMJVH),
-            EUHNNX: GeckoEnumStructAccessor(
-                self.struct, EUHNNX, UHNNXW, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            NXWEEZ: GeckoEnumStructAccessor(
-                self.struct, NXWEEZ, UHNNXW, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            EZFETD: GeckoEnumStructAccessor(
-                self.struct, EZFETD, ZFETDR, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            FETDRX: GeckoEnumStructAccessor(
-                self.struct, FETDRX, ZFETDR, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            ETDRXA: GeckoEnumStructAccessor(
-                self.struct, ETDRXA, TDRXAI, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            DRXAIV: GeckoEnumStructAccessor(
-                self.struct, DRXAIV, TDRXAI, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            RXAIVE: GeckoEnumStructAccessor(
-                self.struct, RXAIVE, XAIVEM, FJTACC, NNXWEE, None, TYEKCW, None
-            ),
-            AIVEMV: GeckoEnumStructAccessor(
-                self.struct, AIVEMV, XAIVEM, MNZMJI, EEZFET, None, TYEKCW, None
-            ),
-            IVEMVC: GeckoEnumStructAccessor(
-                self.struct, IVEMVC, VEMVCY, FJTACC, YWONFZ, None, QVXOIH, None
-            ),
-            WONFZC: GeckoBoolStructAccessor(self.struct, WONFZC, VEMVCY, ZDGKEA, None),
-            ONFZCZ: GeckoBoolStructAccessor(self.struct, ONFZCZ, UHNNXW, UNXNKM, None),
-            NFZCZO: GeckoBoolStructAccessor(self.struct, NFZCZO, UHNNXW, XNKMLO, None),
-            FZCZOL: GeckoBoolStructAccessor(self.struct, FZCZOL, UHNNXW, MFZDGK, None),
-            ZCZOLS: GeckoBoolStructAccessor(self.struct, ZCZOLS, UHNNXW, ZDGKEA, None),
-            CZOLSI: GeckoBoolStructAccessor(self.struct, CZOLSI, ZFETDR, UNXNKM, None),
-            ZOLSIP: GeckoBoolStructAccessor(self.struct, ZOLSIP, ZFETDR, XNKMLO, None),
-            OLSIPM: GeckoBoolStructAccessor(self.struct, OLSIPM, ZFETDR, MFZDGK, None),
-            LSIPMD: GeckoBoolStructAccessor(self.struct, LSIPMD, ZFETDR, ZDGKEA, None),
-            SIPMDM: GeckoBoolStructAccessor(self.struct, SIPMDM, TDRXAI, UNXNKM, None),
-            IPMDMP: GeckoBoolStructAccessor(self.struct, IPMDMP, TDRXAI, XNKMLO, None),
-            PMDMPS: GeckoBoolStructAccessor(self.struct, PMDMPS, TDRXAI, MFZDGK, None),
-            MDMPSC: GeckoBoolStructAccessor(self.struct, MDMPSC, TDRXAI, ZDGKEA, None),
-            DMPSCT: GeckoBoolStructAccessor(self.struct, DMPSCT, XAIVEM, UNXNKM, None),
-            MPSCTT: GeckoBoolStructAccessor(self.struct, MPSCTT, XAIVEM, XNKMLO, None),
-            PSCTTG: GeckoBoolStructAccessor(self.struct, PSCTTG, XAIVEM, MFZDGK, None),
-            SCTTGC: GeckoBoolStructAccessor(self.struct, SCTTGC, XAIVEM, ZDGKEA, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-63.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-63.py
@@ -12,1510 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-ADXLUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AOESVZ = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-AONPYY = 80
-APUMEA = "".join(chr(c) for c in [49])
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-AWBSIR = 31
-AXADXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-AXNCUG = 124
-AZMKQT = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-BBEKBD = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-BDFSRO = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-BFEGZU = 43
-BHZVOA = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BJLOIN = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 128
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVNAXA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-BVWVUB = 95
-BWJYKL = 78
-BXIBHZ = 111
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-CHWDAF = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-CMCVDS = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRHYUA = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-CRTFMN = 105
-CTHBSK = 39
-CTTGCR = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-CUGUCY = 125
-CVDSSR = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYRAPU = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-CYWONF = 137
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-DFSROG = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-DGKEAK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-DMPSCT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DRXAIV = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DXLUBG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-DZXNQT = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-EAKSTS = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-ELWUEU = 113
-EMCGET = "".join(chr(c) for c in [82, 69, 68])
-EMVCYW = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-EOCTHB = 38
-ESVZSS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-ETDRXA = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-ETIXQV = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-EUHNNX = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = 135
-FFTTID = 89
-FIKJPU = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FSROGM = "".join(chr(c) for c in [73, 100, 111, 108])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-FZDGKE = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(chr(c) for c in [66, 76, 85, 69])
-GKEAKS = 110
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GUCYRA = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(chr(c) for c in [79, 110, 122, 101, 110, 83, 116, 97, 114, 116])
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = 157
-HXEKVK = 53
-HYUAXN = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-HZVOAC = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = 158
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = 149
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JFJNTT = 63
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JPUNRJ = 34
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-JZTATD = 64
-KBDFSR = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KEAKST = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KJPUNR = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [77, 65, 65, 88])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-LRAHEO = 36
-LSIPMD = 147
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LUBGJF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCGETI = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-MCVDSS = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-MDDPMX = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-MDMPSC = 151
-MEAOES = "".join(chr(c) for c in [52])
-MFZDGK = 6
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MPSCTT = 153
-MVCYWO = 136
-MXFUBJ = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-NAXADX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NCUGUC = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-NFZCZO = 141
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NNXWEE = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-NRSJMC = 25
-NRXCHW = 130
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-OGMDDP = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-OIHBXI = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-OINELW = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-OLSIPM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-ONFZCZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMDMPS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-PMXFUB = 112
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PSCTTG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-PUMEAO = "".join(chr(c) for c in [50])
-PUNRJZ = "".join(chr(c) for c in [65, 109, 80, 109])
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QNRXCH = "".join(chr(c) for c in [79, 110, 122, 101, 110, 68, 117, 114])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-QVXOIH = 8
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = 127
-RAZMKQ = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-RHYUAX = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RKINEJ = 115
-ROGMDD = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-RXAIVE = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-RXCHWD = "".join(chr(c) for c in [79, 110, 122, 101, 110, 70, 114, 101, 113])
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SBVNAX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-SCTTGC = 155
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIPMDM = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-SRURAZ = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-SSRURA = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-SSUHBV = 93
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SVZSSB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-SXUJUT = 48
-TACCPQ = 118
-TATDZX = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(chr(c) for c in [80, 68, 67])
-TDRXAI = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-TFMNHT = 106
-TGCRHY = "".join(chr(c) for c in [82, 71, 66])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(chr(c) for c in [67, 89, 65, 78])
-TMFZDG = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-TOPHUG = 4
-TSEMCG = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTGCRH = 123
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UAXNCU = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-UBSSUH = 92
-UBYGDS = 97
-UCYRAP = 126
-UEUHNN = 121
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UGUCYR = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-UHBVWV = 94
-UHNNXW = 133
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UMEAOE = "".join(chr(c) for c in [51])
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNRJZT = "".join(chr(c) for c in [50, 52, 104])
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-VEMVCY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-VOACMC = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = "".join(chr(c) for c in [79, 70, 70])
-WEEZFE = 134
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WONFZC = 139
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-WVUBYG = 96
-XADXLU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-XAIVEM = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-XBQFYL = 35
-XCHWDA = 132
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-XIBHZV = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-XLSXUJ = 47
-XLUBGJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-XNCUGU = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-XNKMLO = 5
-XNQTMF = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-XOIHBX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-YWONFZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = 143
-ZDGKEA = 7
-ZFETDR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [76, 65])
-ZOLSIP = 145
-ZSSBVN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-ZTATDZ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ZUQEXL = 45
-ZVOACM = "".join(chr(c) for c in [65, 108, 112, 115])
-ZXNQTM = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-AFIKJP = [JVHFTH, WDAFIK, VLASSA, DAFIKJ]
-AOAWBS = [JMAOAW, MAOAWB]
-BGJFJN = [KCWAON]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DDPMXF = [
-    XIBHZV,
-    IBHZVO,
-    BHZVOA,
-    HZVOAC,
-    ZVOACM,
-    VOACMC,
-    OACMCV,
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-]
-EAOESV = [VLASSA, APUMEA, PUMEAO, UMEAOE, MEAOES]
-EFJTAC = [XFEFJT, FEFJTA]
-EZFETD = [EEZFET]
-GCRHYU = [TGCRHY, IXQVXO]
-GJFJNT = []
-IFJBIA = [TSIFJB, SIFJBI]
-IHBXIB = [XOIHBX, OIHBXI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-INELWU = [JVHFTH, LOINEL, OINELW, VLASSA]
-IRYXBQ = [BSIRYX, SIRYXB]
-IVEMVC = [ETDRXA, TDRXAI, DRXAIV, RXAIVE, XAIVEM, AIVEMV, VLASSA, VLASSA]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-NRJZTA = [JVHFTH, PUNRJZ, UNRJZT]
-NXWEEZ = [HNNXWE, NNXWEE]
-OIJUGS = [MLOIJU, LOIJUG]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QPLSPF = [LGQPLS, GQPLSP]
-QTMFZD = [XNQTMF, NQTMFZ]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SPFTSI = [PIPIVL, WJYKLG]
-STSEMC = [AKSTSE, KSTSEM]
-TDZXNQ = [TATDZX, ATDZXN]
-UBGJFJ = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-UBJLOI = [XFUBJL, FUBJLO, VLASSA, VLASSA]
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-XQVXOI = [WDAFIK, EMCGET, MCGETI, CGETIX, GETIXQ, ETIXQV, TIXQVX, IXQVXO]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-YUAXNC = [RHYUAX, HYUAXN]
-ZILXWA = [TSIFJB, KZILXW]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1523,386 +19,1353 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return JFJNTT
+        return 63
 
     @property
     def output_keys(self):
-        return UBGJFJ
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "OnzenStart": GeckoTimeStructAccessor(
+                self.struct, "OnzenStart", 128, "ALL"
+            ),
+            "OnzenDur": GeckoTimeStructAccessor(self.struct, "OnzenDur", 130, "ALL"),
+            "OnzenFreq": GeckoByteStructAccessor(self.struct, "OnzenFreq", 132, "ALL"),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoTimeStructAccessor(self.struct, HBQNRX, BQNRXC, QBMJVH),
-            QNRXCH: GeckoTimeStructAccessor(self.struct, QNRXCH, NRXCHW, QBMJVH),
-            RXCHWD: GeckoByteStructAccessor(self.struct, RXCHWD, XCHWDA, QBMJVH),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, AFIKJP, None, None, QBMJVH
-            ),
-            FIKJPU: GeckoTimeStructAccessor(self.struct, FIKJPU, IKJPUN, QBMJVH),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoWordStructAccessor(self.struct, RJZTAT, JZTATD, QBMJVH),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, UXFEFJ, MNZMJI, TDZXNQ, None, TYEKCW, QBMJVH
-            ),
-            DZXNQT: GeckoBoolStructAccessor(
-                self.struct, DZXNQT, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, UXFEFJ, XNKMLO, QTMFZD, None, TYEKCW, QBMJVH
-            ),
-            TMFZDG: GeckoBoolStructAccessor(
-                self.struct, TMFZDG, UXFEFJ, MFZDGK, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, UXFEFJ, ZDGKEA, QBMJVH
-            ),
-            DGKEAK: GeckoBoolStructAccessor(
-                self.struct, DGKEAK, GKEAKS, FJTACC, QBMJVH
-            ),
-            KEAKST: GeckoBoolStructAccessor(
-                self.struct, KEAKST, GKEAKS, MNZMJI, QBMJVH
-            ),
-            EAKSTS: GeckoEnumStructAccessor(
-                self.struct, EAKSTS, GKEAKS, TYEKCW, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, GKEAKS, RYXBQF, STSEMC, None, TYEKCW, QBMJVH
-            ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, GKEAKS, UNXNKM, XQVXOI, None, QVXOIH, QBMJVH
-            ),
-            VXOIHB: GeckoEnumStructAccessor(
-                self.struct, VXOIHB, GKEAKS, ZDGKEA, IHBXIB, None, TYEKCW, QBMJVH
-            ),
-            DPMXFU: GeckoBoolStructAccessor(
-                self.struct, DPMXFU, PMXFUB, MNZMJI, QBMJVH
-            ),
-            MXFUBJ: GeckoEnumStructAccessor(
-                self.struct, MXFUBJ, PMXFUB, TYEKCW, UBJLOI, None, UNXNKM, QBMJVH
-            ),
-            BJLOIN: GeckoBoolStructAccessor(
-                self.struct, BJLOIN, PMXFUB, UNXNKM, QBMJVH
-            ),
-            JLOINE: GeckoEnumStructAccessor(
-                self.struct, JLOINE, PMXFUB, MFZDGK, INELWU, None, UNXNKM, QBMJVH
-            ),
-            NELWUE: GeckoByteStructAccessor(self.struct, NELWUE, ELWUEU, QBMJVH),
-            LWUEUH: GeckoBoolStructAccessor(
-                self.struct, LWUEUH, UTYEKC, FJTACC, QBMJVH
-            ),
-            WUEUHN: GeckoByteStructAccessor(self.struct, WUEUHN, UEUHNN, QBMJVH),
-            EUHNNX: GeckoEnumStructAccessor(
-                self.struct, EUHNNX, UHNNXW, None, NXWEEZ, None, None, QBMJVH
-            ),
-            XWEEZF: GeckoEnumStructAccessor(
-                self.struct, XWEEZF, WEEZFE, None, EZFETD, None, None, QBMJVH
-            ),
-            ZFETDR: GeckoEnumStructAccessor(
-                self.struct, ZFETDR, FETDRX, FJTACC, IVEMVC, None, QVXOIH, QBMJVH
-            ),
-            VEMVCY: GeckoBoolStructAccessor(
-                self.struct, VEMVCY, FETDRX, ZDGKEA, QBMJVH
-            ),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, QBMJVH),
-            VCYWON: GeckoWordStructAccessor(self.struct, VCYWON, CYWONF, QBMJVH),
-            YWONFZ: GeckoWordStructAccessor(self.struct, YWONFZ, WONFZC, QBMJVH),
-            ONFZCZ: GeckoWordStructAccessor(self.struct, ONFZCZ, NFZCZO, QBMJVH),
-            FZCZOL: GeckoWordStructAccessor(self.struct, FZCZOL, ZCZOLS, QBMJVH),
-            CZOLSI: GeckoWordStructAccessor(self.struct, CZOLSI, ZOLSIP, QBMJVH),
-            OLSIPM: GeckoWordStructAccessor(self.struct, OLSIPM, LSIPMD, QBMJVH),
-            SIPMDM: GeckoWordStructAccessor(self.struct, SIPMDM, IPMDMP, QBMJVH),
-            PMDMPS: GeckoWordStructAccessor(self.struct, PMDMPS, MDMPSC, QBMJVH),
-            DMPSCT: GeckoWordStructAccessor(self.struct, DMPSCT, MPSCTT, QBMJVH),
-            PSCTTG: GeckoWordStructAccessor(self.struct, PSCTTG, SCTTGC, QBMJVH),
-            CTTGCR: GeckoEnumStructAccessor(
-                self.struct, CTTGCR, TTGCRH, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            CRHYUA: GeckoEnumStructAccessor(
-                self.struct, CRHYUA, TTGCRH, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            UAXNCU: GeckoEnumStructAccessor(
-                self.struct, UAXNCU, AXNCUG, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            XNCUGU: GeckoEnumStructAccessor(
-                self.struct, XNCUGU, AXNCUG, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            NCUGUC: GeckoEnumStructAccessor(
-                self.struct, NCUGUC, CUGUCY, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            UGUCYR: GeckoEnumStructAccessor(
-                self.struct, UGUCYR, CUGUCY, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            GUCYRA: GeckoEnumStructAccessor(
-                self.struct, GUCYRA, UCYRAP, FJTACC, GCRHYU, None, TYEKCW, None
-            ),
-            CYRAPU: GeckoEnumStructAccessor(
-                self.struct, CYRAPU, UCYRAP, MNZMJI, YUAXNC, None, TYEKCW, None
-            ),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, RAPUME, FJTACC, EAOESV, None, QVXOIH, None
-            ),
-            AOESVZ: GeckoBoolStructAccessor(self.struct, AOESVZ, RAPUME, ZDGKEA, None),
-            OESVZS: GeckoBoolStructAccessor(self.struct, OESVZS, TTGCRH, UNXNKM, None),
-            ESVZSS: GeckoBoolStructAccessor(self.struct, ESVZSS, TTGCRH, XNKMLO, None),
-            SVZSSB: GeckoBoolStructAccessor(self.struct, SVZSSB, TTGCRH, MFZDGK, None),
-            VZSSBV: GeckoBoolStructAccessor(self.struct, VZSSBV, TTGCRH, ZDGKEA, None),
-            ZSSBVN: GeckoBoolStructAccessor(self.struct, ZSSBVN, AXNCUG, UNXNKM, None),
-            SSBVNA: GeckoBoolStructAccessor(self.struct, SSBVNA, AXNCUG, XNKMLO, None),
-            SBVNAX: GeckoBoolStructAccessor(self.struct, SBVNAX, AXNCUG, MFZDGK, None),
-            BVNAXA: GeckoBoolStructAccessor(self.struct, BVNAXA, AXNCUG, ZDGKEA, None),
-            VNAXAD: GeckoBoolStructAccessor(self.struct, VNAXAD, CUGUCY, UNXNKM, None),
-            NAXADX: GeckoBoolStructAccessor(self.struct, NAXADX, CUGUCY, XNKMLO, None),
-            AXADXL: GeckoBoolStructAccessor(self.struct, AXADXL, CUGUCY, MFZDGK, None),
-            XADXLU: GeckoBoolStructAccessor(self.struct, XADXLU, CUGUCY, ZDGKEA, None),
-            ADXLUB: GeckoBoolStructAccessor(self.struct, ADXLUB, UCYRAP, UNXNKM, None),
-            DXLUBG: GeckoBoolStructAccessor(self.struct, DXLUBG, UCYRAP, XNKMLO, None),
-            XLUBGJ: GeckoBoolStructAccessor(self.struct, XLUBGJ, UCYRAP, MFZDGK, None),
-            LUBGJF: GeckoBoolStructAccessor(self.struct, LUBGJF, UCYRAP, ZDGKEA, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-64.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-64.py
@@ -12,1578 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-ACMCVD = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-ACQFFT = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-ADXLUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-AFIKJP = 157
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-AJVDQL = "".join(chr(c) for c in [70, 51])
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = 6
-AMJMAO = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-AOESVZ = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-AONPYY = 80
-APUMEA = 125
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ATDZXN = "".join(chr(c) for c in [65, 109, 80, 109])
-AWBSIR = 31
-AXADXL = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-AXNCUG = "".join(chr(c) for c in [82, 71, 66])
-AZMKQT = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-BBEKBD = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-BDFSRO = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-BDJQRJ = 100
-BEKBDF = "".join(chr(c) for c in [80, 68, 67])
-BFEGZU = 43
-BGJFJN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-BHZVOA = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-BIAMJM = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-BJEUTO = 109
-BLKXSJ = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-BQNRXC = 160
-BQSNQL = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-BSIRYX = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-BVNAXA = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-BVWVUB = 95
-BWJYKL = 78
-BXTIAC = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-BYGDSB = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-CBFEGZ = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-CCPQIP = 120
-CGETIX = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-CHWDAF = 130
-CMCVDS = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-CPQIPO = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-CQBMJV = 0
-CQFFTT = 88
-CRHYUA = 153
-CRTFMN = 105
-CTHBSK = 39
-CTTGCR = 149
-CUGUCY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-CVDSSR = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CXQIEF = 14
-CYRAPU = 124
-CYWONF = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-CZOLSI = 137
-DAFIKJ = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-DDPMXF = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-DFSROG = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-DGKEAK = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-DJQRJJ = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-DKHTZB = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-DMPSCT = 145
-DNIBXT = 84
-DNQGVU = 72
-DPMXFU = "".join(chr(c) for c in [73, 100, 111, 108])
-DQLAII = "".join(chr(c) for c in [70, 50, 51])
-DRXAIV = 134
-DSBDJQ = 99
-DSSRUR = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-DUBSSU = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-DXLUBG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-EAKSTS = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-EAOESV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-EFXQGL = 16
-EGZUQE = 44
-EJNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-EKBDFS = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-EKCWAO = 79
-EKVKZI = 122
-ELHBQN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-EMCGET = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-EMVCYW = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-EOCTHB = 38
-ESVZSS = "".join(chr(c) for c in [49])
-EUHNNX = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-EUTOPH = 3
-EXLSXU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-EZFETD = 133
-FCRTFM = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-FEFJTA = "".join(chr(c) for c in [79, 119, 110])
-FEGZUQ = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FETDRX = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-FFTTID = 89
-FIKJPU = "".join(chr(c) for c in [79, 70, 70])
-FJBIAM = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-FJNTTU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-FJTACC = 0
-FMNHTB = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-FSROGM = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 30
-FTTIDU = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-FUBJLO = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-FWRKIN = 77
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FYLJUI = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-FZCZOL = 136
-FZDGKE = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-GCRHYU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-GDSBDJ = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-GETIXQ = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-GJFJNT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-GKEAKS = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-GQPLSP = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-GSELHB = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-GTYIYW = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-GVUNXN = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-GYOUSP = 60
-GZUQEX = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-HBQNRX = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-HBXIBH = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = 22
-HNNXWE = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-HTBJEU = 108
-HTZBBE = "".join(chr(c) for c in [76, 65])
-HUGTYI = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-HUOJRJ = 19
-HWDAFI = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-HXEKVK = 53
-HYUAXN = 155
-HZVOAC = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-IACQFF = 87
-IAMJMA = 1
-IBHZVO = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-IBXTIA = 85
-IBXYBQ = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-IDUBSS = 91
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-IHBXIB = "".join(chr(c) for c in [67, 89, 65, 78])
-IJUGSE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-IKJPUN = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-ILXWAJ = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-INELWU = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-IPOUYN = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-IUSOOQ = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-IUXFEF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-IVDNQG = 82
-IVEMVC = 135
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-IYWSKW = 10
-JBIAMJ = 63
-JEUTOP = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-JFJNTT = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-JHIUSO = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-JIGYOU = 59
-JJJVYF = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JJVYFC = 103
-JLOINE = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-JMAOAW = "".join(chr(c) for c in [70])
-JMCBFE = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-JNIBXY = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-JNTTUV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-JPUNRJ = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-JQRJJJ = 101
-JRJHIU = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-JTACCP = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-JUGSEL = 73
-JUIKFW = 70
-JUTYEK = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-JVDQLA = "".join(chr(c) for c in [70, 50, 49])
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-JYMOUN = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-KBDFSR = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-KCWAON = "".join(chr(c) for c in [76, 73])
-KFWRKI = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-KHTZBB = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-KINEJN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KLGQPL = 28
-KMLOIJ = 76
-KPHUOJ = 18
-KQTDKH = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(chr(c) for c in [79, 117, 116, 54])
-KSTSEM = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-KVKZIL = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-KZILXW = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-LAIIDN = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LGQPLS = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-LHBQNR = 75
-LIUXFE = 56
-LJUIKF = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-LNMHXE = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-LOIJUG = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-LOINEL = 112
-LRAHEO = 36
-LSIPMD = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-LSPFTS = 29
-LSXUJU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-LUBGJF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-LXWAJV = 83
-MAOAWB = "".join(chr(c) for c in [67])
-MCBFEG = 42
-MCGETI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-MCVDSS = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-MDDPMX = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-MDMPSC = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-MEAOES = 126
-MHXEKV = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-MJIGYO = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-MJMAOA = 33
-MJVHFT = 12
-MKQTDK = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-MLOIJU = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-MNHTBJ = 107
-MNZMJI = 1
-MOUNBL = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-MPSCTT = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-MVCYWO = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-MXFUBJ = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-NAXADX = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-NBLKXS = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-NCUGUC = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-NEJNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-NELWUE = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-NFZCZO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-NIBXTI = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-NIBXYB = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NKMLOI = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-NMHXEK = 52
-NNXWEE = 113
-NPYYLI = 54
-NQGVUN = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-NQJYMO = 27
-NQLNMH = "".join(chr(c) for c in [67, 69])
-NQTMFZ = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-NRJZTA = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-NRSJMC = 25
-NRXCHW = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-NTTUVR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-NXNKML = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-NXWEEZ = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-NZMJIG = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-OACMCV = 111
-OAWBSI = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = 127
-OGMDDP = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-OIHBXI = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-OINELW = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-OJRJHI = 20
-OKPHUO = "".join(chr(c) for c in [79, 117, 116, 55])
-OLSIPM = 139
-ONFZCZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-ONPYYL = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-OOQNRS = 24
-OPHUGT = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-OUNBLK = 57
-OUSPBW = 61
-OUYNQJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-PBWJYK = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-PFTSIF = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-PHUGTY = 6
-PHUOJR = "".join(chr(c) for c in [79, 117, 116, 56])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-PMDMPS = 143
-PMXFUB = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-POUYNQ = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-PQIPOU = 32
-PSCTTG = 147
-PUMEAO = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-PUNRJZ = 158
-PYYLIU = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = 46
-QFFTTI = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QFYLJU = 66
-QGVUNX = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-QIEFXQ = 15
-QIPOUY = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-QJYMOU = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QLAIID = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-QNRSJM = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-QRJJJV = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-QSNQLN = 51
-QTDKHT = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-QTMFZD = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-QVXOIH = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-RAZMKQ = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-RHYUAX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-RJHIUS = 21
-RJJJVY = 102
-RJZTAT = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-RKINEJ = 115
-ROGMDD = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-RSJMCB = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-RTFMNH = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-RURAZM = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-RXAIVE = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-RXCHWD = 128
-RYXBQF = 3
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-SBVNAX = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-SCTTGC = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-SEMCGE = 110
-SIFJBI = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-SIPMDM = 141
-SIRYXB = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-SJMCBF = 41
-SJWMNZ = "".join(chr(c) for c in [72, 105])
-SKSOKP = 50
-SKWIVD = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-SNQLNM = "".join(chr(c) for c in [85, 76])
-SOKPHU = 17
-SOOQNR = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-SPBWJY = 62
-SROGMD = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-SRURAZ = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSRURA = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-SSUHBV = 93
-STSEMC = 7
-SUHBVW = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-SVZSSB = "".join(chr(c) for c in [50])
-SXUJUT = 48
-TACCPQ = 118
-TATDZX = 34
-TBJEUT = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-TDKHTZ = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-TDRXAI = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-TDZXNQ = "".join(chr(c) for c in [50, 52, 104])
-TFMNHT = 106
-TGCRHY = 151
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-TIDUBS = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-TIXQVX = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-TMFZDG = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-TOPHUG = 4
-TSEMCG = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-TSIFJB = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-TTGCRH = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-TTIDUB = 90
-TYEKCW = 2
-TYIYWS = 8
-TZBBEK = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-UAXNCU = 123
-UBGJFJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-UBJLOI = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-UBSSUH = 92
-UBYGDS = 97
-UCYRAP = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-UEUHNN = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-UGSELH = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-UGTYIY = 116
-UGUCYR = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-UHBVWV = 94
-UIKFWR = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-UJUTYE = 49
-UMEAOE = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-UNBLKX = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-UNRJZT = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-UNXNKM = 4
-UOJRJH = "".join(chr(c) for c in [79, 117, 116, 57])
-UQEXLS = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-URAZMK = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-USOOQN = 23
-USPBWJ = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-UTOPHU = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-UTYEKC = 119
-UXFEFJ = 81
-VCYWON = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-VDNQGV = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-VDQLAI = "".join(chr(c) for c in [70, 50, 50])
-VDSSRU = "".join(chr(c) for c in [65, 108, 112, 115])
-VEMVCY = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = 74
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-VOACMC = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-VRFLSI = 64
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-VUNXNK = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-VWVUBY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-VXOIHB = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-VYFCRT = 104
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(chr(c) for c in [51])
-WAJVDQ = "".join(chr(c) for c in [70, 50])
-WAONPY = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-WBSIRY = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-WDAFIK = 132
-WEEZFE = 121
-WIVDNQ = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-WJYKLG = "".join(chr(c) for c in [80, 49])
-WMNZMJ = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-WRKINE = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-WSKWIV = 71
-WUEUHN = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-WVUBYG = 96
-XADXLU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-XBQFYL = 35
-XCHWDA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-XFUBJL = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-XIBHZV = 8
-XLSXUJ = 47
-XLUBGJ = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-XNKMLO = 5
-XNQTMF = 64
-XOIHBX = "".join(chr(c) for c in [66, 76, 85, 69])
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XQVXOI = "".join(chr(c) for c in [82, 69, 68])
-XSJWMN = "".join(chr(c) for c in [76, 111])
-XTIACQ = 86
-XUJUTY = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-XWAJVD = "".join(chr(c) for c in [70, 49])
-XWEEZF = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-YBQSNQ = 114
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-YGDSBD = 98
-YIYWSK = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-YKLGQP = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YLIUXF = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-YLJUIK = 68
-YNQJYM = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-YOUSPB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-YUAXNC = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-YWONFZ = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-YWSKWI = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-YXBQFY = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-YYLIUX = 55
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [77, 65, 65, 88])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-ZDGKEA = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-ZFETDR = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-ZMJIGY = 58
-ZMKQTD = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-ZOLSIP = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-ZSSBVN = "".join(chr(c) for c in [52])
-ZTATDZ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-ZUQEXL = 45
-ZXNQTM = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-AOAWBS = [JMAOAW, MAOAWB]
-BJLOIN = [
-    ACMCVD,
-    CMCVDS,
-    MCVDSS,
-    CVDSSR,
-    VDSSRU,
-    DSSRUR,
-    SSRURA,
-    SRURAZ,
-    RURAZM,
-    URAZMK,
-    RAZMKQ,
-    AZMKQT,
-    ZMKQTD,
-    MKQTDK,
-    KQTDKH,
-    QTDKHT,
-    TDKHTZ,
-    DKHTZB,
-    KHTZBB,
-    HTZBBE,
-    TZBBEK,
-    ZBBEKB,
-    BBEKBD,
-    BEKBDF,
-    EKBDFS,
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-    DDPMXF,
-    DPMXFU,
-    PMXFUB,
-    MXFUBJ,
-    XFUBJL,
-    FUBJLO,
-    UBJLOI,
-]
-BXIBHZ = [FIKJPU, XQVXOI, QVXOIH, VXOIHB, XOIHBX, OIHBXI, IHBXIB, HBXIBH]
-BXYBQS = [KINEJN, INEJNI, NEJNIB, EJNIBX, JNIBXY, NIBXYB, IBXYBQ]
-CWAONP = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KCWAON,
-]
-DZXNQT = [JVHFTH, ATDZXN, TDZXNQ]
-EFJTAC = [XFEFJT, FEFJTA]
-ELWUEU = [INELWU, NELWUE, VLASSA, VLASSA]
-ETDRXA = [ZFETDR, FETDRX]
-ETIXQV = [CGETIX, GETIXQ]
-GUCYRA = [CUGUCY, UGUCYR]
-IFJBIA = [TSIFJB, SIFJBI]
-IIDNIB = [XWAJVD, WAJVDQ, AJVDQL, JVDQLA, VDQLAI, DQLAII, QLAIID, LAIIDN, AIIDNI]
-IKFWRK = [TSIFJB, UIKFWR]
-IRYXBQ = [BSIRYX, SIRYXB]
-JWMNZM = [XSJWMN, SJWMNZ]
-JYKLGQ = [JVHFTH, WJYKLG, PIPIVL]
-JZTATD = [NRJZTA, RJZTAT]
-KEAKST = [DGKEAK, GKEAKS]
-KJPUNR = [JVHFTH, FIKJPU, VLASSA, IKJPUN]
-KWIVDN = [JVHFTH, QJYMOU, SKWIVD]
-LKXSJW = [UNBLKX, NBLKXS, BLKXSJ]
-MFZDGK = [QTMFZD, TMFZDG]
-OIJUGS = [MLOIJU, LOIJUG]
-OQNRSJ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QLNMHX = [SNQLNM, NQLNMH]
-QNRXCH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KQXPIC,
-]
-QPLSPF = [LGQPLS, GQPLSP]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-SELHBQ = [VLASSA, UGSELH, GSELHB]
-SPFTSI = [PIPIVL, WJYKLG]
-SSBVNA = [VLASSA, ESVZSS, SVZSSB, VZSSBV, ZSSBVN]
-TTUVRF = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    QNRSJM,
-    YEKCWA,
-]
-TUVRFL = [KCWAON]
-UHNNXW = [JVHFTH, UEUHNN, EUHNNX, VLASSA]
-UVRFLS = []
-UYNQJY = [QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-WONFZC = [VEMVCY, EMVCYW, MVCYWO, VCYWON, CYWONF, YWONFZ, VLASSA, VLASSA]
-XAIVEM = [RXAIVE]
-XNCUGU = [AXNCUG, HBXIBH]
-YFCRTF = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, QLAIID, LAIIDN, AIIDNI]
-YMOUNB = [QJYMOU, JYMOUN]
-ZILXWA = [TSIFJB, KZILXW]
-ZVOACM = [BHZVOA, HZVOAC]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1591,392 +19,1406 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return VRFLSI
+        return 64
 
     @property
     def output_keys(self):
-        return TTUVRF
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
-            ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, QXPICX, None, None, QBMJVH
-            ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, QXPICX, None, None, QBMJVH
-            ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, QXPICX, None, None, QBMJVH
-            ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, QXPICX, None, None, QBMJVH
-            ),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, RJHIUS, None, QXPICX, None, None, QBMJVH
-            ),
-            JHIUSO: GeckoEnumStructAccessor(
-                self.struct, JHIUSO, HIUSOO, None, QXPICX, None, None, QBMJVH
-            ),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, None, QXPICX, None, None, QBMJVH
-            ),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, OQNRSJ, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, NRSJMC, None, OQNRSJ, None, None, QBMJVH
-            ),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, QBMJVH),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, QBMJVH),
-            CBFEGZ: GeckoByteStructAccessor(self.struct, CBFEGZ, BFEGZU, QBMJVH),
-            FEGZUQ: GeckoByteStructAccessor(self.struct, FEGZUQ, EGZUQE, QBMJVH),
-            GZUQEX: GeckoByteStructAccessor(self.struct, GZUQEX, ZUQEXL, QBMJVH),
-            UQEXLS: GeckoByteStructAccessor(self.struct, UQEXLS, QEXLSX, QBMJVH),
-            EXLSXU: GeckoByteStructAccessor(self.struct, EXLSXU, XLSXUJ, QBMJVH),
-            LSXUJU: GeckoByteStructAccessor(self.struct, LSXUJU, SXUJUT, QBMJVH),
-            XUJUTY: GeckoByteStructAccessor(self.struct, XUJUTY, UJUTYE, QBMJVH),
-            JUTYEK: GeckoBoolStructAccessor(
-                self.struct, JUTYEK, UTYEKC, TYEKCW, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, CWAONP, None, None, None
-            ),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, QBMJVH),
-            PYYLIU: GeckoByteStructAccessor(self.struct, PYYLIU, YYLIUX, QBMJVH),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, QBMJVH),
-            IUXFEF: GeckoEnumStructAccessor(
-                self.struct, IUXFEF, UXFEFJ, FJTACC, EFJTAC, None, TYEKCW, QBMJVH
-            ),
-            JTACCP: GeckoByteStructAccessor(self.struct, JTACCP, TACCPQ, QBMJVH),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, QBMJVH),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, PQIPOU, None, UYNQJY, None, None, QBMJVH
-            ),
-            YNQJYM: GeckoEnumStructAccessor(
-                self.struct, YNQJYM, NQJYMO, None, YMOUNB, None, None, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, LKXSJW, None, None, QBMJVH
-            ),
-            KXSJWM: GeckoEnumStructAccessor(
-                self.struct, KXSJWM, UXFEFJ, TYEKCW, JWMNZM, None, TYEKCW, QBMJVH
-            ),
-            WMNZMJ: GeckoBoolStructAccessor(
-                self.struct, WMNZMJ, UTYEKC, MNZMJI, QBMJVH
-            ),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, QBMJVH),
-            MJIGYO: GeckoByteStructAccessor(self.struct, MJIGYO, JIGYOU, QBMJVH),
-            IGYOUS: GeckoByteStructAccessor(self.struct, IGYOUS, GYOUSP, QBMJVH),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, JYKLGQ, None, None, QBMJVH
-            ),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, QPLSPF, None, None, QBMJVH
-            ),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, LSPFTS, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, IFJBIA, None, None, QBMJVH
-            ),
-            FJBIAM: GeckoByteStructAccessor(self.struct, FJBIAM, JBIAMJ, QBMJVH),
-            BIAMJM: GeckoTempStructAccessor(self.struct, BIAMJM, IAMJMA, QBMJVH),
-            AMJMAO: GeckoEnumStructAccessor(
-                self.struct, AMJMAO, MJMAOA, None, AOAWBS, None, None, QBMJVH
-            ),
-            OAWBSI: GeckoEnumStructAccessor(
-                self.struct, OAWBSI, AWBSIR, None, SPFTSI, None, None, QBMJVH
-            ),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, UXFEFJ, RYXBQF, IRYXBQ, None, TYEKCW, QBMJVH
-            ),
-            YXBQFY: GeckoByteStructAccessor(self.struct, YXBQFY, XBQFYL, QBMJVH),
-            BQFYLJ: GeckoTempStructAccessor(self.struct, BQFYLJ, QFYLJU, QBMJVH),
-            FYLJUI: GeckoTempStructAccessor(self.struct, FYLJUI, YLJUIK, QBMJVH),
-            LJUIKF: GeckoEnumStructAccessor(
-                self.struct, LJUIKF, JUIKFW, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoByteStructAccessor(self.struct, KFWRKI, FWRKIN, QBMJVH),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, BXYBQS, None, None, QBMJVH
-            ),
-            XYBQSN: GeckoByteStructAccessor(self.struct, XYBQSN, YBQSNQ, QBMJVH),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, QLNMHX, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoByteStructAccessor(self.struct, LNMHXE, NMHXEK, QBMJVH),
-            MHXEKV: GeckoByteStructAccessor(self.struct, MHXEKV, HXEKVK, QBMJVH),
-            XEKVKZ: GeckoByteStructAccessor(self.struct, XEKVKZ, EKVKZI, QBMJVH),
-            KVKZIL: GeckoEnumStructAccessor(
-                self.struct, KVKZIL, VKZILX, None, ZILXWA, None, None, QBMJVH
-            ),
-            ILXWAJ: GeckoEnumStructAccessor(
-                self.struct, ILXWAJ, LXWAJV, None, IIDNIB, None, None, QBMJVH
-            ),
-            IDNIBX: GeckoEnumStructAccessor(
-                self.struct, IDNIBX, DNIBXT, None, IIDNIB, None, None, QBMJVH
-            ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, IBXTIA, None, IIDNIB, None, None, QBMJVH
-            ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, XTIACQ, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIACQF: GeckoEnumStructAccessor(
-                self.struct, TIACQF, IACQFF, None, IIDNIB, None, None, QBMJVH
-            ),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, CQFFTT, None, IIDNIB, None, None, QBMJVH
-            ),
-            QFFTTI: GeckoEnumStructAccessor(
-                self.struct, QFFTTI, FFTTID, None, IIDNIB, None, None, QBMJVH
-            ),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, IIDNIB, None, None, QBMJVH
-            ),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, IIDNIB, None, None, QBMJVH
-            ),
-            BSSUHB: GeckoEnumStructAccessor(
-                self.struct, BSSUHB, SSUHBV, None, IIDNIB, None, None, QBMJVH
-            ),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, IIDNIB, None, None, QBMJVH
-            ),
-            HBVWVU: GeckoEnumStructAccessor(
-                self.struct, HBVWVU, BVWVUB, None, IIDNIB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, IIDNIB, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, IIDNIB, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoByteStructAccessor(self.struct, BYGDSB, YGDSBD, QBMJVH),
-            GDSBDJ: GeckoByteStructAccessor(self.struct, GDSBDJ, DSBDJQ, QBMJVH),
-            SBDJQR: GeckoByteStructAccessor(self.struct, SBDJQR, BDJQRJ, QBMJVH),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, QBMJVH),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, QBMJVH),
-            JJJVYF: GeckoByteStructAccessor(self.struct, JJJVYF, JJVYFC, QBMJVH),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FCRTFM: GeckoEnumStructAccessor(
-                self.struct, FCRTFM, CRTFMN, None, YFCRTF, None, None, QBMJVH
-            ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, YFCRTF, None, None, QBMJVH
-            ),
-            FMNHTB: GeckoEnumStructAccessor(
-                self.struct, FMNHTB, MNHTBJ, None, YFCRTF, None, None, QBMJVH
-            ),
-            NHTBJE: GeckoEnumStructAccessor(
-                self.struct, NHTBJE, HTBJEU, None, YFCRTF, None, None, QBMJVH
-            ),
-            TBJEUT: GeckoEnumStructAccessor(
-                self.struct, TBJEUT, BJEUTO, None, YFCRTF, None, None, QBMJVH
-            ),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, QBMJVH),
-            UTOPHU: GeckoTimeStructAccessor(self.struct, UTOPHU, TOPHUG, QBMJVH),
-            OPHUGT: GeckoTimeStructAccessor(self.struct, OPHUGT, PHUGTY, QBMJVH),
-            HUGTYI: GeckoTimeStructAccessor(self.struct, HUGTYI, UGTYIY, QBMJVH),
-            GTYIYW: GeckoTimeStructAccessor(self.struct, GTYIYW, TYIYWS, QBMJVH),
-            YIYWSK: GeckoTimeStructAccessor(self.struct, YIYWSK, IYWSKW, QBMJVH),
-            YWSKWI: GeckoEnumStructAccessor(
-                self.struct, YWSKWI, WSKWIV, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoBoolStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, FJTACC, QBMJVH
-            ),
-            VDNQGV: GeckoBoolStructAccessor(
-                self.struct, VDNQGV, DNQGVU, TYEKCW, QBMJVH
-            ),
-            NQGVUN: GeckoBoolStructAccessor(
-                self.struct, NQGVUN, DNQGVU, FJTACC, QBMJVH
-            ),
-            QGVUNX: GeckoBoolStructAccessor(
-                self.struct, QGVUNX, DNQGVU, MNZMJI, QBMJVH
-            ),
-            GVUNXN: GeckoBoolStructAccessor(
-                self.struct, GVUNXN, DNQGVU, RYXBQF, QBMJVH
-            ),
-            VUNXNK: GeckoBoolStructAccessor(
-                self.struct, VUNXNK, DNQGVU, UNXNKM, QBMJVH
-            ),
-            NXNKML: GeckoBoolStructAccessor(
-                self.struct, NXNKML, DNQGVU, XNKMLO, QBMJVH
-            ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, OIJUGS, None, None, QBMJVH
-            ),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, QBMJVH
-            ),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, QBMJVH),
-            HBQNRX: GeckoEnumStructAccessor(
-                self.struct, HBQNRX, BQNRXC, None, QNRXCH, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoTimeStructAccessor(self.struct, NRXCHW, RXCHWD, QBMJVH),
-            XCHWDA: GeckoTimeStructAccessor(self.struct, XCHWDA, CHWDAF, QBMJVH),
-            HWDAFI: GeckoByteStructAccessor(self.struct, HWDAFI, WDAFIK, QBMJVH),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, KJPUNR, None, None, QBMJVH
-            ),
-            JPUNRJ: GeckoTimeStructAccessor(self.struct, JPUNRJ, PUNRJZ, QBMJVH),
-            UNRJZT: GeckoEnumStructAccessor(
-                self.struct, UNRJZT, UTYEKC, RYXBQF, JZTATD, None, TYEKCW, QBMJVH
-            ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, TATDZX, None, DZXNQT, None, None, QBMJVH
-            ),
-            ZXNQTM: GeckoWordStructAccessor(self.struct, ZXNQTM, XNQTMF, QBMJVH),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, UXFEFJ, MNZMJI, MFZDGK, None, TYEKCW, QBMJVH
-            ),
-            FZDGKE: GeckoBoolStructAccessor(
-                self.struct, FZDGKE, UXFEFJ, UNXNKM, QBMJVH
-            ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, UXFEFJ, XNKMLO, KEAKST, None, TYEKCW, QBMJVH
-            ),
-            EAKSTS: GeckoBoolStructAccessor(
-                self.struct, EAKSTS, UXFEFJ, AKSTSE, QBMJVH
-            ),
-            KSTSEM: GeckoBoolStructAccessor(
-                self.struct, KSTSEM, UXFEFJ, STSEMC, QBMJVH
-            ),
-            TSEMCG: GeckoBoolStructAccessor(
-                self.struct, TSEMCG, SEMCGE, FJTACC, QBMJVH
-            ),
-            EMCGET: GeckoBoolStructAccessor(
-                self.struct, EMCGET, SEMCGE, MNZMJI, QBMJVH
-            ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, SEMCGE, TYEKCW, ETIXQV, None, TYEKCW, QBMJVH
-            ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, SEMCGE, RYXBQF, ETIXQV, None, TYEKCW, QBMJVH
-            ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, SEMCGE, UNXNKM, BXIBHZ, None, XIBHZV, QBMJVH
-            ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, SEMCGE, STSEMC, ZVOACM, None, TYEKCW, QBMJVH
-            ),
-            JLOINE: GeckoBoolStructAccessor(
-                self.struct, JLOINE, LOINEL, MNZMJI, QBMJVH
-            ),
-            OINELW: GeckoEnumStructAccessor(
-                self.struct, OINELW, LOINEL, TYEKCW, ELWUEU, None, UNXNKM, QBMJVH
-            ),
-            LWUEUH: GeckoBoolStructAccessor(
-                self.struct, LWUEUH, LOINEL, UNXNKM, QBMJVH
-            ),
-            WUEUHN: GeckoEnumStructAccessor(
-                self.struct, WUEUHN, LOINEL, AKSTSE, UHNNXW, None, UNXNKM, QBMJVH
-            ),
-            HNNXWE: GeckoByteStructAccessor(self.struct, HNNXWE, NNXWEE, QBMJVH),
-            NXWEEZ: GeckoBoolStructAccessor(
-                self.struct, NXWEEZ, UTYEKC, FJTACC, QBMJVH
-            ),
-            XWEEZF: GeckoByteStructAccessor(self.struct, XWEEZF, WEEZFE, QBMJVH),
-            EEZFET: GeckoEnumStructAccessor(
-                self.struct, EEZFET, EZFETD, None, ETDRXA, None, None, QBMJVH
-            ),
-            TDRXAI: GeckoEnumStructAccessor(
-                self.struct, TDRXAI, DRXAIV, None, XAIVEM, None, None, QBMJVH
-            ),
-            AIVEMV: GeckoEnumStructAccessor(
-                self.struct, AIVEMV, IVEMVC, FJTACC, WONFZC, None, XIBHZV, QBMJVH
-            ),
-            ONFZCZ: GeckoBoolStructAccessor(
-                self.struct, ONFZCZ, IVEMVC, STSEMC, QBMJVH
-            ),
-            NFZCZO: GeckoByteStructAccessor(self.struct, NFZCZO, FZCZOL, QBMJVH),
-            ZCZOLS: GeckoWordStructAccessor(self.struct, ZCZOLS, CZOLSI, QBMJVH),
-            ZOLSIP: GeckoWordStructAccessor(self.struct, ZOLSIP, OLSIPM, QBMJVH),
-            LSIPMD: GeckoWordStructAccessor(self.struct, LSIPMD, SIPMDM, QBMJVH),
-            IPMDMP: GeckoWordStructAccessor(self.struct, IPMDMP, PMDMPS, QBMJVH),
-            MDMPSC: GeckoWordStructAccessor(self.struct, MDMPSC, DMPSCT, QBMJVH),
-            MPSCTT: GeckoWordStructAccessor(self.struct, MPSCTT, PSCTTG, QBMJVH),
-            SCTTGC: GeckoWordStructAccessor(self.struct, SCTTGC, CTTGCR, QBMJVH),
-            TTGCRH: GeckoWordStructAccessor(self.struct, TTGCRH, TGCRHY, QBMJVH),
-            GCRHYU: GeckoWordStructAccessor(self.struct, GCRHYU, CRHYUA, QBMJVH),
-            RHYUAX: GeckoWordStructAccessor(self.struct, RHYUAX, HYUAXN, QBMJVH),
-            YUAXNC: GeckoEnumStructAccessor(
-                self.struct, YUAXNC, UAXNCU, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            NCUGUC: GeckoEnumStructAccessor(
-                self.struct, NCUGUC, UAXNCU, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            UCYRAP: GeckoEnumStructAccessor(
-                self.struct, UCYRAP, CYRAPU, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            YRAPUM: GeckoEnumStructAccessor(
-                self.struct, YRAPUM, CYRAPU, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            RAPUME: GeckoEnumStructAccessor(
-                self.struct, RAPUME, APUMEA, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            PUMEAO: GeckoEnumStructAccessor(
-                self.struct, PUMEAO, APUMEA, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            UMEAOE: GeckoEnumStructAccessor(
-                self.struct, UMEAOE, MEAOES, FJTACC, XNCUGU, None, TYEKCW, None
-            ),
-            EAOESV: GeckoEnumStructAccessor(
-                self.struct, EAOESV, MEAOES, MNZMJI, GUCYRA, None, TYEKCW, None
-            ),
-            AOESVZ: GeckoEnumStructAccessor(
-                self.struct, AOESVZ, OESVZS, FJTACC, SSBVNA, None, XIBHZV, None
-            ),
-            SBVNAX: GeckoBoolStructAccessor(self.struct, SBVNAX, OESVZS, STSEMC, None),
-            BVNAXA: GeckoBoolStructAccessor(self.struct, BVNAXA, UAXNCU, UNXNKM, None),
-            VNAXAD: GeckoBoolStructAccessor(self.struct, VNAXAD, UAXNCU, XNKMLO, None),
-            NAXADX: GeckoBoolStructAccessor(self.struct, NAXADX, UAXNCU, AKSTSE, None),
-            AXADXL: GeckoBoolStructAccessor(self.struct, AXADXL, UAXNCU, STSEMC, None),
-            XADXLU: GeckoBoolStructAccessor(self.struct, XADXLU, CYRAPU, UNXNKM, None),
-            ADXLUB: GeckoBoolStructAccessor(self.struct, ADXLUB, CYRAPU, XNKMLO, None),
-            DXLUBG: GeckoBoolStructAccessor(self.struct, DXLUBG, CYRAPU, AKSTSE, None),
-            XLUBGJ: GeckoBoolStructAccessor(self.struct, XLUBGJ, CYRAPU, STSEMC, None),
-            LUBGJF: GeckoBoolStructAccessor(self.struct, LUBGJF, APUMEA, UNXNKM, None),
-            UBGJFJ: GeckoBoolStructAccessor(self.struct, UBGJFJ, APUMEA, XNKMLO, None),
-            BGJFJN: GeckoBoolStructAccessor(self.struct, BGJFJN, APUMEA, AKSTSE, None),
-            GJFJNT: GeckoBoolStructAccessor(self.struct, GJFJNT, APUMEA, STSEMC, None),
-            JFJNTT: GeckoBoolStructAccessor(self.struct, JFJNTT, MEAOES, UNXNKM, None),
-            FJNTTU: GeckoBoolStructAccessor(self.struct, FJNTTU, MEAOES, XNKMLO, None),
-            JNTTUV: GeckoBoolStructAccessor(self.struct, JNTTUV, MEAOES, AKSTSE, None),
-            NTTUVR: GeckoBoolStructAccessor(self.struct, NTTUVR, MEAOES, STSEMC, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-65.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-65.py
@@ -12,1671 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 45
-ACMCVD = 7
-ACQFFT = 114
-ADXLUB = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-AFIKJP = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-AOAWBS = 58
-AOESVZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-AONPYY = 23
-APUMEA = 143
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AWBSIR = 59
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-BDFSRO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-BDJQRJ = 87
-BEKBDF = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BFEGZU = "".join(chr(c) for c in [70, 51])
-BGJFJN = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-BHZVOA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BIAMJM = "".join(chr(c) for c in [76, 111])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-BLKXSJ = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BMIKGN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 78
-BQNRXC = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-BQSNQL = "".join(chr(c) for c in [70])
-BSIRYX = 60
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BVNAXA = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BWJYKL = 32
-BXIBHZ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BXYBQS = 1
-BYGDSB = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-CBFEGZ = "".join(chr(c) for c in [70, 50])
-CCPQIP = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CHWDAF = 72
-CMCVDS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CPOUBM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-CPQIPO = 46
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-CRHYUA = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-CRTFMN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-CTHBSK = 39
-CTTGCR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-CUGUCY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 22
-CXQIEF = 14
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-CYWONF = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DDPMXF = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-DFSROG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-DGKEAK = 132
-DJQRJJ = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-DMPSCT = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-DNIBXT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-DNQGVU = 106
-DPMXFU = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-DRXAIV = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-DSBDJQ = 86
-DSSRUR = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DUBSSU = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-DXLUBG = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-DZXNQT = 75
-EAKSTS = "".join(chr(c) for c in [79, 70, 70])
-EAOESV = 147
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-EFJTAC = 43
-EFXQGL = 16
-EGZUQE = "".join(chr(c) for c in [70, 50, 50])
-EKBDFS = 111
-EKCWAO = 21
-EKVKZI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-ELHBQN = 10
-ELWUEU = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-EMCGET = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-EMVCYW = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-EOCTHB = 38
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-ETIXQV = 34
-EUHNNX = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-EUTOPH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-EZFETD = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-FCPOUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-FCRTFM = 92
-FEFJTA = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-FEGZUQ = "".join(chr(c) for c in [70, 50, 49])
-FETDRX = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-FFTTID = "".join(chr(c) for c in [85, 76])
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-FJNTTU = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-FJTACC = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FLSIJU = "".join(chr(c) for c in [51])
-FMNHTB = 94
-FOUURI = 65
-FSROGM = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 57
-FTTIDU = "".join(chr(c) for c in [67, 69])
-FUBJLO = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-FWRKIN = 29
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FZCZOL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FZDGKE = 130
-GCRHYU = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-GDSBDJ = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-GETIXQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-GJFJNT = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-GKEAKS = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GQPLSP = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-GSELHB = 8
-GTYIYW = 101
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-GVUNXN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-GYOUSP = 0
-GZUQEX = "".join(chr(c) for c in [70, 50, 51])
-HBQNRX = 71
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [56, 65])
-HNNXWE = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-HTBJEU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-HUGTYI = 100
-HUOJRJ = "".join(chr(c) for c in [50, 65])
-HWDAFI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-HYUAXN = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [72, 105])
-IBHZVO = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-IBXTIA = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IBXYBQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IDUBSS = 52
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IFJBIA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-IHBXIB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IIDNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-IJUGSE = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-IJUZMR = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-IKGNVF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-IKJPUN = 5
-ILXWAJ = 68
-INEJNI = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-INELWU = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-IPOUYN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-IRYXBQ = 61
-IUSOOQ = "".join(chr(c) for c in [57, 65])
-IUXFEF = 41
-IVDNQG = 105
-IVEMVC = 112
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [50, 52, 104])
-IYWSKW = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JBIAMJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JEUTOP = 97
-JFJNTT = 125
-JHIUSO = "".join(chr(c) for c in [55, 65])
-JIGYOU = "".join(chr(c) for c in [79, 119, 110])
-JJJVYF = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-JJVYFC = 90
-JLOINE = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-JMAOAW = 1
-JMCBFE = 163
-JNIBXY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JNTTUV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-JPUNRJ = 76
-JQRJJJ = 88
-JRJHIU = "".join(chr(c) for c in [53, 65])
-JTACCP = 44
-JUGSEL = 116
-JUIKFW = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-JUTYEK = 19
-JUZMRK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-JVDQLA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JWMNZM = 55
-JYKLGQ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-JZTATD = 73
-KBDFSR = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-KCWAON = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-KEAKST = 157
-KFWRKI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-KGNVFO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-KHTZBB = 8
-KINEJN = 30
-KJPUNR = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-KLGQPL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-KMLOIJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KPHUOJ = "".join(chr(c) for c in [48, 65])
-KQTDKH = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-KVFCPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-KVKZIL = 35
-KXSJWM = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KZILXW = 66
-LAIIDN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LHBQNR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LIUXFE = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-LJUIKF = 28
-LKXSJW = 80
-LNMHXE = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-LOIJUG = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LOINEL = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-LRAHEO = 36
-LSIJUZ = "".join(chr(c) for c in [52])
-LSIPMD = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-LSPFTS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-LSXUJU = 17
-LUBGJF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-LWUEUH = "".join(chr(c) for c in [80, 68, 67])
-LXWAJV = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-MAOAWB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-MCBFEG = "".join(chr(c) for c in [70, 49])
-MCGETI = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-MCVDSS = 110
-MDDPMX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-MEAOES = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-MFZDGK = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-MHXEKV = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-MIKGNV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-MJIGYO = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-MJMAOA = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [66, 76, 85, 69])
-MLOIJU = 4
-MNHTBJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-MNZMJI = 56
-MOUNBL = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-MPSCTT = 134
-MRKVFC = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-MVCYWO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-MXFUBJ = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-NAXADX = "".join(chr(c) for c in [82, 71, 66])
-NCUGUC = 136
-NEJNIB = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-NELWUE = "".join(chr(c) for c in [77, 65, 65, 88])
-NHTBJE = 95
-NIBXTI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NIBXYB = 63
-NKMLOI = 3
-NMHXEK = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-NNXWEE = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-NPYYLI = 24
-NQGVUN = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-NQJYMO = 119
-NQLNMH = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NRSJMC = "".join(chr(c) for c in [49, 53, 65])
-NRXCHW = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NTTUVR = 126
-NXNKML = 109
-NXWEEZ = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-NZMJIG = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-OACMCV = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-OAWBSI = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = 149
-OGMDDP = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OIHBXI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-OIJUGS = 6
-OINELW = "".join(chr(c) for c in [76, 65])
-OJRJHI = "".join(chr(c) for c in [52, 65])
-OKPHUO = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-OLSIPM = 121
-ONFZCZ = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-ONPYYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-OOQNRS = "".join(chr(c) for c in [49, 50, 65])
-OPHUGT = 99
-OQNRSJ = "".join(chr(c) for c in [49, 51, 65])
-OUBMIK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-OUNBLK = 79
-OUSPBW = 118
-OUYNQJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-PBWJYK = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-PFTSIF = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-PHUGTY = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-PHUOJR = "".join(chr(c) for c in [49, 65])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-PMDMPS = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-PMXFUB = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-POUBMI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-POUYNQ = 48
-PQIPOU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-PSCTTG = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-PUMEAO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-PUNRJZ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-QFFTTI = 51
-QFYLJU = "".join(chr(c) for c in [80, 49])
-QGVUNX = 107
-QIEFXQ = 15
-QIPOUY = 47
-QJYMOU = 2
-QLAIID = 115
-QLNMHX = 31
-QNRSJM = "".join(chr(c) for c in [49, 52, 65])
-QPLSPF = 27
-QRJJJV = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QSNQLN = "".join(chr(c) for c in [67])
-QTDKHT = "".join(chr(c) for c in [67, 89, 65, 78])
-QTMFZD = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-QVXOIH = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-RAZMKQ = "".join(chr(c) for c in [82, 69, 68])
-RFLSIJ = "".join(chr(c) for c in [50])
-RHYUAX = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-RJHIUS = "".join(chr(c) for c in [54, 65])
-RJJJVY = 89
-RJZTAT = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-RKINEJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-RKVFCP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-ROGMDD = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-RTFMNH = 93
-RURAZM = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RXAIVE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-RXCHWD = 82
-RYXBQF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-SBVNAX = 155
-SELHBQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-SIFJBI = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-SIPMDM = 133
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SJMCBF = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-SJWMNZ = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SKSOKP = 50
-SKWIVD = 104
-SOKPHU = 161
-SOOQNR = "".join(chr(c) for c in [49, 49, 65])
-SPBWJY = 120
-SROGMD = "".join(chr(c) for c in [65, 108, 112, 115])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-SSRURA = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-SSUHBV = 122
-STSEMC = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SUHBVW = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-SVZSSB = 151
-SXUJUT = "".join(chr(c) for c in [79, 117, 116, 55])
-TACCPQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-TATDZX = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-TBJEUT = 96
-TDKHTZ = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TDRXAI = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-TDZXNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TFMNHT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-TGCRHY = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 162
-TIDUBS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-TIXQVX = "".join(chr(c) for c in [65, 109, 80, 109])
-TMFZDG = 128
-TOPHUG = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-TSEMCG = 158
-TSIFJB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TTGCRH = 135
-TTUVRF = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-TUVRFL = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-TYEKCW = 20
-TYIYWS = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-TZBBEK = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-UBGJFJ = 124
-UBJLOI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-UBMIKG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-UBSSUH = 53
-UBYGDS = 84
-UCYRAP = 139
-UEUHNN = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-UGSELH = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-UGTYIY = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-UGUCYR = 137
-UHBVWV = 74
-UHNNXW = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UIKFWR = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-UJUTYE = "".join(chr(c) for c in [79, 117, 116, 56])
-UMEAOE = 145
-UNBLKX = "".join(chr(c) for c in [76, 73])
-UNRJZT = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-UNXNKM = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-UOJRJH = "".join(chr(c) for c in [51, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-URAZMK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-USOOQN = "".join(chr(c) for c in [49, 48, 65])
-USPBWJ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-UTOPHU = 98
-UTYEKC = "".join(chr(c) for c in [79, 117, 116, 57])
-UVRFLS = 127
-UXFEFJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-UYNQJY = 49
-UZMRKV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-VDNQGV = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-VDQLAI = 77
-VDSSRU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-VEMVCY = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-VFCPOU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = 123
-VOACMC = 6
-VRFLSI = "".join(chr(c) for c in [49])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-VUNXNK = 108
-VWVUBY = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-VXOIHB = 64
-VYFCRT = 91
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-WAJVDQ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-WAONPY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WDAFIK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-WEEZFE = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-WIVDNQ = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-WJYKLG = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-WMNZMJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-WONFZC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-WSKWIV = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-WUEUHN = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WVUBYG = 83
-XADXLU = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-XBQFYL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-XEKVKZ = 3
-XFEFJT = 42
-XFUBJL = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XIBHZV = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 54])
-XNCUGU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-XNQTMF = 160
-XOIHBX = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = 54
-XTIACQ = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-XUJUTY = 18
-XWAJVD = 70
-XWEEZF = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-XYBQSN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YBQSNQ = 33
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-YFCRTF = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-YGDSBD = 85
-YIYWSK = 102
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-YLIUXF = 25
-YLJUIK = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YMOUNB = 4
-YNQJYM = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = 141
-YUAXNC = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-YWONFZ = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-YWSKWI = 103
-YXBQFY = 62
-YYLIUX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = 113
-ZDGKEA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZFETDR = "".join(chr(c) for c in [73, 100, 111, 108])
-ZILXWA = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZMJIGY = 81
-ZMKQTD = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-ZMRKVF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-ZOLSIP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-ZSSBVN = 153
-ZTATDZ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-ZUQEXL = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-ZVOACM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-ZXNQTM = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-AJVDQL = [INEJNI, WAJVDQ]
-AMJMAO = [BIAMJM, IAMJMA]
-ATDZXN = [VLASSA, ZTATDZ, TATDZX]
-AXADXL = [NAXADX, TDKHTZ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BVWVUB = [INEJNI, HBVWVU]
-BXTIAC = [LAIIDN, AIIDNI, IIDNIB, IDNIBX, DNIBXT, NIBXTI, IBXTIA]
-CGETIX = [EMCGET, MCGETI]
-DKHTZB = [EAKSTS, RAZMKQ, AZMKQT, ZMKQTD, MKQTDK, KQTDKH, QTDKHT, TDKHTZ]
-EJNIBX = [INEJNI, NEJNIB]
-EXLSXU = [MCBFEG, CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX]
-FJBIAM = [TSIFJB, SIFJBI, IFJBIA]
-FYLJUI = [JVHFTH, QFYLJU, PIPIVL]
-GNVFOU = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    SJMCBF,
-    XLSXUJ,
-    SXUJUT,
-    UJUTYE,
-    UTYEKC,
-    YEKCWA,
-    KCWAON,
-    WAONPY,
-    ONPYYL,
-    YYLIUX,
-    MOUNBL,
-]
-HBXIBH = [OIHBXI, IHBXIB]
-HXEKVK = [NMHXEK, MHXEKV]
-HZVOAC = [IBHZVO, BHZVOA]
-IGYOUS = [MJIGYO, JIGYOU]
-IKFWRK = [JUIKFW, UIKFWR]
-KSTSEM = [JVHFTH, EAKSTS, VLASSA, AKSTSE]
-KWIVDN = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, ZUQEXL, UQEXLS, QEXLSX]
-LGQPLS = [WJYKLG, JYKLGQ, YKLGQP, KLGQPL]
-MDMPSC = [IPMDMP, PMDMPS]
-NBLKXS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    UNBLKX,
-]
-NFZCZO = [JVHFTH, WONFZC, ONFZCZ, VLASSA]
-NQTMFZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KQXPIC,
-]
-NRJZTA = [PUNRJZ, UNRJZT]
-NVFOUU = [UNBLKX]
-PYYLIU = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QNRXCH = [JVHFTH, PLSPFT, BQNRXC]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-RSJMCB = [
-    OKPHUO,
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-]
-SCTTGC = [PSCTTG]
-SIJUZM = [VLASSA, VRFLSI, RFLSIJ, FLSIJU, LSIJUZ]
-SNQLNM = [BQSNQL, QSNQLN]
-SPFTSI = [PLSPFT, LSPFTS]
-SRURAZ = [DSSRUR, SSRURA]
-TTIDUB = [FFTTID, FTTIDU]
-UAXNCU = [TGCRHY, GCRHYU, CRHYUA, RHYUAX, HYUAXN, YUAXNC, VLASSA, VLASSA]
-VCYWON = [EMVCYW, MVCYWO, VLASSA, VLASSA]
-VFOUUR = []
-WRKINE = [PIPIVL, QFYLJU]
-XAIVEM = [
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-    DDPMXF,
-    DPMXFU,
-    PMXFUB,
-    MXFUBJ,
-    XFUBJL,
-    FUBJLO,
-    UBJLOI,
-    BJLOIN,
-    JLOINE,
-    LOINEL,
-    OINELW,
-    INELWU,
-    NELWUE,
-    ELWUEU,
-    LWUEUH,
-    WUEUHN,
-    UEUHNN,
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-]
-XLUBGJ = [ADXLUB, DXLUBG]
-XQVXOI = [JVHFTH, TIXQVX, IXQVXO]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1684,402 +19,1452 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return FOUURI
+        return 65
 
     @property
     def output_keys(self):
-        return GNVFOU
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, RSJMCB, None, None, QBMJVH
-            ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, QXPICX, None, None, QBMJVH
-            ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, QXPICX, None, None, QBMJVH
-            ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, QXPICX, None, None, QBMJVH
-            ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, TYEKCW, None, QXPICX, None, None, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, QXPICX, None, None, QBMJVH
-            ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, QXPICX, None, None, QBMJVH
-            ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, QXPICX, None, None, QBMJVH
-            ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, PYYLIU, None, None, QBMJVH
-            ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, None, PYYLIU, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoBoolStructAccessor(
-                self.struct, YNQJYM, NQJYMO, QJYMOU, QBMJVH
-            ),
-            JYMOUN: GeckoBoolStructAccessor(
-                self.struct, JYMOUN, NQJYMO, YMOUNB, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, NBLKXS, None, None, None
-            ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, GYOUSP, IGYOUS, None, QJYMOU, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, LGQPLS, None, None, QBMJVH
-            ),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, ZMJIGY, QJYMOU, AMJMAO, None, QJYMOU, QBMJVH
-            ),
-            MJMAOA: GeckoBoolStructAccessor(
-                self.struct, MJMAOA, NQJYMO, JMAOAW, QBMJVH
-            ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoByteStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoByteStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FYLJUI, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, WRKINE, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTempStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, SNQLNM, None, None, QBMJVH
-            ),
-            NQLNMH: GeckoEnumStructAccessor(
-                self.struct, NQLNMH, QLNMHX, None, WRKINE, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, ZMJIGY, XEKVKZ, HXEKVK, None, QJYMOU, QBMJVH
-            ),
-            EKVKZI: GeckoByteStructAccessor(self.struct, EKVKZI, KVKZIL, QBMJVH),
-            VKZILX: GeckoTempStructAccessor(self.struct, VKZILX, KZILXW, QBMJVH),
-            ZILXWA: GeckoTempStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, EXLSXU, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, EXLSXU, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, EXLSXU, None, None, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, EXLSXU, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, EXLSXU, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, EXLSXU, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, EXLSXU, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoEnumStructAccessor(
-                self.struct, YFCRTF, FCRTFM, None, EXLSXU, None, None, QBMJVH
-            ),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, EXLSXU, None, None, QBMJVH
-            ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, EXLSXU, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, EXLSXU, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, EXLSXU, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, EXLSXU, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoByteStructAccessor(self.struct, EUTOPH, UTOPHU, QBMJVH),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, QBMJVH),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, QBMJVH),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, QBMJVH),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, QBMJVH),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, QBMJVH),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, KWIVDN, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, KWIVDN, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, KWIVDN, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, KWIVDN, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, KWIVDN, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoTimeStructAccessor(self.struct, KMLOIJ, MLOIJU, QBMJVH),
-            LOIJUG: GeckoTimeStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoTimeStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoTimeStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoTimeStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, QNRXCH, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, RXCHWD, GYOUSP, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, QJYMOU, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, CHWDAF, GYOUSP, QBMJVH
-            ),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, CHWDAF, JMAOAW, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, CHWDAF, XEKVKZ, QBMJVH
-            ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, CHWDAF, YMOUNB, QBMJVH
-            ),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, CHWDAF, IKJPUN, QBMJVH
-            ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, None, ATDZXN, None, None, QBMJVH
-            ),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, QBMJVH),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, XNQTMF, None, NQTMFZ, None, None, QBMJVH
-            ),
-            QTMFZD: GeckoTimeStructAccessor(self.struct, QTMFZD, TMFZDG, QBMJVH),
-            MFZDGK: GeckoTimeStructAccessor(self.struct, MFZDGK, FZDGKE, QBMJVH),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, QBMJVH),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, KEAKST, None, KSTSEM, None, None, QBMJVH
-            ),
-            STSEMC: GeckoTimeStructAccessor(self.struct, STSEMC, TSEMCG, QBMJVH),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, NQJYMO, XEKVKZ, CGETIX, None, QJYMOU, QBMJVH
-            ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, XQVXOI, None, None, QBMJVH
-            ),
-            QVXOIH: GeckoWordStructAccessor(self.struct, QVXOIH, VXOIHB, QBMJVH),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, ZMJIGY, JMAOAW, HBXIBH, None, QJYMOU, QBMJVH
-            ),
-            BXIBHZ: GeckoBoolStructAccessor(
-                self.struct, BXIBHZ, ZMJIGY, YMOUNB, QBMJVH
-            ),
-            XIBHZV: GeckoEnumStructAccessor(
-                self.struct, XIBHZV, ZMJIGY, IKJPUN, HZVOAC, None, QJYMOU, QBMJVH
-            ),
-            ZVOACM: GeckoBoolStructAccessor(
-                self.struct, ZVOACM, ZMJIGY, VOACMC, QBMJVH
-            ),
-            OACMCV: GeckoBoolStructAccessor(
-                self.struct, OACMCV, ZMJIGY, ACMCVD, QBMJVH
-            ),
-            CMCVDS: GeckoBoolStructAccessor(
-                self.struct, CMCVDS, MCVDSS, GYOUSP, QBMJVH
-            ),
-            CVDSSR: GeckoBoolStructAccessor(
-                self.struct, CVDSSR, MCVDSS, JMAOAW, QBMJVH
-            ),
-            VDSSRU: GeckoEnumStructAccessor(
-                self.struct, VDSSRU, MCVDSS, QJYMOU, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, MCVDSS, XEKVKZ, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, MCVDSS, YMOUNB, DKHTZB, None, KHTZBB, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MCVDSS, ACMCVD, BBEKBD, None, QJYMOU, QBMJVH
-            ),
-            AIVEMV: GeckoBoolStructAccessor(
-                self.struct, AIVEMV, IVEMVC, JMAOAW, QBMJVH
-            ),
-            VEMVCY: GeckoEnumStructAccessor(
-                self.struct, VEMVCY, IVEMVC, QJYMOU, VCYWON, None, YMOUNB, QBMJVH
-            ),
-            CYWONF: GeckoBoolStructAccessor(
-                self.struct, CYWONF, IVEMVC, YMOUNB, QBMJVH
-            ),
-            YWONFZ: GeckoEnumStructAccessor(
-                self.struct, YWONFZ, IVEMVC, VOACMC, NFZCZO, None, YMOUNB, QBMJVH
-            ),
-            FZCZOL: GeckoByteStructAccessor(self.struct, FZCZOL, ZCZOLS, QBMJVH),
-            CZOLSI: GeckoBoolStructAccessor(
-                self.struct, CZOLSI, NQJYMO, GYOUSP, QBMJVH
-            ),
-            ZOLSIP: GeckoByteStructAccessor(self.struct, ZOLSIP, OLSIPM, QBMJVH),
-            LSIPMD: GeckoEnumStructAccessor(
-                self.struct, LSIPMD, SIPMDM, None, MDMPSC, None, None, QBMJVH
-            ),
-            DMPSCT: GeckoEnumStructAccessor(
-                self.struct, DMPSCT, MPSCTT, None, SCTTGC, None, None, QBMJVH
-            ),
-            CTTGCR: GeckoEnumStructAccessor(
-                self.struct, CTTGCR, TTGCRH, GYOUSP, UAXNCU, None, KHTZBB, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, TTGCRH, ACMCVD, QBMJVH
-            ),
-            XNCUGU: GeckoByteStructAccessor(self.struct, XNCUGU, NCUGUC, QBMJVH),
-            CUGUCY: GeckoWordStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoWordStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoWordStructAccessor(self.struct, CYRAPU, YRAPUM, QBMJVH),
-            RAPUME: GeckoWordStructAccessor(self.struct, RAPUME, APUMEA, QBMJVH),
-            PUMEAO: GeckoWordStructAccessor(self.struct, PUMEAO, UMEAOE, QBMJVH),
-            MEAOES: GeckoWordStructAccessor(self.struct, MEAOES, EAOESV, QBMJVH),
-            AOESVZ: GeckoWordStructAccessor(self.struct, AOESVZ, OESVZS, QBMJVH),
-            ESVZSS: GeckoWordStructAccessor(self.struct, ESVZSS, SVZSSB, QBMJVH),
-            VZSSBV: GeckoWordStructAccessor(self.struct, VZSSBV, ZSSBVN, QBMJVH),
-            SSBVNA: GeckoWordStructAccessor(self.struct, SSBVNA, SBVNAX, QBMJVH),
-            BVNAXA: GeckoEnumStructAccessor(
-                self.struct, BVNAXA, VNAXAD, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, VNAXAD, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            LUBGJF: GeckoEnumStructAccessor(
-                self.struct, LUBGJF, UBGJFJ, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            BGJFJN: GeckoEnumStructAccessor(
-                self.struct, BGJFJN, UBGJFJ, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            GJFJNT: GeckoEnumStructAccessor(
-                self.struct, GJFJNT, JFJNTT, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            FJNTTU: GeckoEnumStructAccessor(
-                self.struct, FJNTTU, JFJNTT, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            JNTTUV: GeckoEnumStructAccessor(
-                self.struct, JNTTUV, NTTUVR, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            TTUVRF: GeckoEnumStructAccessor(
-                self.struct, TTUVRF, NTTUVR, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            TUVRFL: GeckoEnumStructAccessor(
-                self.struct, TUVRFL, UVRFLS, GYOUSP, SIJUZM, None, KHTZBB, None
-            ),
-            IJUZMR: GeckoBoolStructAccessor(self.struct, IJUZMR, UVRFLS, ACMCVD, None),
-            JUZMRK: GeckoBoolStructAccessor(self.struct, JUZMRK, VNAXAD, YMOUNB, None),
-            UZMRKV: GeckoBoolStructAccessor(self.struct, UZMRKV, VNAXAD, IKJPUN, None),
-            ZMRKVF: GeckoBoolStructAccessor(self.struct, ZMRKVF, VNAXAD, VOACMC, None),
-            MRKVFC: GeckoBoolStructAccessor(self.struct, MRKVFC, VNAXAD, ACMCVD, None),
-            RKVFCP: GeckoBoolStructAccessor(self.struct, RKVFCP, UBGJFJ, YMOUNB, None),
-            KVFCPO: GeckoBoolStructAccessor(self.struct, KVFCPO, UBGJFJ, IKJPUN, None),
-            VFCPOU: GeckoBoolStructAccessor(self.struct, VFCPOU, UBGJFJ, VOACMC, None),
-            FCPOUB: GeckoBoolStructAccessor(self.struct, FCPOUB, UBGJFJ, ACMCVD, None),
-            CPOUBM: GeckoBoolStructAccessor(self.struct, CPOUBM, JFJNTT, YMOUNB, None),
-            POUBMI: GeckoBoolStructAccessor(self.struct, POUBMI, JFJNTT, IKJPUN, None),
-            OUBMIK: GeckoBoolStructAccessor(self.struct, OUBMIK, JFJNTT, VOACMC, None),
-            UBMIKG: GeckoBoolStructAccessor(self.struct, UBMIKG, JFJNTT, ACMCVD, None),
-            BMIKGN: GeckoBoolStructAccessor(self.struct, BMIKGN, NTTUVR, YMOUNB, None),
-            MIKGNV: GeckoBoolStructAccessor(self.struct, MIKGNV, NTTUVR, IKJPUN, None),
-            IKGNVF: GeckoBoolStructAccessor(self.struct, IKGNVF, NTTUVR, VOACMC, None),
-            KGNVFO: GeckoBoolStructAccessor(self.struct, KGNVFO, NTTUVR, ACMCVD, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-cfg-66.py
+++ b/src/geckolib/driver/packs/inyt-v2-cfg-66.py
@@ -12,1764 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = 45
-ACMCVD = 7
-ACQFFT = 114
-ADXLUB = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-AFIKJP = "".join(
-    chr(c) for c in [65, 117, 120, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-AHEOCT = 37
-AIIDNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 87, 95, 66, 79, 79, 83, 84])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        101,
-        75,
-        101,
-        121,
-        65,
-        115,
-        73,
-        110,
-        118,
-        101,
-        114,
-        116,
-        68,
-        105,
-        115,
-        112,
-        108,
-        97,
-        121,
-        75,
-        101,
-        121,
-    ]
-)
-AKQXPI = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-AKSTSE = "".join(chr(c) for c in [83, 76, 69, 69, 80])
-AOAWBS = 58
-AOESVZ = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        55,
-    ]
-)
-AONPYY = 23
-APUMEA = 143
-ASSAKQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AWBSIR = 59
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        100,
-        105,
-        99,
-        97,
-        116,
-        101,
-        100,
-        80,
-        117,
-        109,
-        112,
-        115,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-BDFSRO = "".join(chr(c) for c in [72, 121, 100, 114, 111, 112, 111, 111, 108])
-BDJQRJ = 87
-BEKBDF = "".join(chr(c) for c in [67, 117, 115, 116, 111, 109, 101, 114, 73, 68])
-BFEGZU = "".join(chr(c) for c in [70, 51])
-BGJFJN = "".join(chr(c) for c in [90, 111, 110, 101, 50, 84, 121, 112, 101])
-BHZVOA = "".join(chr(c) for c in [76, 97, 115, 116, 80, 117, 109, 112, 75, 101, 121])
-BIAMJM = "".join(chr(c) for c in [76, 111])
-BJEUTO = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114, 70, 117, 115, 101])
-BJLOIN = "".join(chr(c) for c in [72, 111, 116, 115, 112, 114, 105, 110, 103])
-BLKXSJ = "".join(chr(c) for c in [76, 105, 103, 104, 116, 73, 110, 116, 115])
-BMIKGN = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 49]
-)
-BMJVHF = "".join(chr(c) for c in [79, 117, 116, 49])
-BQFYLJ = 78
-BQNRXC = "".join(
-    chr(c) for c in [79, 85, 84, 83, 73, 68, 69, 95, 70, 73, 76, 84, 69, 82]
-)
-BQSNQL = "".join(chr(c) for c in [70])
-BSIRYX = 60
-BSKSOK = "".join(chr(c) for c in [79, 117, 116, 72, 116, 82, 67, 117, 114])
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-        73,
-        110,
-        112,
-        117,
-        116,
-        67,
-        117,
-        114,
-        114,
-        101,
-        110,
-        116,
-    ]
-)
-BVNAXA = "".join(chr(c) for c in [90, 111, 110, 101, 49, 76, 101, 100])
-BWJYKL = 32
-BXIBHZ = "".join(
-    chr(c) for c in [83, 101, 108, 102, 67, 108, 101, 97, 110, 77, 115, 103]
-)
-BXYBQS = 1
-BYGDSB = "".join(chr(c) for c in [79, 117, 116, 51, 70, 117, 115, 101])
-CBFEGZ = "".join(chr(c) for c in [70, 50])
-CCPQIP = "".join(chr(c) for c in [79, 117, 116, 49, 49, 67, 117, 114])
-CHWDAF = 72
-CMCVDS = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        84,
-        104,
-        101,
-        114,
-        97,
-        112,
-        121,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-CPOUBM = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 49]
-)
-CPQIPO = 46
-CQBMJV = 0
-CQFFTT = "".join(chr(c) for c in [85, 76, 95, 67, 69])
-CRHYUA = "".join(chr(c) for c in [80, 50, 95, 84, 79, 95, 80, 53])
-CRTFMN = "".join(chr(c) for c in [79, 117, 116, 49, 49, 70, 117, 115, 101])
-CTHBSK = 39
-CTTGCR = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        115,
-        85,
-        115,
-        101,
-        100,
-    ]
-)
-CUGUCY = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-    ]
-)
-CVDSSR = "".join(
-    chr(c)
-    for c in [67, 117, 115, 116, 111, 109, 75, 101, 121, 69, 110, 97, 98, 108, 101, 100]
-)
-CVYYPI = "".join(chr(c) for c in [80, 52, 72])
-CWAONP = 22
-CXQIEF = 14
-CYRAPU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        51,
-    ]
-)
-CYWONF = "".join(
-    chr(c)
-    for c in [
-        76,
-        111,
-        119,
-        101,
-        114,
-        83,
-        101,
-        116,
-        112,
-        111,
-        105,
-        110,
-        116,
-        77,
-        101,
-        110,
-        117,
-    ]
-)
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        68,
-        101,
-        97,
-        108,
-        101,
-        114,
-        76,
-        111,
-        99,
-        107,
-        83,
-        117,
-        112,
-        112,
-        111,
-        114,
-        116,
-    ]
-)
-DAFIKJ = "".join(
-    chr(c)
-    for c in [
-        67,
-        108,
-        101,
-        97,
-        110,
-        117,
-        112,
-        79,
-        110,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-DDPMXF = "".join(chr(c) for c in [66, 101, 108, 108, 97, 103, 105, 111])
-DFSROG = "".join(
-    chr(c) for c in [69, 110, 100, 108, 101, 115, 115, 80, 111, 111, 108, 115]
-)
-DGKEAK = 132
-DJQRJJ = "".join(chr(c) for c in [79, 117, 116, 54, 70, 117, 115, 101])
-DMPSCT = "".join(
-    chr(c)
-    for c in [69, 120, 101, 114, 99, 105, 115, 101, 67, 111, 110, 116, 114, 111, 108]
-)
-DNIBXT = "".join(chr(c) for c in [65, 85, 84, 79, 95, 83, 65, 86, 69, 82])
-DNQGVU = 106
-DPMXFU = "".join(
-    chr(c)
-    for c in [76, 101, 105, 115, 117, 114, 101, 95, 80, 114, 111, 100, 95, 73, 110, 100]
-)
-DQLAII = "".join(
-    chr(c) for c in [67, 111, 111, 108, 90, 111, 110, 101, 77, 111, 100, 101]
-)
-DRXAIV = "".join(chr(c) for c in [73, 98, 101, 114, 83, 112, 97])
-DSBDJQ = 86
-DSSRUR = "".join(
-    chr(c) for c in [78, 79, 95, 82, 69, 83, 84, 82, 73, 67, 84, 73, 79, 78]
-)
-DUBSSU = "".join(
-    chr(c) for c in [73, 110, 112, 117, 116, 67, 117, 114, 114, 101, 110, 116]
-)
-DXLUBG = "".join(chr(c) for c in [83, 84, 65, 84, 85, 83])
-DZXNQT = 75
-EAKSTS = "".join(chr(c) for c in [79, 70, 70])
-EAOESV = 147
-ECVYYP = "".join(chr(c) for c in [80, 51, 76])
-EEZFET = "".join(chr(c) for c in [67, 108, 101, 97, 114, 119, 97, 116, 101, 114])
-EFJTAC = 43
-EFXQGL = 16
-EGZUQE = "".join(chr(c) for c in [70, 50, 50])
-EKBDFS = 111
-EKCWAO = 21
-EKVKZI = "".join(
-    chr(c) for c in [67, 111, 111, 108, 100, 111, 119, 110, 84, 105, 109, 101]
-)
-ELHBQN = 10
-ELWUEU = "".join(chr(c) for c in [77, 97, 114, 113, 117, 105, 115])
-EMCGET = "".join(chr(c) for c in [78, 79, 84, 95, 65, 76, 76, 79, 87, 69, 68])
-EMVCYW = "".join(
-    chr(c) for c in [72, 73, 68, 69, 95, 68, 69, 84, 65, 73, 76, 69, 68, 95, 77, 83, 71]
-)
-EOCTHB = 38
-ESVZSS = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        56,
-    ]
-)
-ETDRXA = "".join(chr(c) for c in [84, 104, 101, 114, 109, 111, 83, 112, 97, 115])
-ETIXQV = 34
-EUHNNX = "".join(chr(c) for c in [83, 117, 110, 114, 97, 110, 115])
-EUTOPH = "".join(chr(c) for c in [70, 49, 67, 117, 114, 114, 101, 110, 116])
-EZFETD = "".join(chr(c) for c in [68, 101, 108, 117, 120, 101])
-FCPOUB = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 52]
-)
-FCRTFM = 92
-FEFJTA = "".join(chr(c) for c in [79, 117, 116, 56, 67, 117, 114])
-FEGZUQ = "".join(chr(c) for c in [70, 50, 49])
-FETDRX = "".join(chr(c) for c in [65, 115, 112, 101, 110])
-FFTTID = "".join(chr(c) for c in [85, 76])
-FIKJPU = "".join(
-    chr(c)
-    for c in [
-        81,
-        117,
-        105,
-        99,
-        107,
-        79,
-        110,
-        79,
-        102,
-        102,
-        67,
-        117,
-        115,
-        116,
-        111,
-        109,
-        75,
-        101,
-        121,
-    ]
-)
-FJNTTU = "".join(chr(c) for c in [90, 111, 110, 101, 51, 84, 121, 112, 101])
-FJTACC = "".join(chr(c) for c in [79, 117, 116, 57, 67, 117, 114])
-FLSIJU = "".join(chr(c) for c in [51])
-FMNHTB = 94
-FOUURI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 52]
-)
-FSROGM = "".join(chr(c) for c in [87, 101, 108, 108, 105, 115])
-FTHECV = "".join(chr(c) for c in [80, 50, 72])
-FTSIFJ = 57
-FTTIDU = "".join(chr(c) for c in [67, 69])
-FUBJLO = "".join(chr(c) for c in [68, 121, 110, 97, 115, 116, 121])
-FWRKIN = 29
-FXQGLR = "".join(chr(c) for c in [79, 117, 116, 72, 116, 114])
-FZCZOL = "".join(
-    chr(c) for c in [75, 101, 121, 112, 97, 100, 79, 112, 116, 105, 111, 110, 115, 52]
-)
-FZDGKE = 130
-GCRHYU = "".join(chr(c) for c in [65, 76, 76, 95, 80, 85, 77, 80, 83])
-GDSBDJ = "".join(chr(c) for c in [79, 117, 116, 52, 70, 117, 115, 101])
-GETIXQ = "".join(chr(c) for c in [84, 105, 109, 101, 70, 111, 114, 109, 97, 116])
-GJFJNT = "".join(chr(c) for c in [90, 111, 110, 101, 51, 76, 101, 100])
-GKEAKS = "".join(chr(c) for c in [83, 105, 108, 101, 110, 116, 77, 111, 100, 101])
-GLRAHE = "".join(chr(c) for c in [79, 117, 116, 49, 67, 117, 114])
-GMDDPM = "".join(chr(c) for c in [66, 97, 114, 101, 102, 111, 111, 116])
-GNVFOU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 49]
-)
-GQPLSP = "".join(chr(c) for c in [67, 112, 85, 115, 97, 103, 101])
-GSELHB = 8
-GTYIYW = 101
-GUCYRA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        50,
-    ]
-)
-GVUNXN = "".join(chr(c) for c in [70, 50, 50, 76, 105, 110, 101])
-GYOUSP = 0
-GZUQEX = "".join(chr(c) for c in [70, 50, 51])
-HBQNRX = 71
-HBSKSO = 40
-HBVWVU = "".join(chr(c) for c in [68, 117, 97, 108, 80, 97, 99, 107])
-HECVYY = "".join(chr(c) for c in [80, 51, 72])
-HEOCTH = "".join(chr(c) for c in [79, 117, 116, 51, 67, 117, 114])
-HFTHEC = "".join(chr(c) for c in [80, 49, 76])
-HIUSOO = "".join(chr(c) for c in [56, 65])
-HNNXWE = "".join(
-    chr(c) for c in [83, 117, 112, 101, 114, 105, 111, 114, 83, 112, 97, 115]
-)
-HTBJEU = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 70, 117, 115, 101])
-HTZBBE = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        69,
-        100,
-        105,
-        116,
-    ]
-)
-HUGTYI = 100
-HUOJRJ = "".join(chr(c) for c in [50, 65])
-HWDAFI = "".join(
-    chr(c)
-    for c in [83, 111, 97, 107, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-HYUAXN = "".join(chr(c) for c in [80, 52, 95, 65, 78, 68, 95, 80, 53])
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        77,
-        97,
-        120,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        80,
-        104,
-        97,
-        115,
-        101,
-        115,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [72, 105])
-IBHZVO = "".join(chr(c) for c in [70, 114, 101, 101, 80, 117, 109, 112, 75, 101, 121])
-IBXTIA = "".join(chr(c) for c in [66, 79, 84, 72, 95, 72, 69, 65, 84])
-IBXYBQ = "".join(chr(c) for c in [83, 101, 116, 112, 111, 105, 110, 116, 71])
-ICXQIE = "".join(chr(c) for c in [79, 117, 116, 51])
-IDNIBX = "".join(chr(c) for c in [65, 85, 84, 79, 95, 87, 95, 66, 79, 79, 83, 84])
-IDUBSS = 52
-IEFXQG = "".join(chr(c) for c in [79, 117, 116, 53])
-IEVBVH = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        78,
-        111,
-        116,
-        66,
-        108,
-        105,
-        110,
-        107,
-        105,
-        110,
-        103,
-        76,
-        69,
-        68,
-    ]
-)
-IFJBIA = "".join(
-    chr(c) for c in [87, 105, 116, 104, 83, 80, 79, 118, 101, 114, 57, 53, 70]
-)
-IHBXIB = "".join(
-    chr(c) for c in [72, 105, 103, 104, 83, 112, 101, 101, 100, 79, 110, 108, 121]
-)
-IIDNIB = "".join(chr(c) for c in [72, 69, 65, 84, 95, 83, 65, 86, 69, 82])
-IJUGSE = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114, 50])
-IJUZMR = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        78,
-        111,
-        114,
-        109,
-        97,
-        108,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-IKGNVF = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 51]
-)
-IKJPUN = 5
-ILXWAJ = 68
-INEJNI = "".join(chr(c) for c in [83, 116, 97, 110, 100, 97, 114, 100])
-INELWU = "".join(chr(c) for c in [80, 114, 111, 95, 70, 108, 111, 97, 116])
-IPIVLA = "".join(chr(c) for c in [79, 51])
-IPMDMP = "".join(chr(c) for c in [78, 79, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-IPOUYN = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 67, 117, 114])
-IRYXBQ = 61
-IUSOOQ = "".join(chr(c) for c in [57, 65])
-IUXFEF = 41
-IVDNQG = 105
-IVEMVC = 112
-IVLASS = "".join(chr(c) for c in [72, 84, 82])
-IXQVXO = "".join(chr(c) for c in [50, 52, 104])
-IYWSKW = "".join(chr(c) for c in [70, 50, 51, 67, 117, 114, 114, 101, 110, 116])
-JBIAMJ = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 112, 101, 101, 100])
-JEUTOP = 97
-JFJNTT = 125
-JHIUSO = "".join(chr(c) for c in [55, 65])
-JIGYOU = "".join(chr(c) for c in [79, 119, 110])
-JJJVYF = "".join(chr(c) for c in [79, 117, 116, 56, 70, 117, 115, 101])
-JJVYFC = 90
-JLOINE = "".join(chr(c) for c in [74, 97, 99, 117, 122, 122, 105])
-JMAOAW = 1
-JMCBFE = 163
-JNIBXY = "".join(
-    chr(c) for c in [79, 51, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-JNTTUV = "".join(chr(c) for c in [90, 111, 110, 101, 52, 76, 101, 100])
-JPUNRJ = 76
-JQRJJJ = 88
-JRJHIU = "".join(chr(c) for c in [53, 65])
-JTACCP = 44
-JUGSEL = 116
-JUIKFW = "".join(chr(c) for c in [70, 105, 108, 116, 101, 114])
-JUTYEK = 19
-JUZMRK = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-JVDQLA = "".join(
-    chr(c) for c in [78, 111, 72, 101, 97, 116, 80, 101, 114, 105, 111, 100]
-)
-JVHFTH = "".join(chr(c) for c in [78, 65])
-JVYFCR = "".join(chr(c) for c in [79, 117, 116, 57, 70, 117, 115, 101])
-JWMNZM = 55
-JYKLGQ = "".join(chr(c) for c in [70, 105, 108, 116, 67, 80])
-JYMOUN = "".join(
-    chr(c)
-    for c in [
-        87,
-        97,
-        116,
-        101,
-        114,
-        102,
-        97,
-        108,
-        108,
-        86,
-        97,
-        108,
-        118,
-        101,
-        79,
-        110,
-        67,
-        80,
-    ]
-)
-JZTATD = 73
-KBDFSR = "".join(chr(c) for c in [71, 101, 110, 101, 114, 105, 99])
-KCWAON = "".join(chr(c) for c in [79, 117, 116, 49, 49])
-KEAKST = 157
-KFWRKI = "".join(chr(c) for c in [79, 51, 80, 117, 109, 112])
-KGNVFO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 52]
-)
-KHTZBB = 8
-KINEJN = 30
-KJPUNR = "".join(
-    chr(c) for c in [77, 117, 108, 116, 105, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-KLGQPL = "".join(
-    chr(c) for c in [70, 105, 108, 116, 80, 49, 68, 117, 114, 79, 110, 108, 121]
-)
-KMLOIJ = "".join(chr(c) for c in [70, 105, 108, 116, 83, 116, 97, 114, 116])
-KPHUOJ = "".join(chr(c) for c in [48, 65])
-KQTDKH = "".join(chr(c) for c in [77, 65, 71, 69, 78, 84, 65])
-KQXPIC = "".join(chr(c) for c in [65, 85, 88])
-KSOKPH = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 80, 117, 109, 112, 67, 117, 114, 114, 101, 110, 116]
-)
-KVFCPO = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 50]
-)
-KVKZIL = 35
-KXSJWM = "".join(chr(c) for c in [80, 117, 109, 112, 84, 105, 109, 101, 79, 117, 116])
-KZILXW = 66
-LAIIDN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-LASSAK = "".join(chr(c) for c in [70, 97, 110])
-LHBQNR = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        80,
-        114,
-        111,
-        103,
-        65,
-        118,
-        97,
-        105,
-        108,
-        97,
-        98,
-        108,
-        101,
-    ]
-)
-LIUXFE = "".join(chr(c) for c in [79, 117, 116, 54, 67, 117, 114])
-LJUIKF = 28
-LKXSJW = 80
-LNMHXE = "".join(
-    chr(c) for c in [80, 114, 111, 98, 101, 76, 111, 99, 97, 116, 105, 111, 110]
-)
-LOIJUG = "".join(chr(c) for c in [70, 105, 108, 116, 68, 117, 114])
-LOINEL = "".join(chr(c) for c in [74, 97, 122, 122, 105])
-LRAHEO = 36
-LSIJUZ = "".join(chr(c) for c in [52])
-LSIPMD = "".join(
-    chr(c) for c in [69, 120, 101, 114, 99, 105, 115, 101, 84, 121, 112, 101]
-)
-LSPFTS = "".join(chr(c) for c in [65, 76, 87, 65, 89, 83, 95, 79, 78])
-LSXUJU = 17
-LUBGJF = "".join(chr(c) for c in [90, 111, 110, 101, 50, 76, 101, 100])
-LWUEUH = "".join(chr(c) for c in [80, 68, 67])
-LXWAJV = "".join(chr(c) for c in [69, 99, 111, 110, 84, 121, 112, 101])
-MAOAWB = "".join(chr(c) for c in [79, 84, 84, 114, 105, 103, 103, 101, 114, 71])
-MCBFEG = "".join(chr(c) for c in [70, 49])
-MCGETI = "".join(chr(c) for c in [65, 76, 76, 79, 87, 69, 68])
-MCVDSS = 110
-MDDPMX = "".join(chr(c) for c in [66, 101, 97, 99, 104, 99, 111, 109, 98, 101, 114])
-MEAOES = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        54,
-    ]
-)
-MFZDGK = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 68, 117, 114])
-MHXEKV = "".join(chr(c) for c in [73, 110, 116, 111, 84, 117, 98])
-MIKGNV = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 51, 84, 111, 79, 117, 116, 50]
-)
-MJIGYO = "".join(chr(c) for c in [83, 104, 97, 114, 101, 100])
-MJMAOA = "".join(
-    chr(c) for c in [65, 117, 120, 65, 115, 66, 117, 98, 98, 108, 101, 71, 101, 110]
-)
-MJVHFT = 12
-MKQTDK = "".join(chr(c) for c in [66, 76, 85, 69])
-MLOIJU = 4
-MNHTBJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 49, 70, 117, 115, 101])
-MNZMJI = 56
-MOUNBL = "".join(chr(c) for c in [79, 117, 116, 76, 105])
-MPSCTT = 134
-MRKVFC = "".join(
-    chr(c) for c in [77, 97, 112, 112, 105, 110, 103, 69, 110, 97, 98, 108, 101]
-)
-MVCYWO = "".join(chr(c) for c in [83, 72, 79, 87, 95, 65, 76, 76, 95, 77, 83, 71])
-MXFUBJ = "".join(chr(c) for c in [67, 111, 97, 115, 116])
-NAXADX = "".join(chr(c) for c in [82, 71, 66])
-NCUGUC = 136
-NEJNIB = "".join(chr(c) for c in [84, 111, 103, 103, 108, 101])
-NELWUE = "".join(chr(c) for c in [77, 65, 65, 88])
-NHTBJE = 95
-NIBXTI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76, 95, 72, 69, 65, 84])
-NIBXYB = 63
-NKMLOI = 3
-NMHXEK = "".join(chr(c) for c in [73, 110, 116, 111, 80, 105, 112, 105, 110, 103])
-NNXWEE = "".join(
-    chr(c) for c in [83, 112, 97, 95, 73, 110, 100, 117, 115, 116, 114, 105, 101, 115]
-)
-NPYYLI = 24
-NQGVUN = "".join(chr(c) for c in [70, 50, 49, 76, 105, 110, 101])
-NQJYMO = 119
-NQLNMH = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 80, 117, 109, 112])
-NRSJMC = "".join(chr(c) for c in [49, 53, 65])
-NRXCHW = "".join(chr(c) for c in [85, 68, 80, 114, 111, 103, 69, 99, 111, 110])
-NTTUVR = 126
-NVFOUU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 50]
-)
-NXNKML = 109
-NXWEEZ = "".join(chr(c) for c in [86, 105, 107, 105, 110, 103])
-NZMJIG = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 114])
-OACMCV = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 111, 112]
-)
-OAWBSI = "".join(
-    chr(c)
-    for c in [67, 112, 79, 110, 84, 105, 109, 101, 68, 117, 114, 105, 110, 103, 79, 84]
-)
-OCTHBS = "".join(chr(c) for c in [79, 117, 116, 52, 67, 117, 114])
-OESVZS = 149
-OGMDDP = "".join(chr(c) for c in [65, 114, 99, 116, 105, 99])
-OIHBXI = "".join(chr(c) for c in [66, 111, 116, 104, 83, 112, 101, 101, 100, 115])
-OIJUGS = 6
-OINELW = "".join(chr(c) for c in [76, 65])
-OJRJHI = "".join(chr(c) for c in [52, 65])
-OKPHUO = "".join(chr(c) for c in [78, 111, 116, 95, 83, 101, 116])
-OLSIPM = 121
-ONFZCZ = "".join(chr(c) for c in [70, 111, 114, 90, 111, 110, 101, 115])
-ONPYYL = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116])
-OOQNRS = "".join(chr(c) for c in [49, 50, 65])
-OPHUGT = 99
-OQNRSJ = "".join(chr(c) for c in [49, 51, 65])
-OUBMIK = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 51]
-)
-OUNBLK = 79
-OUSPBW = 118
-OUURIE = "".join(
-    chr(c)
-    for c in [
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-        76,
-        105,
-        103,
-        104,
-        116,
-        82,
-        101,
-        109,
-        105,
-        110,
-        100,
-        101,
-        114,
-        115,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-PBWJYK = "".join(
-    chr(c) for c in [70, 105, 108, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101]
-)
-PFTSIF = "".join(chr(c) for c in [79, 116, 79, 112, 116, 105, 111, 110])
-PHUGTY = "".join(chr(c) for c in [70, 51, 67, 117, 114, 114, 101, 110, 116])
-PHUOJR = "".join(chr(c) for c in [49, 65])
-PICXQI = 13
-PIPIVL = "".join(chr(c) for c in [67, 80])
-PIVLAS = "".join(chr(c) for c in [76, 49, 50, 48])
-PLSPFT = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-PMDMPS = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-PMXFUB = "".join(chr(c) for c in [66, 117, 108, 108, 102, 114, 111, 103])
-POUBMI = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 50]
-)
-POUYNQ = 48
-PQIPOU = "".join(chr(c) for c in [79, 117, 116, 49, 50, 67, 117, 114])
-PSCTTG = "".join(
-    chr(c)
-    for c in [85, 83, 69, 95, 83, 84, 65, 78, 68, 65, 82, 68, 95, 80, 85, 77, 80, 83]
-)
-PUMEAO = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        53,
-    ]
-)
-PUNRJZ = "".join(
-    chr(c) for c in [78, 111, 66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67]
-)
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [76, 105, 110, 101, 51])
-QFFTTI = 51
-QFYLJU = "".join(chr(c) for c in [80, 49])
-QGVUNX = 107
-QIEFXQ = 15
-QIPOUY = 47
-QJYMOU = 2
-QLAIID = 115
-QLNMHX = 31
-QNRSJM = "".join(chr(c) for c in [49, 52, 65])
-QPLSPF = 27
-QRJJJV = "".join(chr(c) for c in [79, 117, 116, 55, 70, 117, 115, 101])
-QSNQLN = "".join(chr(c) for c in [67])
-QTDKHT = "".join(chr(c) for c in [67, 89, 65, 78])
-QTMFZD = "".join(
-    chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 83, 116, 97, 114, 116]
-)
-QVXOIH = "".join(
-    chr(c)
-    for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 84, 114, 105, 103, 65, 68, 67]
-)
-RAHEOC = "".join(chr(c) for c in [79, 117, 116, 50, 67, 117, 114])
-RAPUME = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        52,
-    ]
-)
-RAZMKQ = "".join(chr(c) for c in [82, 69, 68])
-RFLSIJ = "".join(chr(c) for c in [50])
-RHYUAX = "".join(chr(c) for c in [80, 51, 95, 84, 79, 95, 80, 53])
-RJHIUS = "".join(chr(c) for c in [54, 65])
-RJJJVY = 89
-RJZTAT = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-RKINEJ = "".join(chr(c) for c in [79, 51, 84, 121, 112, 101])
-RKVFCP = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 49]
-)
-ROGMDD = "".join(chr(c) for c in [65, 114, 116, 101, 115, 105, 97, 110])
-RTFMNH = 93
-RURAZM = "".join(
-    chr(c) for c in [66, 114, 101, 97, 107, 101, 114, 67, 104, 97, 110, 103, 101]
-)
-RXAIVE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 95, 83, 112, 97, 115])
-RXCHWD = 82
-RYXBQF = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 84, 105, 109, 101]
-)
-SAKQXP = "".join(chr(c) for c in [72, 84, 82, 50])
-SBDJQR = "".join(chr(c) for c in [79, 117, 116, 53, 70, 117, 115, 101])
-SBVNAX = 155
-SELHBQ = "".join(chr(c) for c in [69, 99, 111, 110, 68, 117, 114])
-SEMCGE = "".join(
-    chr(c)
-    for c in [
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        84,
-        111,
-        82,
-        101,
-        103,
-        117,
-        108,
-        97,
-        116,
-        101,
-    ]
-)
-SIFJBI = "".join(
-    chr(c) for c in [65, 108, 119, 97, 121, 115, 69, 110, 97, 98, 108, 101, 100]
-)
-SIPMDM = 133
-SIRYXB = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        79,
-        110,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-SJMCBF = "".join(
-    chr(c) for c in [72, 101, 97, 116, 80, 117, 109, 112, 70, 117, 115, 101]
-)
-SJWMNZ = "".join(
-    chr(c) for c in [76, 105, 103, 104, 116, 84, 105, 109, 101, 79, 117, 116]
-)
-SKSOKP = 50
-SKWIVD = 104
-SOKPHU = 161
-SOOQNR = "".join(chr(c) for c in [49, 49, 65])
-SPBWJY = 120
-SROGMD = "".join(chr(c) for c in [65, 108, 112, 115])
-SSAKQX = "".join(chr(c) for c in [79, 78, 90, 69, 78])
-SSBVNA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        49,
-        48,
-    ]
-)
-SSRURA = "".join(
-    chr(c)
-    for c in [80, 65, 83, 83, 87, 79, 82, 68, 95, 80, 82, 79, 84, 69, 67, 84, 69, 68]
-)
-SSUHBV = 122
-STSEMC = "".join(
-    chr(c) for c in [83, 105, 108, 101, 110, 116, 68, 117, 114, 97, 116, 105, 111, 110]
-)
-SUHBVW = "".join(chr(c) for c in [73, 110, 112, 117, 116, 77, 101, 110, 117])
-SVZSSB = 151
-SXUJUT = "".join(chr(c) for c in [79, 117, 116, 55])
-TACCPQ = "".join(chr(c) for c in [79, 117, 116, 49, 48, 67, 117, 114])
-TATDZX = "".join(chr(c) for c in [83, 108, 97, 118, 101])
-TBJEUT = 96
-TDKHTZ = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-TDRXAI = "".join(chr(c) for c in [84, 105, 116, 97, 110, 95, 83, 112, 97, 115])
-TDZXNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 67, 111, 110, 102, 105, 103])
-TFMNHT = "".join(chr(c) for c in [79, 117, 116, 49, 50, 70, 117, 115, 101])
-TGCRHY = "".join(chr(c) for c in [78, 79, 95, 80, 85, 77, 80])
-THBSKS = "".join(chr(c) for c in [79, 117, 116, 53, 67, 117, 114])
-THECVY = "".join(chr(c) for c in [80, 50, 76])
-TIACQF = 162
-TIDUBS = "".join(chr(c) for c in [78, 98, 80, 104, 97, 115, 101, 115])
-TIXQVX = "".join(chr(c) for c in [65, 109, 80, 109])
-TMFZDG = 128
-TOPHUG = "".join(chr(c) for c in [70, 50, 67, 117, 114, 114, 101, 110, 116])
-TSEMCG = 158
-TSIFJB = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101, 100])
-TTGCRH = 135
-TTUVRF = "".join(chr(c) for c in [90, 111, 110, 101, 52, 84, 121, 112, 101])
-TUVRFL = "".join(
-    chr(c) for c in [78, 117, 109, 98, 101, 114, 79, 102, 90, 111, 110, 101, 115]
-)
-TYEKCW = 20
-TYIYWS = "".join(chr(c) for c in [70, 50, 50, 67, 117, 114, 114, 101, 110, 116])
-TZBBEK = "".join(chr(c) for c in [68, 105, 115, 97, 98, 108, 101])
-UBGJFJ = 124
-UBJLOI = "".join(chr(c) for c in [70, 111, 117, 114, 95, 87, 105, 110, 100])
-UBMIKG = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 50, 84, 111, 79, 117, 116, 52]
-)
-UBSSUH = 53
-UBYGDS = 84
-UCYRAP = 139
-UEUHNN = "".join(chr(c) for c in [83, 116, 114, 111, 110, 103])
-UGSELH = "".join(chr(c) for c in [69, 99, 111, 110, 83, 116, 97, 114, 116])
-UGTYIY = "".join(chr(c) for c in [70, 50, 49, 67, 117, 114, 114, 101, 110, 116])
-UGUCYR = 137
-UHBVWV = 74
-UHNNXW = "".join(chr(c) for c in [83, 117, 110, 114, 105, 115, 101])
-UIKFWR = "".join(chr(c) for c in [65, 108, 119, 97, 121, 115])
-UJUTYE = "".join(chr(c) for c in [79, 117, 116, 56])
-UMEAOE = 145
-UNBLKX = "".join(chr(c) for c in [76, 73])
-UNRJZT = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 79, 110, 73, 50, 67])
-UNXNKM = "".join(chr(c) for c in [70, 50, 51, 76, 105, 110, 101])
-UOJRJH = "".join(chr(c) for c in [51, 65])
-UQEXLS = "".join(chr(c) for c in [76, 105, 110, 101, 50])
-URAZMK = "".join(
-    chr(c)
-    for c in [
-        75,
-        101,
-        121,
-        112,
-        97,
-        100,
-        66,
-        97,
-        99,
-        107,
-        108,
-        105,
-        103,
-        104,
-        116,
-        67,
-        111,
-        108,
-        111,
-        114,
-    ]
-)
-URIEVB = "".join(
-    chr(c) for c in [83, 65, 77, 69, 95, 65, 83, 95, 78, 79, 82, 77, 65, 76]
-)
-USOOQN = "".join(chr(c) for c in [49, 48, 65])
-USPBWJ = "".join(chr(c) for c in [65, 117, 120, 84, 105, 109, 101, 79, 117, 116])
-UTOPHU = 98
-UTYEKC = "".join(chr(c) for c in [79, 117, 116, 57])
-UURIEV = 164
-UVRFLS = 127
-UXFEFJ = "".join(chr(c) for c in [79, 117, 116, 55, 67, 117, 114])
-UYNQJY = 49
-UZMRKV = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-VDNQGV = "".join(chr(c) for c in [70, 51, 76, 105, 110, 101])
-VDQLAI = 77
-VDSSRU = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 67, 104, 97, 110, 103, 101]
-)
-VEMVCY = "".join(
-    chr(c) for c in [73, 110, 102, 111, 77, 115, 103, 67, 111, 110, 102, 105, 103]
-)
-VFCPOU = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 49, 84, 111, 79, 117, 116, 51]
-)
-VFOUUR = "".join(
-    chr(c) for c in [77, 97, 112, 90, 111, 110, 101, 52, 84, 111, 79, 117, 116, 51]
-)
-VHDVRI = 66
-VHFTHE = "".join(chr(c) for c in [80, 49, 72])
-VKZILX = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VLASSA = "".join(chr(c) for c in [])
-VNAXAD = 123
-VOACMC = 6
-VRFLSI = "".join(chr(c) for c in [49])
-VUBYGD = "".join(chr(c) for c in [79, 117, 116, 50, 70, 117, 115, 101])
-VUNXNK = 108
-VWVUBY = "".join(chr(c) for c in [79, 117, 116, 49, 70, 117, 115, 101])
-VXOIHB = 64
-VYFCRT = 91
-VYYPIP = "".join(chr(c) for c in [80, 52, 76])
-VZSSBV = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        80,
-        117,
-        109,
-        112,
-        67,
-        111,
-        109,
-        98,
-        105,
-        110,
-        97,
-        116,
-        105,
-        111,
-        110,
-        57,
-    ]
-)
-WAJVDQ = "".join(chr(c) for c in [78, 105, 103, 104, 116])
-WAONPY = "".join(chr(c) for c in [79, 117, 116, 49, 50])
-WBSIRY = "".join(
-    chr(c)
-    for c in [
-        67,
-        112,
-        79,
-        102,
-        102,
-        84,
-        105,
-        109,
-        101,
-        68,
-        117,
-        114,
-        105,
-        110,
-        103,
-        79,
-        84,
-    ]
-)
-WDAFIK = "".join(
-    chr(c) for c in [79, 102, 102, 79, 110, 67, 117, 115, 116, 111, 109, 75, 101, 121]
-)
-WEEZFE = "".join(chr(c) for c in [79, 107, 101, 97, 110, 111, 115])
-WIVDNQ = "".join(chr(c) for c in [70, 50, 76, 105, 110, 101])
-WJYKLG = "".join(chr(c) for c in [80, 117, 114, 103, 101, 79, 110, 108, 121])
-WMNZMJ = "".join(chr(c) for c in [76, 49, 50, 48, 84, 105, 109, 101, 79, 117, 116])
-WONFZC = "".join(chr(c) for c in [70, 111, 114, 83, 112, 101, 101, 100, 115])
-WSKWIV = "".join(chr(c) for c in [70, 49, 76, 105, 110, 101])
-WUEUHN = "".join(
-    chr(c)
-    for c in [80, 114, 101, 109, 105, 117, 109, 95, 76, 101, 105, 115, 117, 114, 101]
-)
-WVUBYG = 83
-XADXLU = "".join(chr(c) for c in [90, 111, 110, 101, 49, 84, 121, 112, 101])
-XBQFYL = "".join(chr(c) for c in [68, 114, 97, 105, 110, 77, 111, 100, 101])
-XCHWDA = "".join(
-    chr(c)
-    for c in [
-        69,
-        99,
-        111,
-        110,
-        67,
-        111,
-        110,
-        116,
-        114,
-        111,
-        108,
-        97,
-        98,
-        108,
-        101,
-        77,
-        97,
-        110,
-        117,
-        97,
-        108,
-        108,
-        121,
-    ]
-)
-XEKVKZ = 3
-XFEFJT = 42
-XFUBJL = "".join(
-    chr(c) for c in [68, 105, 109, 101, 110, 115, 105, 111, 110, 95, 111, 110, 101]
-)
-XIBHZV = "".join(
-    chr(c)
-    for c in [66, 108, 111, 119, 101, 114, 75, 101, 121, 79, 112, 116, 105, 111, 110]
-)
-XLSXUJ = "".join(chr(c) for c in [79, 117, 116, 54])
-XNCUGU = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        78,
-        117,
-        109,
-        98,
-        101,
-        114,
-        79,
-        102,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-XNKMLO = "".join(chr(c) for c in [70, 105, 108, 116, 70, 114, 101, 113])
-XNQTMF = 160
-XOIHBX = "".join(
-    chr(c)
-    for c in [80, 117, 109, 112, 49, 85, 115, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-XPICXQ = "".join(chr(c) for c in [79, 117, 116, 50])
-XQGLRA = 26
-XQIEFX = "".join(chr(c) for c in [79, 117, 116, 52])
-XSJWMN = 54
-XTIACQ = "".join(
-    chr(c)
-    for c in [
-        71,
-        101,
-        110,
-        101,
-        114,
-        105,
-        99,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        73,
-        68,
-    ]
-)
-XUJUTY = 18
-XWAJVD = 70
-XWEEZF = "".join(
-    chr(c) for c in [87, 87, 79, 95, 87, 104, 105, 114, 108, 99, 97, 114, 101]
-)
-XYBQSN = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-YBQSNQ = 33
-YEKCWA = "".join(chr(c) for c in [79, 117, 116, 49, 48])
-YFCRTF = "".join(chr(c) for c in [79, 117, 116, 49, 48, 70, 117, 115, 101])
-YGDSBD = 85
-YIYWSK = 102
-YKLGQP = "".join(chr(c) for c in [70, 105, 108, 116, 80, 49])
-YLIUXF = 25
-YLJUIK = "".join(chr(c) for c in [79, 51, 85, 115, 97, 103, 101])
-YMOUNB = 4
-YNQJYM = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 65, 115, 67, 80]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 102, 97, 108, 108, 84, 105, 109, 101, 79, 117, 116]
-)
-YPIPIV = "".join(chr(c) for c in [66, 76, 79])
-YRAPUM = 141
-YUAXNC = "".join(chr(c) for c in [80, 53, 95, 79, 78, 76, 89])
-YWONFZ = "".join(
-    chr(c) for c in [83, 105, 110, 103, 108, 101, 80, 117, 109, 112, 75, 101, 121]
-)
-YWSKWI = 103
-YXBQFY = 62
-YYLIUX = "".join(chr(c) for c in [68, 105, 114, 101, 99, 116, 50])
-YYPIPI = "".join(chr(c) for c in [80, 53])
-ZBBEKB = "".join(chr(c) for c in [69, 110, 97, 98, 108, 101])
-ZCQBMJ = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 78, 117, 109, 98, 101, 114]
-)
-ZCZOLS = 113
-ZDGKEA = "".join(chr(c) for c in [80, 114, 111, 103, 79, 117, 116, 70, 114, 101, 113])
-ZFETDR = "".join(chr(c) for c in [73, 100, 111, 108])
-ZILXWA = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-ZMJIGY = 81
-ZMKQTD = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-ZOLSIP = "".join(chr(c) for c in [76, 111, 99, 107, 69, 110, 97, 98, 108, 101, 100])
-ZSSBVN = 153
-ZTATDZ = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114])
-ZUQEXL = "".join(chr(c) for c in [76, 105, 110, 101, 49])
-ZVOACM = "".join(
-    chr(c)
-    for c in [72, 101, 97, 116, 101, 114, 83, 111, 102, 116, 83, 116, 97, 114, 116]
-)
-ZXNQTM = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 65, 99, 99, 101, 115, 115, 111, 114, 121]
-)
-AJVDQL = [INEJNI, WAJVDQ]
-AMJMAO = [BIAMJM, IAMJMA]
-ATDZXN = [VLASSA, ZTATDZ, TATDZX]
-AXADXL = [NAXADX, TDKHTZ]
-BBEKBD = [TZBBEK, ZBBEKB]
-BVHDVR = []
-BVWVUB = [INEJNI, HBVWVU]
-BXTIAC = [LAIIDN, AIIDNI, IIDNIB, IDNIBX, DNIBXT, NIBXTI, IBXTIA]
-CGETIX = [EMCGET, MCGETI]
-DKHTZB = [EAKSTS, RAZMKQ, AZMKQT, ZMKQTD, MKQTDK, KQTDKH, QTDKHT, TDKHTZ]
-EJNIBX = [INEJNI, NEJNIB]
-EVBVHD = [
-    BMJVHF,
-    XPICXQ,
-    ICXQIE,
-    XQIEFX,
-    IEFXQG,
-    FXQGLR,
-    KSOKPH,
-    SJMCBF,
-    XLSXUJ,
-    SXUJUT,
-    UJUTYE,
-    UTYEKC,
-    YEKCWA,
-    KCWAON,
-    WAONPY,
-    ONPYYL,
-    YYLIUX,
-    MOUNBL,
-]
-EXLSXU = [MCBFEG, CBFEGZ, BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL, UQEXLS, QEXLSX]
-FJBIAM = [TSIFJB, SIFJBI, IFJBIA]
-FYLJUI = [JVHFTH, QFYLJU, PIPIVL]
-HBXIBH = [OIHBXI, IHBXIB]
-HXEKVK = [NMHXEK, MHXEKV]
-HZVOAC = [IBHZVO, BHZVOA]
-IGYOUS = [MJIGYO, JIGYOU]
-IKFWRK = [JUIKFW, UIKFWR]
-KSTSEM = [JVHFTH, EAKSTS, VLASSA, AKSTSE]
-KWIVDN = [VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, VLASSA, ZUQEXL, UQEXLS, QEXLSX]
-LGQPLS = [WJYKLG, JYKLGQ, YKLGQP, KLGQPL]
-MDMPSC = [IPMDMP, PMDMPS]
-NBLKXS = [
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    UNBLKX,
-]
-NFZCZO = [JVHFTH, WONFZC, ONFZCZ, VLASSA]
-NQTMFZ = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIVLAS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    KQXPIC,
-]
-NRJZTA = [PUNRJZ, UNRJZT]
-PYYLIU = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    PIPIVL,
-]
-QGLRAH = [
-    JVHFTH,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    IVLASS,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SAKQXP,
-]
-QNRXCH = [JVHFTH, PLSPFT, BQNRXC]
-QXPICX = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    YPIPIV,
-    PIPIVL,
-    IPIVLA,
-    PIVLAS,
-    IVLASS,
-    VLASSA,
-    LASSAK,
-    VLASSA,
-    VLASSA,
-    ASSAKQ,
-    VLASSA,
-    VLASSA,
-    VLASSA,
-    SSAKQX,
-    VLASSA,
-    SAKQXP,
-    AKQXPI,
-    KQXPIC,
-]
-RIEVBV = [URIEVB, TDKHTZ, AZMKQT, JUZMRK, ZMKQTD, QTDKHT, UZMRKV, EAKSTS]
-RSJMCB = [
-    OKPHUO,
-    KPHUOJ,
-    PHUOJR,
-    HUOJRJ,
-    UOJRJH,
-    OJRJHI,
-    JRJHIU,
-    RJHIUS,
-    JHIUSO,
-    HIUSOO,
-    IUSOOQ,
-    USOOQN,
-    SOOQNR,
-    OOQNRS,
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-]
-SCTTGC = [PSCTTG]
-SIJUZM = [VLASSA, VRFLSI, RFLSIJ, FLSIJU, LSIJUZ]
-SNQLNM = [BQSNQL, QSNQLN]
-SPFTSI = [PLSPFT, LSPFTS]
-SRURAZ = [DSSRUR, SSRURA]
-TTIDUB = [FFTTID, FTTIDU]
-UAXNCU = [TGCRHY, GCRHYU, CRHYUA, RHYUAX, HYUAXN, YUAXNC, VLASSA, VLASSA]
-VBVHDV = [UNBLKX]
-VCYWON = [EMVCYW, MVCYWO, VLASSA, VLASSA]
-WRKINE = [PIPIVL, QFYLJU]
-XAIVEM = [
-    KBDFSR,
-    BDFSRO,
-    DFSROG,
-    FSROGM,
-    SROGMD,
-    ROGMDD,
-    OGMDDP,
-    GMDDPM,
-    MDDPMX,
-    DDPMXF,
-    DPMXFU,
-    PMXFUB,
-    MXFUBJ,
-    XFUBJL,
-    FUBJLO,
-    UBJLOI,
-    BJLOIN,
-    JLOINE,
-    LOINEL,
-    OINELW,
-    INELWU,
-    NELWUE,
-    ELWUEU,
-    LWUEUH,
-    WUEUHN,
-    UEUHNN,
-    EUHNNX,
-    UHNNXW,
-    HNNXWE,
-    NNXWEE,
-    NXWEEZ,
-    XWEEZF,
-    WEEZFE,
-    EEZFET,
-    EZFETD,
-    ZFETDR,
-    FETDRX,
-    ETDRXA,
-    TDRXAI,
-    DRXAIV,
-    RXAIVE,
-]
-XLUBGJ = [ADXLUB, DXLUBG]
-XQVXOI = [JVHFTH, TIXQVX, IXQVXO]
-ZMRKVF = [MKQTDK, TDKHTZ, AZMKQT, JUZMRK, ZMKQTD, QTDKHT, UZMRKV, EAKSTS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -1777,409 +19,1484 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return VHDVRI
+        return 66
 
     @property
     def output_keys(self):
-        return EVBVHD
+        return [
+            "Out1",
+            "Out2",
+            "Out3",
+            "Out4",
+            "Out5",
+            "OutHtr",
+            "HeatPumpCurrent",
+            "HeatPumpFuse",
+            "Out6",
+            "Out7",
+            "Out8",
+            "Out9",
+            "Out10",
+            "Out11",
+            "Out12",
+            "Direct",
+            "Direct2",
+            "OutLi",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, QXPICX, None, None, QBMJVH
+            "ConfigNumber": GeckoByteStructAccessor(
+                self.struct, "ConfigNumber", 0, "ALL"
+            ),
+            "Out1": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1",
+                12,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2",
+                13,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3",
+                14,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4",
+                15,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5",
+                16,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtr",
+                26,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "HTR2",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Cur": GeckoByteStructAccessor(self.struct, "Out1Cur", 36, "ALL"),
+            "Out2Cur": GeckoByteStructAccessor(self.struct, "Out2Cur", 37, "ALL"),
+            "Out3Cur": GeckoByteStructAccessor(self.struct, "Out3Cur", 38, "ALL"),
+            "Out4Cur": GeckoByteStructAccessor(self.struct, "Out4Cur", 39, "ALL"),
+            "Out5Cur": GeckoByteStructAccessor(self.struct, "Out5Cur", 40, "ALL"),
+            "OutHtRCur": GeckoByteStructAccessor(self.struct, "OutHtRCur", 50, "ALL"),
+            "HeatPumpCurrent": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpCurrent",
+                161,
+                None,
+                [
+                    "Not_Set",
+                    "0A",
+                    "1A",
+                    "2A",
+                    "3A",
+                    "4A",
+                    "5A",
+                    "6A",
+                    "7A",
+                    "8A",
+                    "9A",
+                    "10A",
+                    "11A",
+                    "12A",
+                    "13A",
+                    "14A",
+                    "15A",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "HeatPumpFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "HeatPumpFuse",
+                163,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6",
+                17,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7",
+                18,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8",
+                19,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9",
+                20,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10",
+                21,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11",
+                22,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12",
+                23,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "HTR",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "HTR2",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct",
+                24,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2",
+                25,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Cur": GeckoByteStructAccessor(self.struct, "Out6Cur", 41, "ALL"),
+            "Out7Cur": GeckoByteStructAccessor(self.struct, "Out7Cur", 42, "ALL"),
+            "Out8Cur": GeckoByteStructAccessor(self.struct, "Out8Cur", 43, "ALL"),
+            "Out9Cur": GeckoByteStructAccessor(self.struct, "Out9Cur", 44, "ALL"),
+            "Out10Cur": GeckoByteStructAccessor(self.struct, "Out10Cur", 45, "ALL"),
+            "Out11Cur": GeckoByteStructAccessor(self.struct, "Out11Cur", 46, "ALL"),
+            "Out12Cur": GeckoByteStructAccessor(self.struct, "Out12Cur", 47, "ALL"),
+            "DirectCur": GeckoByteStructAccessor(self.struct, "DirectCur", 48, "ALL"),
+            "Direct2Cur": GeckoByteStructAccessor(self.struct, "Direct2Cur", 49, "ALL"),
+            "WaterfallAsCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallAsCP", 119, 2, "ALL"
+            ),
+            "WaterfallValveOnCP": GeckoBoolStructAccessor(
+                self.struct, "WaterfallValveOnCP", 119, 4, "ALL"
+            ),
+            "OutLi": GeckoEnumStructAccessor(
+                self.struct,
+                "OutLi",
+                79,
+                None,
+                ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "LI"],
+                None,
+                None,
+                None,
+            ),
+            "LightInts": GeckoByteStructAccessor(self.struct, "LightInts", 80, None),
+            "PumpTimeOut": GeckoByteStructAccessor(
+                self.struct, "PumpTimeOut", 54, "ALL"
+            ),
+            "LightTimeOut": GeckoByteStructAccessor(
+                self.struct, "LightTimeOut", 55, "ALL"
+            ),
+            "L120TimeOut": GeckoByteStructAccessor(
+                self.struct, "L120TimeOut", 56, "ALL"
+            ),
+            "L120Timer": GeckoEnumStructAccessor(
+                self.struct, "L120Timer", 81, 0, ["Shared", "Own"], None, 2, "ALL"
+            ),
+            "WaterfallTimeOut": GeckoByteStructAccessor(
+                self.struct, "WaterfallTimeOut", 118, "ALL"
+            ),
+            "AuxTimeOut": GeckoByteStructAccessor(
+                self.struct, "AuxTimeOut", 120, "ALL"
+            ),
+            "FiltInterface": GeckoEnumStructAccessor(
+                self.struct,
+                "FiltInterface",
+                32,
+                None,
+                ["PurgeOnly", "FiltCP", "FiltP1", "FiltP1DurOnly"],
+                None,
+                None,
+                "ALL",
+            ),
+            "CpUsage": GeckoEnumStructAccessor(
+                self.struct,
+                "CpUsage",
+                27,
+                None,
+                ["STANDARD", "ALWAYS_ON"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OtOption": GeckoEnumStructAccessor(
+                self.struct,
+                "OtOption",
+                57,
+                None,
+                ["Disabled", "AlwaysEnabled", "WithSPOver95F"],
+                None,
+                None,
+                "ALL",
+            ),
+            "PurgeSpeed": GeckoEnumStructAccessor(
+                self.struct, "PurgeSpeed", 81, 2, ["Lo", "Hi"], None, 2, "ALL"
+            ),
+            "AuxAsBubbleGen": GeckoBoolStructAccessor(
+                self.struct, "AuxAsBubbleGen", 119, 1, "ALL"
+            ),
+            "OTTriggerG": GeckoByteStructAccessor(self.struct, "OTTriggerG", 58, "ALL"),
+            "CpOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOnTimeDuringOT", 59, "ALL"
+            ),
+            "CpOffTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "CpOffTimeDuringOT", 60, "ALL"
+            ),
+            "FiltOnTimeDuringOT": GeckoByteStructAccessor(
+                self.struct, "FiltOnTimeDuringOT", 61, "ALL"
+            ),
+            "FiltSuspendTime": GeckoByteStructAccessor(
+                self.struct, "FiltSuspendTime", 62, "ALL"
+            ),
+            "DrainMode": GeckoEnumStructAccessor(
+                self.struct,
+                "DrainMode",
+                78,
+                None,
+                ["NA", "P1", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Usage": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Usage",
+                28,
+                None,
+                ["Filter", "Always"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3Pump": GeckoEnumStructAccessor(
+                self.struct, "O3Pump", 29, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "O3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "O3Type",
+                30,
+                None,
+                ["Standard", "Toggle"],
+                None,
+                None,
+                "ALL",
+            ),
+            "O3SuspendTime": GeckoByteStructAccessor(
+                self.struct, "O3SuspendTime", 63, "ALL"
+            ),
+            "SetpointG": GeckoTempStructAccessor(self.struct, "SetpointG", 1, "ALL"),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 33, None, ["F", "C"], None, None, "ALL"
+            ),
+            "HeaterPump": GeckoEnumStructAccessor(
+                self.struct, "HeaterPump", 31, None, ["CP", "P1"], None, None, "ALL"
+            ),
+            "ProbeLocation": GeckoEnumStructAccessor(
+                self.struct,
+                "ProbeLocation",
+                81,
+                3,
+                ["IntoPiping", "IntoTub"],
+                None,
+                2,
+                "ALL",
+            ),
+            "CooldownTime": GeckoByteStructAccessor(
+                self.struct, "CooldownTime", 35, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 66, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 68, "ALL"
+            ),
+            "EconType": GeckoEnumStructAccessor(
+                self.struct,
+                "EconType",
+                70,
+                None,
+                ["Standard", "Night"],
+                None,
+                None,
+                "ALL",
+            ),
+            "NoHeatPeriod": GeckoByteStructAccessor(
+                self.struct, "NoHeatPeriod", 77, "ALL"
+            ),
+            "CoolZoneMode": GeckoEnumStructAccessor(
+                self.struct,
+                "CoolZoneMode",
+                115,
+                None,
+                [
+                    "CHILL",
+                    "HEAT_W_BOOST",
+                    "HEAT_SAVER",
+                    "AUTO_W_BOOST",
+                    "AUTO_SAVER",
+                    "INTERNAL_HEAT",
+                    "BOTH_HEAT",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "GenericHeatPumpID": GeckoByteStructAccessor(
+                self.struct, "GenericHeatPumpID", 162, "ALL"
+            ),
+            "MaxNumberOfPhases": GeckoByteStructAccessor(
+                self.struct, "MaxNumberOfPhases", 114, "ALL"
+            ),
+            "UL_CE": GeckoEnumStructAccessor(
+                self.struct, "UL_CE", 51, None, ["UL", "CE"], None, None, "ALL"
+            ),
+            "NbPhases": GeckoByteStructAccessor(self.struct, "NbPhases", 52, "ALL"),
+            "InputCurrent": GeckoByteStructAccessor(
+                self.struct, "InputCurrent", 53, "ALL"
+            ),
+            "MinimumInputCurrent": GeckoByteStructAccessor(
+                self.struct, "MinimumInputCurrent", 122, "ALL"
+            ),
+            "InputMenu": GeckoEnumStructAccessor(
+                self.struct,
+                "InputMenu",
+                74,
+                None,
+                ["Standard", "DualPack"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out1Fuse",
+                83,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out2Fuse",
+                84,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out3Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out3Fuse",
+                85,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out4Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out4Fuse",
+                86,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out5Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out5Fuse",
+                87,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out6Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out6Fuse",
+                88,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out7Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out7Fuse",
+                89,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out8Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out8Fuse",
+                90,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out9Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out9Fuse",
+                91,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out10Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out10Fuse",
+                92,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out11Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out11Fuse",
+                93,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Out12Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Out12Fuse",
+                94,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct1Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct1Fuse",
+                95,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "Direct2Fuse": GeckoEnumStructAccessor(
+                self.struct,
+                "Direct2Fuse",
+                96,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "OutHtrFuse": GeckoEnumStructAccessor(
+                self.struct,
+                "OutHtrFuse",
+                97,
+                None,
+                ["F1", "F2", "F3", "F21", "F22", "F23", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F1Current": GeckoByteStructAccessor(self.struct, "F1Current", 98, "ALL"),
+            "F2Current": GeckoByteStructAccessor(self.struct, "F2Current", 99, "ALL"),
+            "F3Current": GeckoByteStructAccessor(self.struct, "F3Current", 100, "ALL"),
+            "F21Current": GeckoByteStructAccessor(
+                self.struct, "F21Current", 101, "ALL"
+            ),
+            "F22Current": GeckoByteStructAccessor(
+                self.struct, "F22Current", 102, "ALL"
+            ),
+            "F23Current": GeckoByteStructAccessor(
+                self.struct, "F23Current", 103, "ALL"
+            ),
+            "F1Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F1Line",
+                104,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F2Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F2Line",
+                105,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F3Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F3Line",
+                106,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F21Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F21Line",
+                107,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F22Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F22Line",
+                108,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "F23Line": GeckoEnumStructAccessor(
+                self.struct,
+                "F23Line",
+                109,
+                None,
+                ["", "", "", "", "", "", "Line1", "Line2", "Line3"],
+                None,
+                None,
+                "ALL",
+            ),
+            "FiltFreq": GeckoByteStructAccessor(self.struct, "FiltFreq", 3, "ALL"),
+            "FiltStart": GeckoTimeStructAccessor(self.struct, "FiltStart", 4, "ALL"),
+            "FiltDur": GeckoTimeStructAccessor(self.struct, "FiltDur", 6, "ALL"),
+            "FiltDur2": GeckoTimeStructAccessor(self.struct, "FiltDur2", 116, "ALL"),
+            "EconStart": GeckoTimeStructAccessor(self.struct, "EconStart", 8, "ALL"),
+            "EconDur": GeckoTimeStructAccessor(self.struct, "EconDur", 10, "ALL"),
+            "EconProgAvailable": GeckoEnumStructAccessor(
+                self.struct,
+                "EconProgAvailable",
+                71,
+                None,
+                ["NA", "STANDARD", "OUTSIDE_FILTER"],
+                None,
+                None,
+                "ALL",
+            ),
+            "UDProgEcon": GeckoBoolStructAccessor(
+                self.struct, "UDProgEcon", 82, 0, "ALL"
+            ),
+            "EconControlableManually": GeckoBoolStructAccessor(
+                self.struct, "EconControlableManually", 72, 2, "ALL"
+            ),
+            "SoakOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "SoakOnCustomKey", 72, 0, "ALL"
+            ),
+            "OffOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "OffOnCustomKey", 72, 1, "ALL"
+            ),
+            "CleanupOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "CleanupOnCustomKey", 72, 3, "ALL"
+            ),
+            "AuxOnCustomKey": GeckoBoolStructAccessor(
+                self.struct, "AuxOnCustomKey", 72, 4, "ALL"
+            ),
+            "QuickOnOffCustomKey": GeckoBoolStructAccessor(
+                self.struct, "QuickOnOffCustomKey", 72, 5, "ALL"
+            ),
+            "MultiKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "MultiKeyOption",
+                76,
+                None,
+                ["NoBlowerOnI2C", "BlowerOnI2C"],
+                None,
+                None,
+                "ALL",
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct,
+                "MasterSlave",
+                73,
+                None,
+                ["", "Master", "Slave"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SlaveConfig": GeckoByteStructAccessor(
+                self.struct, "SlaveConfig", 75, "ALL"
+            ),
+            "ProgOutAccessory": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutAccessory",
+                160,
+                None,
+                [
+                    "NA",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "ONZEN",
+                    "",
+                    "",
+                    "",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ProgOutStart": GeckoTimeStructAccessor(
+                self.struct, "ProgOutStart", 128, "ALL"
+            ),
+            "ProgOutDur": GeckoTimeStructAccessor(
+                self.struct, "ProgOutDur", 130, "ALL"
+            ),
+            "ProgOutFreq": GeckoByteStructAccessor(
+                self.struct, "ProgOutFreq", 132, "ALL"
+            ),
+            "SilentMode": GeckoEnumStructAccessor(
+                self.struct,
+                "SilentMode",
+                157,
+                None,
+                ["NA", "OFF", "", "SLEEP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SilentDuration": GeckoTimeStructAccessor(
+                self.struct, "SilentDuration", 158, "ALL"
+            ),
+            "SuspendSilentToRegulate": GeckoEnumStructAccessor(
+                self.struct,
+                "SuspendSilentToRegulate",
+                119,
+                3,
+                ["NOT_ALLOWED", "ALLOWED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "TimeFormat": GeckoEnumStructAccessor(
+                self.struct,
+                "TimeFormat",
+                34,
+                None,
+                ["NA", "AmPm", "24h"],
+                None,
+                None,
+                "ALL",
+            ),
+            "AmbiantOHTrigADC": GeckoWordStructAccessor(
+                self.struct, "AmbiantOHTrigADC", 64, "ALL"
+            ),
+            "Pump1UserAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "Pump1UserAccess",
+                81,
+                1,
+                ["BothSpeeds", "HighSpeedOnly"],
+                None,
+                2,
+                "ALL",
+            ),
+            "SelfCleanMsg": GeckoBoolStructAccessor(
+                self.struct, "SelfCleanMsg", 81, 4, "ALL"
+            ),
+            "BlowerKeyOption": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerKeyOption",
+                81,
+                5,
+                ["FreePumpKey", "LastPumpKey"],
+                None,
+                2,
+                "ALL",
+            ),
+            "HeaterSoftStart": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStart", 81, 6, "ALL"
+            ),
+            "HeaterSoftStop": GeckoBoolStructAccessor(
+                self.struct, "HeaterSoftStop", 81, 7, "ALL"
+            ),
+            "KeypadTherapySupport": GeckoBoolStructAccessor(
+                self.struct, "KeypadTherapySupport", 110, 0, "ALL"
+            ),
+            "CustomKeyEnabled": GeckoBoolStructAccessor(
+                self.struct, "CustomKeyEnabled", 110, 1, "ALL"
+            ),
+            "ConfigChange": GeckoEnumStructAccessor(
+                self.struct,
+                "ConfigChange",
+                110,
+                2,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "BreakerChange": GeckoEnumStructAccessor(
+                self.struct,
+                "BreakerChange",
+                110,
+                3,
+                ["NO_RESTRICTION", "PASSWORD_PROTECTED"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadBacklightColor": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightColor",
+                110,
+                4,
+                ["OFF", "RED", "GREEN", "YELLOW", "BLUE", "MAGENTA", "CYAN", "WHITE"],
+                None,
+                8,
+                "ALL",
+            ),
+            "KeypadBacklightEdit": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadBacklightEdit",
+                110,
+                7,
+                ["Disable", "Enable"],
+                None,
+                2,
+                "ALL",
+            ),
+            "ModeKeyAsInvertDisplayKey": GeckoBoolStructAccessor(
+                self.struct, "ModeKeyAsInvertDisplayKey", 112, 1, "ALL"
+            ),
+            "InfoMsgConfig": GeckoEnumStructAccessor(
+                self.struct,
+                "InfoMsgConfig",
+                112,
+                2,
+                ["HIDE_DETAILED_MSG", "SHOW_ALL_MSG", "", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "LowerSetpointMenu": GeckoBoolStructAccessor(
+                self.struct, "LowerSetpointMenu", 112, 4, "ALL"
+            ),
+            "SinglePumpKey": GeckoEnumStructAccessor(
+                self.struct,
+                "SinglePumpKey",
+                112,
+                6,
+                ["NA", "ForSpeeds", "ForZones", ""],
+                None,
+                4,
+                "ALL",
+            ),
+            "KeypadOptions4": GeckoByteStructAccessor(
+                self.struct, "KeypadOptions4", 113, "ALL"
+            ),
+            "DealerLockSupport": GeckoBoolStructAccessor(
+                self.struct, "DealerLockSupport", 119, 0, "ALL"
+            ),
+            "LockEnabled": GeckoByteStructAccessor(
+                self.struct, "LockEnabled", 121, "ALL"
+            ),
+            "ExerciseType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseType",
+                133,
+                None,
+                ["NO_EXERCISE", "SWIM_EXERCISE"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExerciseControl": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseControl",
+                134,
+                None,
+                ["USE_STANDARD_PUMPS"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ExercisePumpsUsed": GeckoEnumStructAccessor(
+                self.struct,
+                "ExercisePumpsUsed",
+                135,
+                0,
+                [
+                    "NO_PUMP",
+                    "ALL_PUMPS",
+                    "P2_TO_P5",
+                    "P3_TO_P5",
+                    "P4_AND_P5",
+                    "P5_ONLY",
+                    "",
+                    "",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "ExerciseDedicatedPumps": GeckoBoolStructAccessor(
+                self.struct, "ExerciseDedicatedPumps", 135, 7, "ALL"
+            ),
+            "ExerciseNumberOfIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseNumberOfIntensity", 136, "ALL"
+            ),
+            "ExercisePumpCombination1": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination1", 137, "ALL"
+            ),
+            "ExercisePumpCombination2": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination2", 139, "ALL"
+            ),
+            "ExercisePumpCombination3": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination3", 141, "ALL"
+            ),
+            "ExercisePumpCombination4": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination4", 143, "ALL"
+            ),
+            "ExercisePumpCombination5": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination5", 145, "ALL"
+            ),
+            "ExercisePumpCombination6": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination6", 147, "ALL"
+            ),
+            "ExercisePumpCombination7": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination7", 149, "ALL"
+            ),
+            "ExercisePumpCombination8": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination8", 151, "ALL"
+            ),
+            "ExercisePumpCombination9": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination9", 153, "ALL"
+            ),
+            "ExercisePumpCombination10": GeckoWordStructAccessor(
+                self.struct, "ExercisePumpCombination10", 155, "ALL"
+            ),
+            "Zone1Led": GeckoEnumStructAccessor(
+                self.struct, "Zone1Led", 123, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone1Type": GeckoEnumStructAccessor(
+                self.struct, "Zone1Type", 123, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone2Led": GeckoEnumStructAccessor(
+                self.struct, "Zone2Led", 124, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone2Type": GeckoEnumStructAccessor(
+                self.struct, "Zone2Type", 124, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone3Led": GeckoEnumStructAccessor(
+                self.struct, "Zone3Led", 125, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone3Type": GeckoEnumStructAccessor(
+                self.struct, "Zone3Type", 125, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "Zone4Led": GeckoEnumStructAccessor(
+                self.struct, "Zone4Led", 126, 0, ["RGB", "WHITE"], None, 2, None
+            ),
+            "Zone4Type": GeckoEnumStructAccessor(
+                self.struct, "Zone4Type", 126, 1, ["NORMAL", "STATUS"], None, 2, None
+            ),
+            "NumberOfZones": GeckoEnumStructAccessor(
+                self.struct,
+                "NumberOfZones",
+                127,
+                0,
+                ["", "1", "2", "3", "4"],
+                None,
+                8,
+                None,
+            ),
+            "StatusLightNormalColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightNormalColor",
+                127,
+                3,
+                ["BLUE", "WHITE", "GREEN", "PURPLE", "YELLOW", "CYAN", "ORANGE", "OFF"],
+                None,
+                8,
+                "ALL",
+            ),
+            "MappingEnable": GeckoBoolStructAccessor(
+                self.struct, "MappingEnable", 127, 7, None
+            ),
+            "MapZone1ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut1", 123, 4, None
+            ),
+            "MapZone1ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut2", 123, 5, None
+            ),
+            "MapZone1ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut3", 123, 6, None
+            ),
+            "MapZone1ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone1ToOut4", 123, 7, None
+            ),
+            "MapZone2ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut1", 124, 4, None
+            ),
+            "MapZone2ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut2", 124, 5, None
+            ),
+            "MapZone2ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut3", 124, 6, None
+            ),
+            "MapZone2ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone2ToOut4", 124, 7, None
+            ),
+            "MapZone3ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut1", 125, 4, None
+            ),
+            "MapZone3ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut2", 125, 5, None
+            ),
+            "MapZone3ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut3", 125, 6, None
+            ),
+            "MapZone3ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone3ToOut4", 125, 7, None
+            ),
+            "MapZone4ToOut1": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut1", 126, 4, None
+            ),
+            "MapZone4ToOut2": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut2", 126, 5, None
+            ),
+            "MapZone4ToOut3": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut3", 126, 6, None
+            ),
+            "MapZone4ToOut4": GeckoBoolStructAccessor(
+                self.struct, "MapZone4ToOut4", 126, 7, None
+            ),
+            "StatusLightRemindersColor": GeckoEnumStructAccessor(
+                self.struct,
+                "StatusLightRemindersColor",
+                164,
+                4,
+                [
+                    "SAME_AS_NORMAL",
+                    "WHITE",
+                    "GREEN",
+                    "PURPLE",
+                    "YELLOW",
+                    "CYAN",
+                    "ORANGE",
+                    "OFF",
+                ],
+                None,
+                8,
+                "ALL",
+            ),
+            "RemindersNotBlinkingLED": GeckoBoolStructAccessor(
+                self.struct, "RemindersNotBlinkingLED", 164, 7, None
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, QXPICX, None, None, QBMJVH
-            ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, None, QXPICX, None, None, QBMJVH
-            ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, QXPICX, None, None, QBMJVH
-            ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, QXPICX, None, None, QBMJVH
-            ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, QGLRAH, None, None, QBMJVH
-            ),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoByteStructAccessor(self.struct, HEOCTH, EOCTHB, QBMJVH),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, QBMJVH),
-            THBSKS: GeckoByteStructAccessor(self.struct, THBSKS, HBSKSO, QBMJVH),
-            BSKSOK: GeckoByteStructAccessor(self.struct, BSKSOK, SKSOKP, QBMJVH),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, RSJMCB, None, None, QBMJVH
-            ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, None, EXLSXU, None, None, QBMJVH
-            ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, LSXUJU, None, QXPICX, None, None, QBMJVH
-            ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XUJUTY, None, QXPICX, None, None, QBMJVH
-            ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, JUTYEK, None, QXPICX, None, None, QBMJVH
-            ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, TYEKCW, None, QXPICX, None, None, QBMJVH
-            ),
-            YEKCWA: GeckoEnumStructAccessor(
-                self.struct, YEKCWA, EKCWAO, None, QXPICX, None, None, QBMJVH
-            ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, QXPICX, None, None, QBMJVH
-            ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, QXPICX, None, None, QBMJVH
-            ),
-            ONPYYL: GeckoEnumStructAccessor(
-                self.struct, ONPYYL, NPYYLI, None, PYYLIU, None, None, QBMJVH
-            ),
-            YYLIUX: GeckoEnumStructAccessor(
-                self.struct, YYLIUX, YLIUXF, None, PYYLIU, None, None, QBMJVH
-            ),
-            LIUXFE: GeckoByteStructAccessor(self.struct, LIUXFE, IUXFEF, QBMJVH),
-            UXFEFJ: GeckoByteStructAccessor(self.struct, UXFEFJ, XFEFJT, QBMJVH),
-            FEFJTA: GeckoByteStructAccessor(self.struct, FEFJTA, EFJTAC, QBMJVH),
-            FJTACC: GeckoByteStructAccessor(self.struct, FJTACC, JTACCP, QBMJVH),
-            TACCPQ: GeckoByteStructAccessor(self.struct, TACCPQ, ACCPQI, QBMJVH),
-            CCPQIP: GeckoByteStructAccessor(self.struct, CCPQIP, CPQIPO, QBMJVH),
-            PQIPOU: GeckoByteStructAccessor(self.struct, PQIPOU, QIPOUY, QBMJVH),
-            IPOUYN: GeckoByteStructAccessor(self.struct, IPOUYN, POUYNQ, QBMJVH),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, QBMJVH),
-            YNQJYM: GeckoBoolStructAccessor(
-                self.struct, YNQJYM, NQJYMO, QJYMOU, QBMJVH
-            ),
-            JYMOUN: GeckoBoolStructAccessor(
-                self.struct, JYMOUN, NQJYMO, YMOUNB, QBMJVH
-            ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, NBLKXS, None, None, None
-            ),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, QBMJVH),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, QBMJVH),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, QBMJVH),
-            NZMJIG: GeckoEnumStructAccessor(
-                self.struct, NZMJIG, ZMJIGY, GYOUSP, IGYOUS, None, QJYMOU, QBMJVH
-            ),
-            YOUSPB: GeckoByteStructAccessor(self.struct, YOUSPB, OUSPBW, QBMJVH),
-            USPBWJ: GeckoByteStructAccessor(self.struct, USPBWJ, SPBWJY, QBMJVH),
-            PBWJYK: GeckoEnumStructAccessor(
-                self.struct, PBWJYK, BWJYKL, None, LGQPLS, None, None, QBMJVH
-            ),
-            GQPLSP: GeckoEnumStructAccessor(
-                self.struct, GQPLSP, QPLSPF, None, SPFTSI, None, None, QBMJVH
-            ),
-            PFTSIF: GeckoEnumStructAccessor(
-                self.struct, PFTSIF, FTSIFJ, None, FJBIAM, None, None, QBMJVH
-            ),
-            JBIAMJ: GeckoEnumStructAccessor(
-                self.struct, JBIAMJ, ZMJIGY, QJYMOU, AMJMAO, None, QJYMOU, QBMJVH
-            ),
-            MJMAOA: GeckoBoolStructAccessor(
-                self.struct, MJMAOA, NQJYMO, JMAOAW, QBMJVH
-            ),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, QBMJVH),
-            OAWBSI: GeckoByteStructAccessor(self.struct, OAWBSI, AWBSIR, QBMJVH),
-            WBSIRY: GeckoByteStructAccessor(self.struct, WBSIRY, BSIRYX, QBMJVH),
-            SIRYXB: GeckoByteStructAccessor(self.struct, SIRYXB, IRYXBQ, QBMJVH),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, QBMJVH),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FYLJUI, None, None, QBMJVH
-            ),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, LJUIKF, None, IKFWRK, None, None, QBMJVH
-            ),
-            KFWRKI: GeckoEnumStructAccessor(
-                self.struct, KFWRKI, FWRKIN, None, WRKINE, None, None, QBMJVH
-            ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, EJNIBX, None, None, QBMJVH
-            ),
-            JNIBXY: GeckoByteStructAccessor(self.struct, JNIBXY, NIBXYB, QBMJVH),
-            IBXYBQ: GeckoTempStructAccessor(self.struct, IBXYBQ, BXYBQS, QBMJVH),
-            XYBQSN: GeckoEnumStructAccessor(
-                self.struct, XYBQSN, YBQSNQ, None, SNQLNM, None, None, QBMJVH
-            ),
-            NQLNMH: GeckoEnumStructAccessor(
-                self.struct, NQLNMH, QLNMHX, None, WRKINE, None, None, QBMJVH
-            ),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, ZMJIGY, XEKVKZ, HXEKVK, None, QJYMOU, QBMJVH
-            ),
-            EKVKZI: GeckoByteStructAccessor(self.struct, EKVKZI, KVKZIL, QBMJVH),
-            VKZILX: GeckoTempStructAccessor(self.struct, VKZILX, KZILXW, QBMJVH),
-            ZILXWA: GeckoTempStructAccessor(self.struct, ZILXWA, ILXWAJ, QBMJVH),
-            LXWAJV: GeckoEnumStructAccessor(
-                self.struct, LXWAJV, XWAJVD, None, AJVDQL, None, None, QBMJVH
-            ),
-            JVDQLA: GeckoByteStructAccessor(self.struct, JVDQLA, VDQLAI, QBMJVH),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, None, BXTIAC, None, None, QBMJVH
-            ),
-            XTIACQ: GeckoByteStructAccessor(self.struct, XTIACQ, TIACQF, QBMJVH),
-            IACQFF: GeckoByteStructAccessor(self.struct, IACQFF, ACQFFT, QBMJVH),
-            CQFFTT: GeckoEnumStructAccessor(
-                self.struct, CQFFTT, QFFTTI, None, TTIDUB, None, None, QBMJVH
-            ),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, QBMJVH),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, QBMJVH),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, QBMJVH),
-            SUHBVW: GeckoEnumStructAccessor(
-                self.struct, SUHBVW, UHBVWV, None, BVWVUB, None, None, QBMJVH
-            ),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, EXLSXU, None, None, QBMJVH
-            ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, EXLSXU, None, None, QBMJVH
-            ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, None, EXLSXU, None, None, QBMJVH
-            ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, None, EXLSXU, None, None, QBMJVH
-            ),
-            SBDJQR: GeckoEnumStructAccessor(
-                self.struct, SBDJQR, BDJQRJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            DJQRJJ: GeckoEnumStructAccessor(
-                self.struct, DJQRJJ, JQRJJJ, None, EXLSXU, None, None, QBMJVH
-            ),
-            QRJJJV: GeckoEnumStructAccessor(
-                self.struct, QRJJJV, RJJJVY, None, EXLSXU, None, None, QBMJVH
-            ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, EXLSXU, None, None, QBMJVH
-            ),
-            JVYFCR: GeckoEnumStructAccessor(
-                self.struct, JVYFCR, VYFCRT, None, EXLSXU, None, None, QBMJVH
-            ),
-            YFCRTF: GeckoEnumStructAccessor(
-                self.struct, YFCRTF, FCRTFM, None, EXLSXU, None, None, QBMJVH
-            ),
-            CRTFMN: GeckoEnumStructAccessor(
-                self.struct, CRTFMN, RTFMNH, None, EXLSXU, None, None, QBMJVH
-            ),
-            TFMNHT: GeckoEnumStructAccessor(
-                self.struct, TFMNHT, FMNHTB, None, EXLSXU, None, None, QBMJVH
-            ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, NHTBJE, None, EXLSXU, None, None, QBMJVH
-            ),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, EXLSXU, None, None, QBMJVH
-            ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, EXLSXU, None, None, QBMJVH
-            ),
-            EUTOPH: GeckoByteStructAccessor(self.struct, EUTOPH, UTOPHU, QBMJVH),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, QBMJVH),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, QBMJVH),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, QBMJVH),
-            TYIYWS: GeckoByteStructAccessor(self.struct, TYIYWS, YIYWSK, QBMJVH),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, QBMJVH),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, SKWIVD, None, KWIVDN, None, None, QBMJVH
-            ),
-            WIVDNQ: GeckoEnumStructAccessor(
-                self.struct, WIVDNQ, IVDNQG, None, KWIVDN, None, None, QBMJVH
-            ),
-            VDNQGV: GeckoEnumStructAccessor(
-                self.struct, VDNQGV, DNQGVU, None, KWIVDN, None, None, QBMJVH
-            ),
-            NQGVUN: GeckoEnumStructAccessor(
-                self.struct, NQGVUN, QGVUNX, None, KWIVDN, None, None, QBMJVH
-            ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, KWIVDN, None, None, QBMJVH
-            ),
-            UNXNKM: GeckoEnumStructAccessor(
-                self.struct, UNXNKM, NXNKML, None, KWIVDN, None, None, QBMJVH
-            ),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, QBMJVH),
-            KMLOIJ: GeckoTimeStructAccessor(self.struct, KMLOIJ, MLOIJU, QBMJVH),
-            LOIJUG: GeckoTimeStructAccessor(self.struct, LOIJUG, OIJUGS, QBMJVH),
-            IJUGSE: GeckoTimeStructAccessor(self.struct, IJUGSE, JUGSEL, QBMJVH),
-            UGSELH: GeckoTimeStructAccessor(self.struct, UGSELH, GSELHB, QBMJVH),
-            SELHBQ: GeckoTimeStructAccessor(self.struct, SELHBQ, ELHBQN, QBMJVH),
-            LHBQNR: GeckoEnumStructAccessor(
-                self.struct, LHBQNR, HBQNRX, None, QNRXCH, None, None, QBMJVH
-            ),
-            NRXCHW: GeckoBoolStructAccessor(
-                self.struct, NRXCHW, RXCHWD, GYOUSP, QBMJVH
-            ),
-            XCHWDA: GeckoBoolStructAccessor(
-                self.struct, XCHWDA, CHWDAF, QJYMOU, QBMJVH
-            ),
-            HWDAFI: GeckoBoolStructAccessor(
-                self.struct, HWDAFI, CHWDAF, GYOUSP, QBMJVH
-            ),
-            WDAFIK: GeckoBoolStructAccessor(
-                self.struct, WDAFIK, CHWDAF, JMAOAW, QBMJVH
-            ),
-            DAFIKJ: GeckoBoolStructAccessor(
-                self.struct, DAFIKJ, CHWDAF, XEKVKZ, QBMJVH
-            ),
-            AFIKJP: GeckoBoolStructAccessor(
-                self.struct, AFIKJP, CHWDAF, YMOUNB, QBMJVH
-            ),
-            FIKJPU: GeckoBoolStructAccessor(
-                self.struct, FIKJPU, CHWDAF, IKJPUN, QBMJVH
-            ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, NRJZTA, None, None, QBMJVH
-            ),
-            RJZTAT: GeckoEnumStructAccessor(
-                self.struct, RJZTAT, JZTATD, None, ATDZXN, None, None, QBMJVH
-            ),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, QBMJVH),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, XNQTMF, None, NQTMFZ, None, None, QBMJVH
-            ),
-            QTMFZD: GeckoTimeStructAccessor(self.struct, QTMFZD, TMFZDG, QBMJVH),
-            MFZDGK: GeckoTimeStructAccessor(self.struct, MFZDGK, FZDGKE, QBMJVH),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, QBMJVH),
-            GKEAKS: GeckoEnumStructAccessor(
-                self.struct, GKEAKS, KEAKST, None, KSTSEM, None, None, QBMJVH
-            ),
-            STSEMC: GeckoTimeStructAccessor(self.struct, STSEMC, TSEMCG, QBMJVH),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, NQJYMO, XEKVKZ, CGETIX, None, QJYMOU, QBMJVH
-            ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, XQVXOI, None, None, QBMJVH
-            ),
-            QVXOIH: GeckoWordStructAccessor(self.struct, QVXOIH, VXOIHB, QBMJVH),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, ZMJIGY, JMAOAW, HBXIBH, None, QJYMOU, QBMJVH
-            ),
-            BXIBHZ: GeckoBoolStructAccessor(
-                self.struct, BXIBHZ, ZMJIGY, YMOUNB, QBMJVH
-            ),
-            XIBHZV: GeckoEnumStructAccessor(
-                self.struct, XIBHZV, ZMJIGY, IKJPUN, HZVOAC, None, QJYMOU, QBMJVH
-            ),
-            ZVOACM: GeckoBoolStructAccessor(
-                self.struct, ZVOACM, ZMJIGY, VOACMC, QBMJVH
-            ),
-            OACMCV: GeckoBoolStructAccessor(
-                self.struct, OACMCV, ZMJIGY, ACMCVD, QBMJVH
-            ),
-            CMCVDS: GeckoBoolStructAccessor(
-                self.struct, CMCVDS, MCVDSS, GYOUSP, QBMJVH
-            ),
-            CVDSSR: GeckoBoolStructAccessor(
-                self.struct, CVDSSR, MCVDSS, JMAOAW, QBMJVH
-            ),
-            VDSSRU: GeckoEnumStructAccessor(
-                self.struct, VDSSRU, MCVDSS, QJYMOU, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, MCVDSS, XEKVKZ, SRURAZ, None, QJYMOU, QBMJVH
-            ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, MCVDSS, YMOUNB, DKHTZB, None, KHTZBB, QBMJVH
-            ),
-            HTZBBE: GeckoEnumStructAccessor(
-                self.struct, HTZBBE, MCVDSS, ACMCVD, BBEKBD, None, QJYMOU, QBMJVH
-            ),
-            AIVEMV: GeckoBoolStructAccessor(
-                self.struct, AIVEMV, IVEMVC, JMAOAW, QBMJVH
-            ),
-            VEMVCY: GeckoEnumStructAccessor(
-                self.struct, VEMVCY, IVEMVC, QJYMOU, VCYWON, None, YMOUNB, QBMJVH
-            ),
-            CYWONF: GeckoBoolStructAccessor(
-                self.struct, CYWONF, IVEMVC, YMOUNB, QBMJVH
-            ),
-            YWONFZ: GeckoEnumStructAccessor(
-                self.struct, YWONFZ, IVEMVC, VOACMC, NFZCZO, None, YMOUNB, QBMJVH
-            ),
-            FZCZOL: GeckoByteStructAccessor(self.struct, FZCZOL, ZCZOLS, QBMJVH),
-            CZOLSI: GeckoBoolStructAccessor(
-                self.struct, CZOLSI, NQJYMO, GYOUSP, QBMJVH
-            ),
-            ZOLSIP: GeckoByteStructAccessor(self.struct, ZOLSIP, OLSIPM, QBMJVH),
-            LSIPMD: GeckoEnumStructAccessor(
-                self.struct, LSIPMD, SIPMDM, None, MDMPSC, None, None, QBMJVH
-            ),
-            DMPSCT: GeckoEnumStructAccessor(
-                self.struct, DMPSCT, MPSCTT, None, SCTTGC, None, None, QBMJVH
-            ),
-            CTTGCR: GeckoEnumStructAccessor(
-                self.struct, CTTGCR, TTGCRH, GYOUSP, UAXNCU, None, KHTZBB, QBMJVH
-            ),
-            AXNCUG: GeckoBoolStructAccessor(
-                self.struct, AXNCUG, TTGCRH, ACMCVD, QBMJVH
-            ),
-            XNCUGU: GeckoByteStructAccessor(self.struct, XNCUGU, NCUGUC, QBMJVH),
-            CUGUCY: GeckoWordStructAccessor(self.struct, CUGUCY, UGUCYR, QBMJVH),
-            GUCYRA: GeckoWordStructAccessor(self.struct, GUCYRA, UCYRAP, QBMJVH),
-            CYRAPU: GeckoWordStructAccessor(self.struct, CYRAPU, YRAPUM, QBMJVH),
-            RAPUME: GeckoWordStructAccessor(self.struct, RAPUME, APUMEA, QBMJVH),
-            PUMEAO: GeckoWordStructAccessor(self.struct, PUMEAO, UMEAOE, QBMJVH),
-            MEAOES: GeckoWordStructAccessor(self.struct, MEAOES, EAOESV, QBMJVH),
-            AOESVZ: GeckoWordStructAccessor(self.struct, AOESVZ, OESVZS, QBMJVH),
-            ESVZSS: GeckoWordStructAccessor(self.struct, ESVZSS, SVZSSB, QBMJVH),
-            VZSSBV: GeckoWordStructAccessor(self.struct, VZSSBV, ZSSBVN, QBMJVH),
-            SSBVNA: GeckoWordStructAccessor(self.struct, SSBVNA, SBVNAX, QBMJVH),
-            BVNAXA: GeckoEnumStructAccessor(
-                self.struct, BVNAXA, VNAXAD, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            XADXLU: GeckoEnumStructAccessor(
-                self.struct, XADXLU, VNAXAD, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            LUBGJF: GeckoEnumStructAccessor(
-                self.struct, LUBGJF, UBGJFJ, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            BGJFJN: GeckoEnumStructAccessor(
-                self.struct, BGJFJN, UBGJFJ, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            GJFJNT: GeckoEnumStructAccessor(
-                self.struct, GJFJNT, JFJNTT, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            FJNTTU: GeckoEnumStructAccessor(
-                self.struct, FJNTTU, JFJNTT, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            JNTTUV: GeckoEnumStructAccessor(
-                self.struct, JNTTUV, NTTUVR, GYOUSP, AXADXL, None, QJYMOU, None
-            ),
-            TTUVRF: GeckoEnumStructAccessor(
-                self.struct, TTUVRF, NTTUVR, JMAOAW, XLUBGJ, None, QJYMOU, None
-            ),
-            TUVRFL: GeckoEnumStructAccessor(
-                self.struct, TUVRFL, UVRFLS, GYOUSP, SIJUZM, None, KHTZBB, None
-            ),
-            IJUZMR: GeckoEnumStructAccessor(
-                self.struct, IJUZMR, UVRFLS, XEKVKZ, ZMRKVF, None, KHTZBB, QBMJVH
-            ),
-            MRKVFC: GeckoBoolStructAccessor(self.struct, MRKVFC, UVRFLS, ACMCVD, None),
-            RKVFCP: GeckoBoolStructAccessor(self.struct, RKVFCP, VNAXAD, YMOUNB, None),
-            KVFCPO: GeckoBoolStructAccessor(self.struct, KVFCPO, VNAXAD, IKJPUN, None),
-            VFCPOU: GeckoBoolStructAccessor(self.struct, VFCPOU, VNAXAD, VOACMC, None),
-            FCPOUB: GeckoBoolStructAccessor(self.struct, FCPOUB, VNAXAD, ACMCVD, None),
-            CPOUBM: GeckoBoolStructAccessor(self.struct, CPOUBM, UBGJFJ, YMOUNB, None),
-            POUBMI: GeckoBoolStructAccessor(self.struct, POUBMI, UBGJFJ, IKJPUN, None),
-            OUBMIK: GeckoBoolStructAccessor(self.struct, OUBMIK, UBGJFJ, VOACMC, None),
-            UBMIKG: GeckoBoolStructAccessor(self.struct, UBMIKG, UBGJFJ, ACMCVD, None),
-            BMIKGN: GeckoBoolStructAccessor(self.struct, BMIKGN, JFJNTT, YMOUNB, None),
-            MIKGNV: GeckoBoolStructAccessor(self.struct, MIKGNV, JFJNTT, IKJPUN, None),
-            IKGNVF: GeckoBoolStructAccessor(self.struct, IKGNVF, JFJNTT, VOACMC, None),
-            KGNVFO: GeckoBoolStructAccessor(self.struct, KGNVFO, JFJNTT, ACMCVD, None),
-            GNVFOU: GeckoBoolStructAccessor(self.struct, GNVFOU, NTTUVR, YMOUNB, None),
-            NVFOUU: GeckoBoolStructAccessor(self.struct, NVFOUU, NTTUVR, IKJPUN, None),
-            VFOUUR: GeckoBoolStructAccessor(self.struct, VFOUUR, NTTUVR, VOACMC, None),
-            FOUURI: GeckoBoolStructAccessor(self.struct, FOUURI, NTTUVR, ACMCVD, None),
-            OUURIE: GeckoEnumStructAccessor(
-                self.struct, OUURIE, UURIEV, YMOUNB, RIEVBV, None, KHTZBB, QBMJVH
-            ),
-            IEVBVH: GeckoBoolStructAccessor(self.struct, IEVBVH, UURIEV, ACMCVD, None),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-58.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-58.py
@@ -12,1071 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [51, 50, 75])
-AJVDQL = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 449
-AMJMAO = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-AOAWBS = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-AZMKQT = 468
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-BDJQRJ = "".join(chr(c) for c in [75, 56, 53])
-BEKBDF = 474
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = 460
-BIAMJM = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BJEUTO = "".join(chr(c) for c in [45, 45, 45])
-BJLOIN = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-BQNRXC = 333
-BQSNQL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-BVWVUB = 301
-BWJYKL = 275
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-BXTIAC = "".join(chr(c) for c in [67, 69])
-BXYBQS = 315
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 53])
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-CMCVDS = 463
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 293
-CRTFMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-CTHBSK = 307
-CVDSSR = 464
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-DDPMXF = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-DFSROG = 476
-DGKEAK = 348
-DJQRJJ = "".join(chr(c) for c in [75, 56])
-DKHTZB = 471
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-DPMXFU = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-DQLAII = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-DSBDJQ = "".join(chr(c) for c in [75, 50, 48, 48])
-DSSRUR = 465
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 49])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 256
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = 311
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-ELWUEU = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 52])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 54])
-EUHNNX = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = 479
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FFTTID = 294
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-FJBIAM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-FMNHTB = 360
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FUBJLO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-FZDGKE = 347
-GDSBDJ = 357
-GETIXQ = 453
-GKEAKS = "".join(chr(c) for c in [67, 70, 71, 48])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 50, 76])
-GVUNXN = 323
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-HBSKSO = 363
-HBVWVU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-HBXIBH = 458
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [76, 73])
-HTBJEU = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-HTZBBE = 472
-HUGTYI = "".join(chr(c) for c in [80, 49, 76])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-IACQFF = 291
-IAMJMA = 283
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-IBXTIA = "".join(chr(c) for c in [85, 76])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [54, 52, 75])
-IDUBSS = 296
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-IIDNIB = "".join(chr(c) for c in [52, 56, 75])
-IJUGSE = 328
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IKJPUN = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-ILXWAJ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-INEJNI = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-INELWU = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 55])
-IYWSKW = "".join(chr(c) for c in [80, 52, 72])
-JBIAMJ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JEUTOP = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [75, 49, 48, 48])
-JJVYFC = "".join(chr(c) for c in [75, 56, 48, 48])
-JLOINE = 374
-JMAOAW = 284
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JQRJJJ = "".join(chr(c) for c in [75, 52])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 89, 84])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 341
-KBDFSR = 475
-KCWAON = 365
-KEAKST = 448
-KFWRKI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-KJPUNR = 332
-KPHUOJ = 304
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 50])
-KVKZIL = "".join(chr(c) for c in [105, 110, 88, 69])
-KWIVDN = "".join(chr(c) for c in [65, 85, 88])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [77, 73, 65])
-LAIIDN = "".join(chr(c) for c in [49, 54, 75])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 331
-LIUXFE = 263
-LJUIKF = 354
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 287
-LOIJUG = 327
-LOINEL = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LXWAJV = "".join(chr(c) for c in [105, 110, 88, 77])
-MAOAWB = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-MCGETI = 452
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-MDDPMX = 479
-MFZDGK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-MHXEKV = 288
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 469
-MLOIJU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-MNHTBJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-MNZMJI = 313
-MOUNBL = 273
-MXFUBJ = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-NELWUE = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-NHTBJE = 361
-NIBXTI = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-NIBXYB = 314
-NKMLOI = "".join(chr(c) for c in [72, 84, 82])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = 322
-NQJYMO = 271
-NQLNMH = 285
-NQTMFZ = 345
-NRJZTA = 340
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 325
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = 462
-OAWBSI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = 478
-OIHBXI = 457
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-OINELW = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [78, 65])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = "".join(chr(c) for c in [80, 49, 72])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = 371
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = 290
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [75, 53])
-QSNQLN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-QTDKHT = 470
-QTMFZD = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 56])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-RJZTAT = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-ROGMDD = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = 358
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-RXCHWD = "".join(chr(c) for c in [70, 97, 110])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [75, 52, 48, 48])
-SELHBQ = 330
-SEMCGE = 451
-SIFJBI = 352
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SNQLNM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = 477
-SRURAZ = 466
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-SSUHBV = 299
-STSEMC = 450
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = 342
-TBJEUT = 376
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-TDZXNQ = 343
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-TIXQVX = 454
-TMFZDG = 346
-TOPHUG = 320
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 51])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = 295
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 51, 72])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-UBJLOI = 373
-UBSSUH = 297
-UBYGDS = "".join(chr(c) for c in [70, 117, 108, 108])
-UEUHNN = 375
-UGSELH = 329
-UGTYIY = "".join(chr(c) for c in [80, 50, 72])
-UHBVWV = 300
-UIKFWR = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNRJZT = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-UNXNKM = 324
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = 467
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDNQGV = 321
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-VUBYGD = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VXOIHB = 456
-VYFCRT = "".join(chr(c) for c in [75, 51, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-WAONPY = 367
-WBSIRY = 350
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-WEEZFE = 58
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = 309
-WSKWIV = "".join(chr(c) for c in [66, 76, 79])
-WUEUHN = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-WVUBYG = 316
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XEKVKZ = 289
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 372
-XIBHZV = 459
-XLSXUJ = 7
-XNKMLO = 326
-XNQTMF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 57])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 455
-XSJWMN = 282
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [75, 54, 48, 48])
-XYBQSN = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-YGDSBD = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-YIYWSK = "".join(chr(c) for c in [80, 51, 76])
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 52, 76])
-YXBQFY = 351
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 473
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-ZILXWA = "".join(chr(c) for c in [68, 74, 83, 52])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = 461
-ZXNQTM = 344
-BYGDSB = [VUBYGD, UBYGDS]
-DNIBXT = [LAIIDN, AIIDNI, IIDNIB, IDNIBX]
-EUTOPH = [BJEUTO, JEUTOP]
-FCRTFM = [
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-JPUNRJ = [
-    OPHUGT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-KINEJN = [HECVYY, RKINEJ, RKINEJ, RKINEJ]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-KMLOIJ = [
-    OPHUGT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NKMLOI,
-]
-LWUEUH = [LOINEL, OINELW, INELWU, NELWUE, ELWUEU]
-MCBFEG = [ASSAKQ, SOOQNR]
-NNXWEE = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    HNNXWE,
-]
-NXWEEZ = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-UHNNXW = []
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDQLAI = [
-    EKVKZI,
-    KVKZIL,
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-]
-WIVDNQ = [
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    SJMCBF,
-    WSKWIV,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    SKWIVD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    KWIVDN,
-]
-XCHWDA = [
-    OPHUGT,
-    PHUGTY,
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    SJMCBF,
-    WSKWIV,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    RXCHWD,
-    HECVYY,
-    HECVYY,
-    SKWIVD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    KWIVDN,
-]
-XTIACQ = [IBXTIA, BXTIAC]
-XWEEZF = [
-    YBQSNQ,
-    XBQFYL,
-    FYLJUI,
-    MAOAWB,
-    SPBWJY,
-    INEJNI,
-    XYBQSN,
-    BQSNQL,
-    LGQPLS,
-    BLKXSJ,
-    IRYXBQ,
-    AWBSIR,
-    IFJBIA,
-    TSIFJB,
-    IBXYBQ,
-    OAWBSI,
-    RYXBQF,
-    SIRYXB,
-    AMJMAO,
-    YLJUIK,
-    BIAMJM,
-    FJBIAM,
-    BQFYLJ,
-    IKFWRK,
-    QFYLJU,
-    JBIAMJ,
-    BSIRYX,
-    AOAWBS,
-    MJMAOA,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1084,304 +19,1141 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return WEEZFE
+        return 58
 
     @property
     def begin(self):
-        return EEZFET
+        return 256
 
     @property
     def end(self):
-        return EZFETD
+        return 479
 
     @property
     def all_device_keys(self):
-        return NNXWEE
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return NXWEEZ
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return XWEEZF
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, JVHFTH, EGZUQE, None),
-            FJBIAM: GeckoBoolStructAccessor(self.struct, FJBIAM, XSJWMN, ICXQIE, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, XSJWMN, AHEOCT, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, QIEFXQ, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, EGZUQE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, CXQIEF, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, JMAOAW, UQEXLS, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, JMAOAW, VHFTHE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, EGZUQE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, WBSIRY, CXQIEF, None),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, WBSIRY, UQEXLS, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, WBSIRY, VHFTHE, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, YXBQFY, QIEFXQ, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, YXBQFY, EGZUQE, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, SIFJBI, EGZUQE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, GYOUSP, ICXQIE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, GYOUSP, AHEOCT, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, LJUIKF, ICXQIE, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, LSPFTS, ICXQIE, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, IAMJMA, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, IAMJMA, AHEOCT, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, IAMJMA, CXQIEF, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, WRKINE, ICXQIE, None),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, WRKINE, AHEOCT, KINEJN, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, WRKINE, EGZUQE, None),
-            NEJNIB: GeckoWordStructAccessor(self.struct, NEJNIB, EJNIBX, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, BXYBQS, AHEOCT, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, YXBQFY, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YXBQFY, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, YXBQFY, CXQIEF, None),
-            SNQLNM: GeckoWordStructAccessor(self.struct, SNQLNM, NQLNMH, None),
-            QLNMHX: GeckoByteStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoEnumStructAccessor(
-                self.struct, HXEKVK, XEKVKZ, None, VDQLAI, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, QLAIID, ICXQIE, DNIBXT, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NIBXTI: GeckoEnumStructAccessor(
-                self.struct, NIBXTI, QLAIID, QIEFXQ, XTIACQ, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoWordStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, BYGDSB, None, QIEFXQ, SAKQXP
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            YGDSBD: GeckoEnumStructAccessor(
-                self.struct, YGDSBD, GDSBDJ, None, FCRTFM, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            CRTFMN: GeckoWordStructAccessor(self.struct, CRTFMN, RTFMNH, None),
-            TFMNHT: GeckoByteStructAccessor(self.struct, TFMNHT, FMNHTB, None),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, None),
-            HTBJEU: GeckoEnumStructAccessor(
-                self.struct, HTBJEU, TBJEUT, None, EUTOPH, None, None, SAKQXP
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, WIVDNQ, None, None, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, WIVDNQ, None, None, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, WIVDNQ, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, WIVDNQ, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, WIVDNQ, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, KMLOIJ, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, SAKQXP),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoEnumStructAccessor(
-                self.struct, QNRXCH, NRXCHW, None, XCHWDA, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, XNKMLO, None, XCHWDA, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            HWDAFI: GeckoEnumStructAccessor(
-                self.struct, HWDAFI, LOIJUG, None, XCHWDA, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, IJUGSE, None, XCHWDA, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, UGSELH, None, XCHWDA, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, SELHBQ, None, XCHWDA, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, LHBQNR, None, XCHWDA, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, KJPUNR, None, JPUNRJ, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, BQNRXC, None, JPUNRJ, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            UNRJZT: GeckoByteStructAccessor(self.struct, UNRJZT, NRJZTA, SAKQXP),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, SAKQXP),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, SAKQXP),
-            ATDZXN: GeckoByteStructAccessor(self.struct, ATDZXN, TDZXNQ, SAKQXP),
-            DZXNQT: GeckoByteStructAccessor(self.struct, DZXNQT, ZXNQTM, SAKQXP),
-            XNQTMF: GeckoByteStructAccessor(self.struct, XNQTMF, NQTMFZ, SAKQXP),
-            QTMFZD: GeckoByteStructAccessor(self.struct, QTMFZD, TMFZDG, SAKQXP),
-            MFZDGK: GeckoByteStructAccessor(self.struct, MFZDGK, FZDGKE, SAKQXP),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, SAKQXP),
-            DDPMXF: GeckoBoolStructAccessor(self.struct, DDPMXF, JVHFTH, UQEXLS, None),
-            DPMXFU: GeckoByteStructAccessor(self.struct, DPMXFU, PMXFUB, SAKQXP),
-            MXFUBJ: GeckoByteStructAccessor(self.struct, MXFUBJ, XFUBJL, SAKQXP),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, SAKQXP),
-            BJLOIN: GeckoEnumStructAccessor(
-                self.struct, BJLOIN, JLOINE, None, LWUEUH, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            WUEUHN: GeckoBoolStructAccessor(
-                self.struct, WUEUHN, UEUHNN, ICXQIE, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            EUHNNX: GeckoBoolStructAccessor(self.struct, EUHNNX, TBJEUT, ICXQIE, None),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-59.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-59.py
@@ -12,1076 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-AFIKJP = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-AHEOCT = 1
-AIIDNI = 290
-AJVDQL = "".join(chr(c) for c in [75, 54, 48, 48])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = 448
-AMJMAO = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-AOAWBS = 284
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-AWBSIR = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-AZMKQT = 467
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-BDJQRJ = "".join(chr(c) for c in [75, 50, 48, 48])
-BEKBDF = 473
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = 459
-BIAMJM = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BJEUTO = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-BJLOIN = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 351
-BQNRXC = 331
-BQSNQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BSIRYX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-BVWVUB = 300
-BWJYKL = 275
-BXIBHZ = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-BXTIAC = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-BXYBQS = 314
-BYGDSB = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [67, 70, 71, 52])
-CHWDAF = "".join(chr(c) for c in [70, 97, 110])
-CMCVDS = 462
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 291
-CRTFMN = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-CTHBSK = 307
-CVDSSR = 463
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-DDPMXF = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-DFSROG = 475
-DGKEAK = 347
-DJQRJJ = "".join(chr(c) for c in [75, 52, 48, 48])
-DKHTZB = 470
-DNIBXT = "".join(chr(c) for c in [52, 56, 75])
-DNQGVU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-DPMXFU = 479
-DQLAII = "".join(chr(c) for c in [105, 110, 89, 84])
-DSBDJQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-DSSRUR = 464
-DUBSSU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-EAKSTS = "".join(chr(c) for c in [67, 70, 71, 48])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-ELWUEU = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-EMCGET = "".join(chr(c) for c in [67, 70, 71, 51])
-EOCTHB = 308
-ETIXQV = "".join(chr(c) for c in [67, 70, 71, 53])
-EUHNNX = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-EUTOPH = "".join(chr(c) for c in [45, 45, 45])
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = 59
-FCRTFM = "".join(chr(c) for c in [75, 51, 48, 48])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = 479
-FFTTID = 293
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-FJBIAM = 377
-FMNHTB = 358
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-FUBJLO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-FWRKIN = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-FZDGKE = 346
-GETIXQ = 452
-GKEAKS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-GQPLSP = 279
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-GTYIYW = "".join(chr(c) for c in [80, 49, 76])
-GVUNXN = 322
-GYOUSP = 353
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-HBXIBH = 457
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-HTBJEU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-HTZBBE = 471
-HUGTYI = "".join(chr(c) for c in [78, 65])
-HUOJRJ = 305
-HXEKVK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-HZVOAC = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-IAMJMA = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-IBHZVO = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-IBXYBQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [51, 50, 75])
-IDUBSS = 295
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-IGYOUS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-IHBXIB = "".join(chr(c) for c in [67, 70, 71, 57])
-IIDNIB = "".join(chr(c) for c in [49, 54, 75])
-IJUGSE = 327
-IKFWRK = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IKJPUN = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-ILXWAJ = "".join(chr(c) for c in [77, 73, 65])
-INEJNI = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-INELWU = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [65, 85, 88])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [67, 70, 71, 54])
-IYWSKW = "".join(chr(c) for c in [80, 51, 72])
-JBIAMJ = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-JEUTOP = 376
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JJJVYF = "".join(chr(c) for c in [75, 53])
-JJVYFC = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-JLOINE = 373
-JMAOAW = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-JMCBFE = 260
-JNIBXY = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-JPUNRJ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-JQRJJJ = "".join(chr(c) for c in [75, 56, 53])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-JUIKFW = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [75, 49, 48, 48])
-JWMNZM = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYKLGQ = 277
-JYMOUN = 272
-JZTATD = 340
-KBDFSR = 474
-KCWAON = 365
-KEAKST = 348
-KFWRKI = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-KINEJN = 309
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-KMLOIJ = 326
-KPHUOJ = 304
-KQTDKH = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [67, 70, 71, 49])
-KVKZIL = 289
-KWIVDN = "".join(chr(c) for c in [66, 76, 79])
-KXSJWM = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-KZILXW = "".join(chr(c) for c in [105, 110, 88, 69])
-LAIIDN = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-LHBQNR = 330
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-LKXSJW = "".join(chr(c) for c in [67, 80, 79, 84])
-LNMHXE = 285
-LOINEL = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSPFTS = 280
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-LXWAJV = "".join(chr(c) for c in [68, 74, 83, 52])
-MAOAWB = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-MCGETI = 451
-MCVDSS = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MDDPMX = 478
-MFZDGK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-MHXEKV = 287
-MJIGYO = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-MJMAOA = 283
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 468
-MLOIJU = "".join(chr(c) for c in [72, 84, 82])
-MNHTBJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-MNZMJI = 313
-MOUNBL = 273
-MXFUBJ = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-NBLKXS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-NELWUE = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-NHTBJE = 360
-NIBXTI = "".join(chr(c) for c in [54, 52, 75])
-NIBXYB = 311
-NKMLOI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NMHXEK = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = 321
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-NQTMFZ = 344
-NRJZTA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = 333
-NXNKML = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NXWEEZ = "".join(chr(c) for c in [76, 73])
-NZMJIG = "".join(chr(c) for c in [78, 79])
-OACMCV = 461
-OAWBSI = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = 477
-OIHBXI = 456
-OIJUGS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-OINELW = 374
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-OUNBLK = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-OUSPBW = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-PFTSIF = 281
-PHUGTY = 320
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-PMXFUB = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = 332
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-QFYLJU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-QGVUNX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLNMHX = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-QPLSPF = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QRJJJV = "".join(chr(c) for c in [75, 56])
-QSNQLN = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QTDKHT = 469
-QTMFZD = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-QVXOIH = "".join(chr(c) for c in [67, 70, 71, 55])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [75, 52])
-RJZTAT = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-RKINEJ = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-ROGMDD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RURAZM = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-RXCHWD = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-RYXBQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = 357
-SELHBQ = 329
-SEMCGE = 450
-SIFJBI = 352
-SIRYXB = 350
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [80, 52, 76])
-SNQLNM = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SPFTSI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-SROGMD = 476
-SRURAZ = 465
-SSRURA = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-SSUHBV = 297
-STSEMC = 449
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = 341
-TBJEUT = 361
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-TDZXNQ = 342
-TFMNHT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [67, 69])
-TIDUBS = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-TIXQVX = 453
-TMFZDG = 345
-TSEMCG = "".join(chr(c) for c in [67, 70, 71, 50])
-TSIFJB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-TTIDUB = 294
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [80, 50, 72])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-UBJLOI = 372
-UBSSUH = 296
-UBYGDS = 316
-UGSELH = 328
-UGTYIY = "".join(chr(c) for c in [80, 49, 72])
-UHBVWV = 299
-UHNNXW = 375
-UIKFWR = 354
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-UNXNKM = 323
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = 466
-USOOQN = 261
-USPBWJ = 355
-UTOPHU = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VDQLAI = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-VDSSRU = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-VUNXNK = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-VWVUBY = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-VXOIHB = 455
-VYFCRT = "".join(chr(c) for c in [75, 56, 48, 48])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(chr(c) for c in [105, 110, 88, 77])
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-WDAFIK = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-WIVDNQ = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WJYKLG = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-WMNZMJ = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-WRKINE = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-WSKWIV = "".join(chr(c) for c in [80, 52, 72])
-WUEUHN = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-WVUBYG = 301
-XBQFYL = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-XCHWDA = 325
-XEKVKZ = 288
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 371
-XIBHZV = 458
-XLSXUJ = 7
-XNKMLO = 324
-XNQTMF = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-XOIHBX = "".join(chr(c) for c in [67, 70, 71, 56])
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = 454
-XSJWMN = 282
-XTIACQ = "".join(chr(c) for c in [85, 76])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-XYBQSN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-YBQSNQ = 315
-YEKCWA = 364
-YFCRTF = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-YGDSBD = "".join(chr(c) for c in [70, 117, 108, 108])
-YIYWSK = "".join(chr(c) for c in [80, 50, 76])
-YKLGQP = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-YMOUNB = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWSKWI = "".join(chr(c) for c in [80, 51, 76])
-YXBQFY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 472
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-ZFETDR = 256
-ZILXWA = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-ZMJIGY = "".join(chr(c) for c in [77, 69, 68])
-ZMKQTD = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = 460
-ZXNQTM = 343
-EEZFET = [
-    QSNQLN,
-    QFYLJU,
-    LJUIKF,
-    OAWBSI,
-    SPBWJY,
-    EJNIBX,
-    BQSNQL,
-    SNQLNM,
-    LGQPLS,
-    BLKXSJ,
-    YXBQFY,
-    BSIRYX,
-    JBIAMJ,
-    TSIFJB,
-    XYBQSN,
-    WBSIRY,
-    XBQFYL,
-    RYXBQF,
-    JMAOAW,
-    JUIKFW,
-    AMJMAO,
-    BIAMJM,
-    FYLJUI,
-    FWRKIN,
-    YLJUIK,
-    IAMJMA,
-    IRYXBQ,
-    AWBSIR,
-    MAOAWB,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-GDSBDJ = [BYGDSB, YGDSBD]
-HWDAFI = [
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    SJMCBF,
-    KWIVDN,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    CHWDAF,
-    HECVYY,
-    HECVYY,
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    IVDNQG,
-]
-IACQFF = [XTIACQ, TIACQF]
-IBXTIA = [IIDNIB, IDNIBX, DNIBXT, NIBXTI]
-JIGYOU = [NZMJIG, QXPICX, ZMJIGY, XPICXQ, MJIGYO]
-KLGQPL = [HECVYY, YKLGQP, YKLGQP, YKLGQP]
-LOIJUG = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    MLOIJU,
-]
-MCBFEG = [ASSAKQ, SOOQNR]
-NEJNIB = [HECVYY, INEJNI, INEJNI, INEJNI]
-NNXWEE = []
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QLAIID = [
-    VKZILX,
-    KZILXW,
-    ZILXWA,
-    ILXWAJ,
-    LXWAJV,
-    XWAJVD,
-    WAJVDQ,
-    AJVDQL,
-    JVDQLA,
-    VDQLAI,
-    DQLAII,
-]
-RAHEOC = [ASSAKQ, LRAHEO]
-RTFMNH = [
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-    JVYFCR,
-    VYFCRT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TOPHUG = [EUTOPH, UTOPHU]
-UEUHNN = [INELWU, NELWUE, ELWUEU, LWUEUH, WUEUHN]
-UNRJZT = [
-    HUGTYI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDNQGV = [
-    HUGTYI,
-    UGTYIY,
-    GTYIYW,
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    SJMCBF,
-    KWIVDN,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WIVDNQ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    IVDNQG,
-]
-WEEZFE = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-XWEEZF = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    NXWEEZ,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1089,305 +19,1144 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return EZFETD
+        return 59
 
     @property
     def begin(self):
-        return ZFETDR
+        return 256
 
     @property
     def end(self):
-        return FETDRX
+        return 479
 
     @property
     def all_device_keys(self):
-        return XWEEZF
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return WEEZFE
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return EEZFET
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoBoolStructAccessor(self.struct, YMOUNB, MOUNBL, ICXQIE, None),
-            OUNBLK: GeckoBoolStructAccessor(self.struct, OUNBLK, MOUNBL, QIEFXQ, None),
-            UNBLKX: GeckoBoolStructAccessor(self.struct, UNBLKX, MOUNBL, EGZUQE, None),
-            NBLKXS: GeckoBoolStructAccessor(self.struct, NBLKXS, MOUNBL, CXQIEF, None),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, MOUNBL, UQEXLS, None),
-            LKXSJW: GeckoBoolStructAccessor(self.struct, LKXSJW, JVHFTH, QIEFXQ, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, XSJWMN, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, XSJWMN, UQEXLS, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, XSJWMN, VHFTHE, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, JIGYOU, None, None, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, GYOUSP, UQEXLS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, GYOUSP, VHFTHE, None),
-            OUSPBW: GeckoWordStructAccessor(self.struct, OUSPBW, USPBWJ, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, AHEOCT, None),
-            PBWJYK: GeckoTempStructAccessor(self.struct, PBWJYK, BWJYKL, None),
-            WJYKLG: GeckoTempStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, JMCBFE, UQEXLS, KLGQPL, None, CXQIEF, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            LGQPLS: GeckoBoolStructAccessor(self.struct, LGQPLS, GQPLSP, QIEFXQ, None),
-            QPLSPF: GeckoBoolStructAccessor(self.struct, QPLSPF, GQPLSP, VHFTHE, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, LSPFTS, QIEFXQ, None),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, AHEOCT, None),
-            FTSIFJ: GeckoBoolStructAccessor(
-                self.struct, FTSIFJ, PFTSIF, QIEFXQ, SAKQXP
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, AHEOCT, None),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoBoolStructAccessor(self.struct, JBIAMJ, JVHFTH, EGZUQE, None),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, XSJWMN, ICXQIE, None),
-            IAMJMA: GeckoBoolStructAccessor(self.struct, IAMJMA, XSJWMN, AHEOCT, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, MJMAOA, QIEFXQ, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MJMAOA, EGZUQE, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, EGZUQE, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, AOAWBS, CXQIEF, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, AOAWBS, UQEXLS, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, AOAWBS, VHFTHE, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, SIRYXB, EGZUQE, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, SIRYXB, CXQIEF, None),
-            RYXBQF: GeckoBoolStructAccessor(self.struct, RYXBQF, SIRYXB, UQEXLS, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, SIRYXB, VHFTHE, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, QIEFXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, BQFYLJ, EGZUQE, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, SIFJBI, EGZUQE, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, GYOUSP, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, GYOUSP, AHEOCT, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, UIKFWR, ICXQIE, None),
-            IKFWRK: GeckoBoolStructAccessor(self.struct, IKFWRK, LSPFTS, ICXQIE, None),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, MJMAOA, ICXQIE, None),
-            FWRKIN: GeckoBoolStructAccessor(self.struct, FWRKIN, MJMAOA, AHEOCT, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, MJMAOA, CXQIEF, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, KINEJN, ICXQIE, None),
-            INEJNI: GeckoEnumStructAccessor(
-                self.struct, INEJNI, KINEJN, AHEOCT, NEJNIB, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, KINEJN, EGZUQE, None),
-            JNIBXY: GeckoWordStructAccessor(self.struct, JNIBXY, NIBXYB, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, YBQSNQ, ICXQIE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, YBQSNQ, AHEOCT, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQFYLJ, ICXQIE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, BQFYLJ, AHEOCT, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, BQFYLJ, CXQIEF, None),
-            QLNMHX: GeckoWordStructAccessor(self.struct, QLNMHX, LNMHXE, None),
-            NMHXEK: GeckoByteStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoByteStructAccessor(self.struct, HXEKVK, XEKVKZ, None),
-            EKVKZI: GeckoEnumStructAccessor(
-                self.struct, EKVKZI, KVKZIL, None, QLAIID, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, AIIDNI, ICXQIE, IBXTIA, None, CXQIEF, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BXTIAC: GeckoEnumStructAccessor(
-                self.struct, BXTIAC, AIIDNI, QIEFXQ, IACQFF, None, QIEFXQ, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            ACQFFT: GeckoWordStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoByteStructAccessor(self.struct, DUBSSU, UBSSUH, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoWordStructAccessor(self.struct, VWVUBY, WVUBYG, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, None, GDSBDJ, None, QIEFXQ, SAKQXP
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            DSBDJQ: GeckoEnumStructAccessor(
-                self.struct, DSBDJQ, SBDJQR, None, RTFMNH, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            TFMNHT: GeckoWordStructAccessor(self.struct, TFMNHT, FMNHTB, None),
-            MNHTBJ: GeckoByteStructAccessor(self.struct, MNHTBJ, NHTBJE, None),
-            HTBJEU: GeckoByteStructAccessor(self.struct, HTBJEU, TBJEUT, None),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, None, TOPHUG, None, None, SAKQXP
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, VDNQGV, None, None, SAKQXP
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, VDNQGV, None, None, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            QGVUNX: GeckoEnumStructAccessor(
-                self.struct, QGVUNX, GVUNXN, None, VDNQGV, None, None, SAKQXP
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            VUNXNK: GeckoEnumStructAccessor(
-                self.struct, VUNXNK, UNXNKM, None, VDNQGV, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            NXNKML: GeckoEnumStructAccessor(
-                self.struct, NXNKML, XNKMLO, None, VDNQGV, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            NKMLOI: GeckoEnumStructAccessor(
-                self.struct, NKMLOI, KMLOIJ, None, LOIJUG, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, SAKQXP),
-            JUGSEL: GeckoByteStructAccessor(self.struct, JUGSEL, UGSELH, SAKQXP),
-            GSELHB: GeckoByteStructAccessor(self.struct, GSELHB, SELHBQ, SAKQXP),
-            ELHBQN: GeckoByteStructAccessor(self.struct, ELHBQN, LHBQNR, SAKQXP),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, SAKQXP),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, SAKQXP),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, HWDAFI, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            WDAFIK: GeckoEnumStructAccessor(
-                self.struct, WDAFIK, KMLOIJ, None, HWDAFI, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, IJUGSE, None, HWDAFI, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            AFIKJP: GeckoEnumStructAccessor(
-                self.struct, AFIKJP, UGSELH, None, HWDAFI, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, SELHBQ, None, HWDAFI, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            IKJPUN: GeckoEnumStructAccessor(
-                self.struct, IKJPUN, LHBQNR, None, HWDAFI, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, BQNRXC, None, HWDAFI, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            JPUNRJ: GeckoEnumStructAccessor(
-                self.struct, JPUNRJ, PUNRJZ, None, UNRJZT, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, NRXCHW, None, UNRJZT, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, SAKQXP),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, SAKQXP),
-            ATDZXN: GeckoByteStructAccessor(self.struct, ATDZXN, TDZXNQ, SAKQXP),
-            DZXNQT: GeckoByteStructAccessor(self.struct, DZXNQT, ZXNQTM, SAKQXP),
-            XNQTMF: GeckoByteStructAccessor(self.struct, XNQTMF, NQTMFZ, SAKQXP),
-            QTMFZD: GeckoByteStructAccessor(self.struct, QTMFZD, TMFZDG, SAKQXP),
-            MFZDGK: GeckoByteStructAccessor(self.struct, MFZDGK, FZDGKE, SAKQXP),
-            ZDGKEA: GeckoByteStructAccessor(self.struct, ZDGKEA, DGKEAK, SAKQXP),
-            GKEAKS: GeckoByteStructAccessor(self.struct, GKEAKS, KEAKST, SAKQXP),
-            PMXFUB: GeckoBoolStructAccessor(self.struct, PMXFUB, JVHFTH, UQEXLS, None),
-            MXFUBJ: GeckoByteStructAccessor(self.struct, MXFUBJ, XFUBJL, SAKQXP),
-            FUBJLO: GeckoByteStructAccessor(self.struct, FUBJLO, UBJLOI, SAKQXP),
-            BJLOIN: GeckoByteStructAccessor(self.struct, BJLOIN, JLOINE, SAKQXP),
-            LOINEL: GeckoEnumStructAccessor(
-                self.struct, LOINEL, OINELW, None, UEUHNN, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            EUHNNX: GeckoBoolStructAccessor(
-                self.struct, EUHNNX, UHNNXW, ICXQIE, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            HNNXWE: GeckoBoolStructAccessor(self.struct, HNNXWE, JEUTOP, ICXQIE, None),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-60.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-60.py
@@ -12,1285 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 348
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-AFIKJP = 321
-AHEOCT = 1
-AIIDNI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AIVEMV = 371
-AJVDQL = 309
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 327
-AWBSIR = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 53])
-BBEKBD = 458
-BDFSRO = 460
-BDJQRJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-BJEUTO = 300
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-BLKXSJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BMJVHF = 256
-BQFYLJ = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-BQNRXC = "".join(chr(c) for c in [80, 51, 72])
-BQSNQL = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-BSIRYX = "".join(chr(c) for c in [72, 69, 65, 84])
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [68, 74, 83, 52])
-BVWVUB = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-BWJYKL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 344
-BXTIAC = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BXYBQS = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-BYGDSB = "".join(chr(c) for c in [49, 54, 75])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = 332
-CHWDAF = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-CMCVDS = "".join(chr(c) for c in [67, 70, 71, 48])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 287
-CRTFMN = 295
-CTHBSK = 307
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 49])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-CYWONF = 374
-CZOLSI = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-DDPMXF = 464
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-DJQRJJ = "".join(chr(c) for c in [85, 76])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 56])
-DMPSCT = 60
-DNIBXT = 315
-DNQGVU = "".join(chr(c) for c in [75, 51, 48, 48])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-DQLAII = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-DRXAIV = 479
-DSBDJQ = "".join(chr(c) for c in [54, 52, 75])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 50])
-DUBSSU = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-DZXNQT = 328
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 476
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-EKBDFS = 459
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-ELHBQN = "".join(chr(c) for c in [80, 49, 76])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-EMVCYW = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-EOCTHB = 308
-ETDRXA = 478
-ETIXQV = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-EUTOPH = 301
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-FCRTFM = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-FFTTID = 288
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-FJBIAM = 281
-FMNHTB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-FSROGM = 461
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-FWRKIN = 284
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-FZCZOL = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-FZDGKE = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [52, 56, 75])
-GKEAKS = 325
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 463
-GQPLSP = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-GSELHB = "".join(chr(c) for c in [78, 65])
-GTYIYW = 357
-GVUNXN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-GYOUSP = "".join(chr(c) for c in [78, 79])
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [80, 50, 76])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-HTBJEU = 299
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 57])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [65, 85, 88])
-HXEKVK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-HZVOAC = 346
-IACQFF = 285
-IAMJMA = 352
-IBHZVO = 345
-IBXTIA = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IBXYBQ = 283
-ICXQIE = 0
-IDNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IDUBSS = "".join(chr(c) for c in [105, 110, 88, 69])
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IGYOUS = 313
-IHBXIB = 343
-IIDNIB = 314
-IKJPUN = 322
-ILXWAJ = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-INEJNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [75, 56, 48, 48])
-IVEMVC = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 340
-IYWSKW = "".join(chr(c) for c in [75, 56, 53])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JEUTOP = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JJJVYF = 291
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-JLOINE = 468
-JMAOAW = "".join(chr(c) for c in [72, 80, 67, 68, 101, 116, 101, 99, 116, 101, 100])
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-JPUNRJ = 323
-JQRJJJ = "".join(chr(c) for c in [67, 69])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-JUIKFW = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-JVHFTH = 274
-JVYFCR = 293
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JYKLGQ = 355
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [72, 84, 82])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [70, 97, 110])
-KFWRKI = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KHTZBB = 456
-KINEJN = 350
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-KLGQPL = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KMLOIJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-KPHUOJ = 304
-KQTDKH = 454
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-KWIVDN = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-KZILXW = 354
-LAIIDN = 311
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 275
-LHBQNR = "".join(chr(c) for c in [80, 50, 72])
-LIUXFE = 263
-LJUIKF = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-LKXSJW = 273
-LNMHXE = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-LOIJUG = "".join(chr(c) for c in [45, 45, 45])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 471
-LXWAJV = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-MAOAWB = 378
-MCGETI = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-MCVDSS = 448
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-MFZDGK = 331
-MHXEKV = 351
-MJIGYO = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJMAOA = 377
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 54])
-MLOIJU = 376
-MNHTBJ = 297
-MNZMJI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MPSCTT = 256
-MVCYWO = 373
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-NBLKXS = 381
-NEJNIB = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-NELWUE = 470
-NFZCZO = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-NIBXTI = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NIBXYB = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-NKMLOI = 361
-NMHXEK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-NNXWEE = 474
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-NQJYMO = 271
-NQLNMH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [80, 52, 72])
-NXNKML = 360
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-NZMJIG = 282
-OACMCV = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-OAWBSI = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-OIJUGS = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-OINELW = 469
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-OLSIPM = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-ONFZCZ = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-OUNBLK = 380
-OUSPBW = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = 353
-PFTSIF = 279
-PHUGTY = "".join(chr(c) for c in [70, 117, 108, 108])
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PMXFUB = 465
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PSCTTG = 479
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-QFYLJU = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-QLNMHX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [80, 51, 76])
-QPLSPF = 277
-QSNQLN = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 55])
-QTMFZD = 330
-QVXOIH = 341
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 452
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-RJZTAT = 326
-RKINEJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-ROGMDD = 462
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-RURAZM = 451
-RXAIVE = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-RXCHWD = "".join(chr(c) for c in [80, 52, 76])
-RYXBQF = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SELHBQ = "".join(chr(c) for c in [80, 49, 72])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-SIFJBI = 280
-SIPMDM = "".join(chr(c) for c in [76, 73])
-SIRYXB = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [75, 53])
-SNQLNM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SPFTSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 51])
-SSRURA = 450
-SSUHBV = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-SUHBVW = "".join(chr(c) for c in [105, 110, 88, 77])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-TDKHTZ = 455
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-TFMNHT = 296
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-TIDUBS = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-TIXQVX = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-TOPHUG = 316
-TSEMCG = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-TSIFJB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-TTIDUB = 289
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 50, 48, 48])
-TZBBEK = 457
-UBJLOI = 467
-UBSSUH = "".join(chr(c) for c in [77, 73, 65])
-UBYGDS = 290
-UEUHNN = 472
-UGSELH = 320
-UGTYIY = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-UHBVWV = "".join(chr(c) for c in [75, 54, 48, 48])
-UHNNXW = 473
-UIKFWR = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-UNRJZT = 324
-UNXNKM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 52])
-USOOQN = 261
-UTOPHU = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VCYWON = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-VDNQGV = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-VDSSRU = 449
-VEMVCY = 372
-VHFTHE = 6
-VKZILX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 347
-VUBYGD = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-VUNXNK = 358
-VWVUBY = "".join(chr(c) for c in [105, 110, 89, 84])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-WAONPY = 367
-WBSIRY = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-WIVDNQ = "".join(chr(c) for c in [75, 49, 48, 48])
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-WMNZMJ = "".join(chr(c) for c in [67, 80, 79, 84])
-WONFZC = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WSKWIV = "".join(chr(c) for c in [75, 52])
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-XAIVEM = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-XBQFYL = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-XCHWDA = "".join(chr(c) for c in [66, 76, 79])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 466
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-XNQTMF = 329
-XOIHBX = 342
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-XTIACQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-XWEEZF = 475
-XYBQSN = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-YBQSNQ = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-YEKCWA = 364
-YFCRTF = 294
-YGDSBD = "".join(chr(c) for c in [51, 50, 75])
-YIYWSK = "".join(chr(c) for c in [75, 52, 48, 48])
-YKLGQP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-YMOUNB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(chr(c) for c in [77, 69, 68])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-YWSKWI = "".join(chr(c) for c in [75, 56])
-YXBQFY = 379
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZDGKEA = 333
-ZFETDR = 477
-ZILXWA = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-ZMKQTD = 453
-ZOLSIP = 375
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-EAKSTS = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    SJMCBF,
-    XCHWDA,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    KEAKST,
-    HECVYY,
-    HECVYY,
-    CHWDAF,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    HWDAFI,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-GETIXQ = [
-    GSELHB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-HUGTYI = [OPHUGT, PHUGTY]
-IJUGSE = [LOIJUG, OIJUGS]
-IKFWRK = [
-    IUXFEF,
-    XBQFYL,
-    BQFYLJ,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    QFYLJU,
-    FYLJUI,
-    YLJUIK,
-    LJUIKF,
-    JUIKFW,
-    UIKFWR,
-]
-IPMDMP = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    SIPMDM,
-]
-IRYXBQ = [BSIRYX, SIRYXB]
-LSIPMD = []
-LSPFTS = [HECVYY, PLSPFT, PLSPFT, PLSPFT]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDMPSC = [
-    IBXTIA,
-    HXEKVK,
-    KVKZIL,
-    YBQSNQ,
-    YKLGQP,
-    DQLAII,
-    NIBXTI,
-    BXTIAC,
-    SPFTSI,
-    JWMNZM,
-    LNMHXE,
-    SNQLNM,
-    NEJNIB,
-    BIAMJM,
-    IDNIBX,
-    QSNQLN,
-    NMHXEK,
-    QLNMHX,
-    BXYBQS,
-    VKZILX,
-    NIBXYB,
-    EJNIBX,
-    XEKVKZ,
-    LXWAJV,
-    EKVKZI,
-    JNIBXY,
-    NQLNMH,
-    BQSNQL,
-    XYBQSN,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PMDMPS = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QGVUNX = [
-    TYIYWS,
-    YIYWSK,
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-]
-QRJJJV = [DJQRJJ, JQRJJJ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SBDJQR = [BYGDSB, YGDSBD, GDSBDJ, DSBDJQ]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-USPBWJ = [GYOUSP, QXPICX, YOUSPB, XPICXQ, OUSPBW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VDQLAI = [HECVYY, JVDQLA, JVDQLA, JVDQLA]
-WDAFIK = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    SJMCBF,
-    XCHWDA,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    CHWDAF,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    HWDAFI,
-]
-WVUBYG = [
-    TIDUBS,
-    IDUBSS,
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-]
-YYLIUX = [NPYYLI, PYYLIU]
-ZCZOLS = [YWONFZ, WONFZC, ONFZCZ, NFZCZO, FZCZOL]
-ZTATDZ = [
-    GSELHB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JZTATD,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1298,326 +19,1227 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return DMPSCT
+        return 60
 
     @property
     def begin(self):
-        return MPSCTT
+        return 256
 
     @property
     def end(self):
-        return PSCTTG
+        return 479
 
     @property
     def all_device_keys(self):
-        return IPMDMP
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return PMDMPS
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return MDMPSC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, ONPYYL, AHEOCT, YYLIUX, None, QIEFXQ, SAKQXP
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, FJTACC, None, None, SAKQXP
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, SAKQXP),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, LKXSJW, ICXQIE, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, LKXSJW, QIEFXQ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, LKXSJW, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, LKXSJW, CXQIEF, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, LKXSJW, UQEXLS, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, JVHFTH, QIEFXQ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, EGZUQE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, UQEXLS, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, NZMJIG, VHFTHE, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, UQEXLS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, PBWJYK, VHFTHE, None),
-            WJYKLG: GeckoWordStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JVHFTH, AHEOCT, None),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, None),
-            GQPLSP: GeckoTempStructAccessor(self.struct, GQPLSP, QPLSPF, None),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, JMCBFE, UQEXLS, LSPFTS, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, AHEOCT, None),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, FJBIAM, QIEFXQ, SAKQXP
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, AHEOCT, None),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, MAOAWB, CXQIEF, None),
-            OAWBSI: GeckoBoolStructAccessor(self.struct, OAWBSI, MAOAWB, UQEXLS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, MAOAWB, VHFTHE, None),
-            WBSIRY: GeckoEnumStructAccessor(
-                self.struct, WBSIRY, MAOAWB, XLSXUJ, IRYXBQ, None, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            RYXBQF: GeckoEnumStructAccessor(
-                self.struct, RYXBQF, YXBQFY, None, IKFWRK, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KFWRKI: GeckoBoolStructAccessor(self.struct, KFWRKI, FWRKIN, ICXQIE, None),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, FWRKIN, AHEOCT, None),
-            RKINEJ: GeckoBoolStructAccessor(self.struct, RKINEJ, KINEJN, ICXQIE, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, KINEJN, AHEOCT, None),
-            NEJNIB: GeckoBoolStructAccessor(self.struct, NEJNIB, JVHFTH, EGZUQE, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, NZMJIG, ICXQIE, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NZMJIG, AHEOCT, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, IBXYBQ, QIEFXQ, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, IBXYBQ, EGZUQE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, FWRKIN, EGZUQE, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, FWRKIN, CXQIEF, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, FWRKIN, UQEXLS, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, FWRKIN, VHFTHE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, KINEJN, EGZUQE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, KINEJN, CXQIEF, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, KINEJN, UQEXLS, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, KINEJN, VHFTHE, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, MHXEKV, QIEFXQ, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, MHXEKV, EGZUQE, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, IAMJMA, EGZUQE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, PBWJYK, ICXQIE, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, PBWJYK, AHEOCT, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KZILXW, ICXQIE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, SIFJBI, ICXQIE, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, IBXYBQ, ICXQIE, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, IBXYBQ, AHEOCT, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, IBXYBQ, CXQIEF, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, ICXQIE, None),
-            JVDQLA: GeckoEnumStructAccessor(
-                self.struct, JVDQLA, AJVDQL, AHEOCT, VDQLAI, None, CXQIEF, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, AJVDQL, EGZUQE, None),
-            QLAIID: GeckoWordStructAccessor(self.struct, QLAIID, LAIIDN, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, IIDNIB, ICXQIE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, ICXQIE, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, DNIBXT, AHEOCT, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, MHXEKV, ICXQIE, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, MHXEKV, AHEOCT, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, MHXEKV, CXQIEF, None),
-            TIACQF: GeckoWordStructAccessor(self.struct, TIACQF, IACQFF, None),
-            ACQFFT: GeckoByteStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoEnumStructAccessor(
-                self.struct, FTTIDU, TTIDUB, None, WVUBYG, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, UBYGDS, ICXQIE, SBDJQR, None, CXQIEF, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BDJQRJ: GeckoEnumStructAccessor(
-                self.struct, BDJQRJ, UBYGDS, QIEFXQ, QRJJJV, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            RJJJVY: GeckoWordStructAccessor(self.struct, RJJJVY, JJJVYF, None),
-            JJVYFC: GeckoByteStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoWordStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoWordStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoEnumStructAccessor(
-                self.struct, UTOPHU, TOPHUG, None, HUGTYI, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGTYIY: GeckoEnumStructAccessor(
-                self.struct, UGTYIY, GTYIYW, None, QGVUNX, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            GVUNXN: GeckoWordStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, IJUGSE, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, WDAFIK, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, WDAFIK, None, None, SAKQXP
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, IKJPUN, None, WDAFIK, None, None, SAKQXP
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, WDAFIK, None, None, SAKQXP
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, WDAFIK, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, RJZTAT, None, ZTATDZ, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            TATDZX: GeckoByteStructAccessor(self.struct, TATDZX, ATDZXN, SAKQXP),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, SAKQXP),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoEnumStructAccessor(
-                self.struct, DGKEAK, GKEAKS, None, EAKSTS, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, RJZTAT, None, EAKSTS, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            KSTSEM: GeckoEnumStructAccessor(
-                self.struct, KSTSEM, ATDZXN, None, EAKSTS, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            STSEMC: GeckoEnumStructAccessor(
-                self.struct, STSEMC, DZXNQT, None, EAKSTS, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, XNQTMF, None, EAKSTS, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, QTMFZD, None, EAKSTS, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MFZDGK, None, EAKSTS, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, CGETIX, None, GETIXQ, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, ZDGKEA, None, GETIXQ, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, SAKQXP),
-            XQVXOI: GeckoByteStructAccessor(self.struct, XQVXOI, QVXOIH, SAKQXP),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, SAKQXP),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, SAKQXP),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, SAKQXP),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, SAKQXP),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, SAKQXP),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, SAKQXP),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, SAKQXP),
-            RXAIVE: GeckoBoolStructAccessor(self.struct, RXAIVE, JVHFTH, UQEXLS, None),
-            XAIVEM: GeckoByteStructAccessor(self.struct, XAIVEM, AIVEMV, SAKQXP),
-            IVEMVC: GeckoByteStructAccessor(self.struct, IVEMVC, VEMVCY, SAKQXP),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, SAKQXP),
-            VCYWON: GeckoEnumStructAccessor(
-                self.struct, VCYWON, CYWONF, None, ZCZOLS, None, None, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            CZOLSI: GeckoBoolStructAccessor(
-                self.struct, CZOLSI, ZOLSIP, ICXQIE, SAKQXP
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            OLSIPM: GeckoBoolStructAccessor(self.struct, OLSIPM, MLOIJU, ICXQIE, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "HPCDetected": GeckoBoolStructAccessor(
+                self.struct, "HPCDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-61.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-61.py
@@ -12,1309 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 347
-ACQFFT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-AHEOCT = 1
-AIIDNI = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-AIVEMV = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-AJVDQL = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [70, 97, 110])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 52])
-BBEKBD = 457
-BDFSRO = 459
-BDJQRJ = "".join(chr(c) for c in [54, 52, 75])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-BJEUTO = 299
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-BLKXSJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BMJVHF = 256
-BQFYLJ = 379
-BQNRXC = "".join(chr(c) for c in [80, 50, 72])
-BQSNQL = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-BSIRYX = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-BVWVUB = "".join(chr(c) for c in [75, 54, 48, 48])
-BWJYKL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 343
-BXTIAC = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BXYBQS = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-BYGDSB = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-CHWDAF = "".join(chr(c) for c in [80, 52, 76])
-CMCVDS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = 285
-CRTFMN = 294
-CTHBSK = 307
-CTTGCR = 479
-CVDSSR = "".join(chr(c) for c in [67, 70, 71, 48])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-CYWONF = 373
-CZOLSI = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-DAFIKJ = "".join(chr(c) for c in [65, 85, 88])
-DDPMXF = 463
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 55])
-DNIBXT = 314
-DNQGVU = "".join(chr(c) for c in [75, 56, 48, 48])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-DQLAII = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-DRXAIV = 478
-DSBDJQ = "".join(chr(c) for c in [51, 50, 75])
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 49])
-DUBSSU = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-DZXNQT = 327
-EAKSTS = 325
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 475
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-EKBDFS = 458
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-ELHBQN = "".join(chr(c) for c in [78, 65])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-EMVCYW = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-EOCTHB = 308
-ETDRXA = 477
-ETIXQV = 332
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-EUTOPH = 300
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-FFTTID = 287
-FIKJPU = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-FJBIAM = 281
-FMNHTB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-FSROGM = 460
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-FZCZOL = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-FZDGKE = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [49, 54, 75])
-GETIXQ = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-GKEAKS = 333
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 462
-GQPLSP = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-GSELHB = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-GVUNXN = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-GYOUSP = "".join(chr(c) for c in [78, 79])
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [80, 49, 76])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [105, 110, 88, 77])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-HTBJEU = 297
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 56])
-HUGTYI = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [66, 76, 79])
-HXEKVK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-HZVOAC = 345
-IACQFF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-IAMJMA = 352
-IBHZVO = 344
-IBXTIA = 315
-IBXYBQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-ICXQIE = 0
-IDNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IDUBSS = 289
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IGYOUS = 313
-IHBXIB = 342
-IIDNIB = 311
-IJUGSE = "".join(chr(c) for c in [45, 45, 45])
-IKFWRK = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-IKJPUN = 321
-ILXWAJ = 354
-INEJNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(chr(c) for c in [72, 69, 65, 84])
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-IVEMVC = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-IYWSKW = "".join(chr(c) for c in [75, 50, 48, 48])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-JLOINE = 467
-JMAOAW = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-JPUNRJ = 322
-JQRJJJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-JUIKFW = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-JVHFTH = 274
-JVYFCR = 291
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JYKLGQ = 355
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-KFWRKI = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-KHTZBB = 455
-KINEJN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-KLGQPL = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KMLOIJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-KPHUOJ = 304
-KQTDKH = 453
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-KWIVDN = "".join(chr(c) for c in [75, 52])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-LAIIDN = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 275
-LHBQNR = "".join(chr(c) for c in [80, 49, 72])
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-LKXSJW = 273
-LNMHXE = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-LOIJUG = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSIPMD = 375
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 470
-LXWAJV = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MAOAWB = 384
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-MCVDSS = 348
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-MFZDGK = 330
-MHXEKV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-MJIGYO = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJMAOA = 377
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 53])
-MLOIJU = 361
-MNHTBJ = 296
-MNZMJI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MVCYWO = 372
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-NBLKXS = 381
-NEJNIB = 350
-NELWUE = 469
-NFZCZO = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NIBXTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-NIBXYB = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-NKMLOI = 360
-NMHXEK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-NNXWEE = 473
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-NQJYMO = 271
-NQLNMH = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [80, 51, 72])
-NXNKML = 358
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-NZMJIG = 282
-OACMCV = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-OAWBSI = 378
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-OIJUGS = 376
-OINELW = 468
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-OLSIPM = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-ONFZCZ = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-OUNBLK = 380
-OUSPBW = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = 353
-PFTSIF = 279
-PHUGTY = 316
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PMDMPS = "".join(chr(c) for c in [76, 73])
-PMXFUB = 464
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PSCTTG = 61
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-QFYLJU = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-QGVUNX = "".join(chr(c) for c in [75, 51, 48, 48])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLNMHX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [80, 50, 76])
-QPLSPF = 277
-QRJJJV = "".join(chr(c) for c in [85, 76])
-QSNQLN = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 54])
-QTMFZD = 329
-QVXOIH = 340
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 451
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [67, 69])
-RJZTAT = 324
-RKINEJ = 284
-ROGMDD = 461
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-RURAZM = 450
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-RXCHWD = "".join(chr(c) for c in [80, 51, 76])
-RYXBQF = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [52, 56, 75])
-SCTTGC = 256
-SELHBQ = 320
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-SIFJBI = 280
-SIPMDM = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-SIRYXB = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [75, 56])
-SNQLNM = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SPFTSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 50])
-SSRURA = 449
-SSUHBV = "".join(chr(c) for c in [77, 73, 65])
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SUHBVW = "".join(chr(c) for c in [68, 74, 83, 52])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [72, 84, 82])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-TDKHTZ = 454
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TFMNHT = 295
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-TOPHUG = 301
-TSEMCG = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-TSIFJB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-TTIDUB = 288
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-TZBBEK = 456
-UBJLOI = 466
-UBSSUH = "".join(chr(c) for c in [105, 110, 88, 69])
-UEUHNN = 471
-UGTYIY = "".join(chr(c) for c in [70, 117, 108, 108])
-UHBVWV = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-UHNNXW = 472
-UIKFWR = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-UNRJZT = 323
-UNXNKM = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 51])
-USOOQN = 261
-UTOPHU = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VCYWON = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [75, 49, 48, 48])
-VDQLAI = 309
-VDSSRU = 448
-VEMVCY = 371
-VHFTHE = 6
-VKZILX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 346
-VUBYGD = "".join(chr(c) for c in [105, 110, 89, 84])
-VWVUBY = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-WAONPY = 367
-WBSIRY = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-WDAFIK = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-WIVDNQ = "".join(chr(c) for c in [75, 53])
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-WMNZMJ = "".join(chr(c) for c in [67, 80, 79, 84])
-WONFZC = 374
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WSKWIV = "".join(chr(c) for c in [75, 56, 53])
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-WVUBYG = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-XAIVEM = 479
-XBQFYL = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-XCHWDA = "".join(chr(c) for c in [80, 52, 72])
-XEKVKZ = 351
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 465
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-XNQTMF = 328
-XOIHBX = 341
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-XTIACQ = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-XWEEZF = 474
-XYBQSN = 283
-YBQSNQ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-YEKCWA = 364
-YFCRTF = 293
-YGDSBD = 290
-YIYWSK = 357
-YKLGQP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-YMOUNB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(chr(c) for c in [77, 69, 68])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-YWSKWI = "".join(chr(c) for c in [75, 52, 48, 48])
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 57])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-ZDGKEA = 331
-ZFETDR = 476
-ZILXWA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-ZMKQTD = 452
-ZTATDZ = 326
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-AFIKJP = [
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    SJMCBF,
-    HWDAFI,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    DAFIKJ,
-]
-ATDZXN = [
-    ELHBQN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TATDZX,
-]
-DJQRJJ = [GDSBDJ, DSBDJQ, SBDJQR, BDJQRJ]
-DMPSCT = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FWRKIN = [
-    IUXFEF,
-    QFYLJU,
-    FYLJUI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YLJUIK,
-    LJUIKF,
-    JUIKFW,
-    UIKFWR,
-    IKFWRK,
-    KFWRKI,
-]
-GTYIYW = [HUGTYI, UGTYIY]
-IPMDMP = []
-JJJVYF = [QRJJJV, RJJJVY]
-KSTSEM = [
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    SJMCBF,
-    HWDAFI,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    AKSTSE,
-    HECVYY,
-    HECVYY,
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    DAFIKJ,
-]
-LSPFTS = [HECVYY, PLSPFT, PLSPFT, PLSPFT]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDMPSC = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    PMDMPS,
-]
-MPSCTT = [
-    XTIACQ,
-    EKVKZI,
-    KZILXW,
-    QSNQLN,
-    YKLGQP,
-    LAIIDN,
-    BXTIAC,
-    TIACQF,
-    SPFTSI,
-    JWMNZM,
-    MHXEKV,
-    QLNMHX,
-    JNIBXY,
-    BIAMJM,
-    NIBXTI,
-    NQLNMH,
-    HXEKVK,
-    NMHXEK,
-    YBQSNQ,
-    ZILXWA,
-    BXYBQS,
-    NIBXYB,
-    KVKZIL,
-    WAJVDQ,
-    VKZILX,
-    IBXYBQ,
-    LNMHXE,
-    SNQLNM,
-    BQSNQL,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QLAIID = [HECVYY, DQLAII, DQLAII, DQLAII]
-RAHEOC = [ASSAKQ, LRAHEO]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TIXQVX = [
-    ELHBQN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-UBYGDS = [
-    DUBSSU,
-    UBSSUH,
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-]
-UGSELH = [IJUGSE, JUGSEL]
-USPBWJ = [GYOUSP, QXPICX, YOUSPB, XPICXQ, OUSPBW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-VUNXNK = [
-    IYWSKW,
-    YWSKWI,
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NQGVUN,
-    QGVUNX,
-    GVUNXN,
-]
-YXBQFY = [IRYXBQ, RYXBQF]
-YYLIUX = [NPYYLI, PYYLIU]
-ZOLSIP = [ONFZCZ, NFZCZO, FZCZOL, ZCZOLS, CZOLSI]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1322,327 +19,1230 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return PSCTTG
+        return 61
 
     @property
     def begin(self):
-        return SCTTGC
+        return 256
 
     @property
     def end(self):
-        return CTTGCR
+        return 479
 
     @property
     def all_device_keys(self):
-        return MDMPSC
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return DMPSCT
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return MPSCTT
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, ONPYYL, AHEOCT, YYLIUX, None, QIEFXQ, SAKQXP
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, FJTACC, None, None, SAKQXP
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, SAKQXP),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, LKXSJW, ICXQIE, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, LKXSJW, QIEFXQ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, LKXSJW, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, LKXSJW, CXQIEF, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, LKXSJW, UQEXLS, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, JVHFTH, QIEFXQ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, EGZUQE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, UQEXLS, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, NZMJIG, VHFTHE, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, UQEXLS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, PBWJYK, VHFTHE, None),
-            WJYKLG: GeckoWordStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JVHFTH, AHEOCT, None),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, None),
-            GQPLSP: GeckoTempStructAccessor(self.struct, GQPLSP, QPLSPF, None),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, JMCBFE, UQEXLS, LSPFTS, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, AHEOCT, None),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, FJBIAM, QIEFXQ, SAKQXP
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, AHEOCT, None),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, OAWBSI, UQEXLS, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, OAWBSI, VHFTHE, None),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, OAWBSI, XLSXUJ, YXBQFY, None, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FWRKIN, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, ICXQIE, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, RKINEJ, AHEOCT, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, ICXQIE, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, NEJNIB, AHEOCT, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, JVHFTH, EGZUQE, None),
-            NIBXYB: GeckoBoolStructAccessor(self.struct, NIBXYB, NZMJIG, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, NZMJIG, AHEOCT, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, XYBQSN, QIEFXQ, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, XYBQSN, EGZUQE, None),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, RKINEJ, EGZUQE, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, RKINEJ, CXQIEF, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, RKINEJ, UQEXLS, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, RKINEJ, VHFTHE, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, NEJNIB, EGZUQE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NEJNIB, CXQIEF, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NEJNIB, UQEXLS, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NEJNIB, VHFTHE, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, XEKVKZ, QIEFXQ, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, XEKVKZ, EGZUQE, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, IAMJMA, EGZUQE, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, PBWJYK, ICXQIE, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, PBWJYK, AHEOCT, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, ILXWAJ, ICXQIE, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, SIFJBI, ICXQIE, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, XYBQSN, ICXQIE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, XYBQSN, AHEOCT, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, XYBQSN, CXQIEF, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, VDQLAI, ICXQIE, None),
-            DQLAII: GeckoEnumStructAccessor(
-                self.struct, DQLAII, VDQLAI, AHEOCT, QLAIID, None, CXQIEF, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, VDQLAI, EGZUQE, None),
-            AIIDNI: GeckoWordStructAccessor(self.struct, AIIDNI, IIDNIB, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, ICXQIE, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, IBXTIA, ICXQIE, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, IBXTIA, AHEOCT, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, XEKVKZ, ICXQIE, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, XEKVKZ, AHEOCT, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, XEKVKZ, CXQIEF, None),
-            ACQFFT: GeckoWordStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoByteStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoEnumStructAccessor(
-                self.struct, TIDUBS, IDUBSS, None, UBYGDS, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            BYGDSB: GeckoEnumStructAccessor(
-                self.struct, BYGDSB, YGDSBD, ICXQIE, DJQRJJ, None, CXQIEF, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JQRJJJ: GeckoEnumStructAccessor(
-                self.struct, JQRJJJ, YGDSBD, QIEFXQ, JJJVYF, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoWordStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoWordStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoEnumStructAccessor(
-                self.struct, OPHUGT, PHUGTY, None, GTYIYW, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            TYIYWS: GeckoEnumStructAccessor(
-                self.struct, TYIYWS, YIYWSK, None, VUNXNK, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            UNXNKM: GeckoWordStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoByteStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoEnumStructAccessor(
-                self.struct, LOIJUG, OIJUGS, None, UGSELH, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, AFIKJP, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            FIKJPU: GeckoEnumStructAccessor(
-                self.struct, FIKJPU, IKJPUN, None, AFIKJP, None, None, SAKQXP
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, AFIKJP, None, None, SAKQXP
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, AFIKJP, None, None, SAKQXP
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, RJZTAT, None, AFIKJP, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            JZTATD: GeckoEnumStructAccessor(
-                self.struct, JZTATD, ZTATDZ, None, ATDZXN, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            TDZXNQ: GeckoByteStructAccessor(self.struct, TDZXNQ, DZXNQT, SAKQXP),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, SAKQXP),
-            KEAKST: GeckoEnumStructAccessor(
-                self.struct, KEAKST, EAKSTS, None, KSTSEM, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            STSEMC: GeckoEnumStructAccessor(
-                self.struct, STSEMC, ZTATDZ, None, KSTSEM, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            TSEMCG: GeckoEnumStructAccessor(
-                self.struct, TSEMCG, DZXNQT, None, KSTSEM, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, XNQTMF, None, KSTSEM, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, QTMFZD, None, KSTSEM, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, MFZDGK, None, KSTSEM, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, ZDGKEA, None, KSTSEM, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, TIXQVX, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, GKEAKS, None, TIXQVX, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            XQVXOI: GeckoByteStructAccessor(self.struct, XQVXOI, QVXOIH, SAKQXP),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, SAKQXP),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, SAKQXP),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, SAKQXP),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, SAKQXP),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, SAKQXP),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, SAKQXP),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, SAKQXP),
-            CMCVDS: GeckoByteStructAccessor(self.struct, CMCVDS, MCVDSS, SAKQXP),
-            AIVEMV: GeckoBoolStructAccessor(self.struct, AIVEMV, JVHFTH, UQEXLS, None),
-            IVEMVC: GeckoByteStructAccessor(self.struct, IVEMVC, VEMVCY, SAKQXP),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, SAKQXP),
-            VCYWON: GeckoByteStructAccessor(self.struct, VCYWON, CYWONF, SAKQXP),
-            YWONFZ: GeckoEnumStructAccessor(
-                self.struct, YWONFZ, WONFZC, None, ZOLSIP, None, None, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            OLSIPM: GeckoBoolStructAccessor(
-                self.struct, OLSIPM, LSIPMD, ICXQIE, SAKQXP
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            SIPMDM: GeckoBoolStructAccessor(self.struct, SIPMDM, OIJUGS, ICXQIE, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-62.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-62.py
@@ -12,1331 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-ACMCVD = 346
-ACQFFT = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-AFIKJP = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-AHEOCT = 1
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-AJVDQL = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-AKQXPI = "".join(chr(c) for c in [85, 100, 80, 49])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-AMJMAO = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-AOAWBS = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-AONPYY = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-ASSAKQ = "".join(chr(c) for c in [79, 70, 70])
-ATDZXN = 326
-AWBSIR = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [67, 70, 71, 51])
-BBEKBD = 456
-BDFSRO = 458
-BDJQRJ = "".join(chr(c) for c in [51, 50, 75])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 57])
-BFEGZU = "".join(chr(c) for c in [67, 80])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-BJEUTO = 297
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-BLKXSJ = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-BMJVHF = 256
-BQFYLJ = 379
-BQNRXC = "".join(chr(c) for c in [80, 49, 72])
-BQSNQL = 283
-BSIRYX = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-BSKSOK = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-BSSUHB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-BVWVUB = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BWJYKL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-BXIBHZ = 342
-BXTIAC = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BXYBQS = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-BYGDSB = "".join(chr(c) for c in [105, 110, 89, 84])
-CBFEGZ = "".join(chr(c) for c in [66, 76])
-CCPQIP = 266
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-CHWDAF = "".join(chr(c) for c in [80, 51, 76])
-CMCVDS = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-CPQIPO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-CRTFMN = 293
-CTHBSK = 307
-CTTGCR = 62
-CVDSSR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-CXQIEF = 4
-CYWONF = 372
-CZOLSI = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-DAFIKJ = "".join(chr(c) for c in [66, 76, 79])
-DDPMXF = 462
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-DJQRJJ = "".join(chr(c) for c in [52, 56, 75])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 54])
-DMPSCT = "".join(chr(c) for c in [76, 73])
-DNIBXT = 311
-DNQGVU = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-DQLAII = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-DRXAIV = 477
-DSBDJQ = 290
-DSSRUR = "".join(chr(c) for c in [67, 70, 71, 48])
-DUBSSU = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-EAKSTS = 333
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 474
-EFJTAC = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-EFXQGL = "".join(chr(c) for c in [85, 100, 80, 52])
-EGZUQE = 3
-EJNIBX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-EKBDFS = 457
-EKCWAO = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-EKVKZI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-ELHBQN = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-EMVCYW = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-EOCTHB = 308
-ETDRXA = 476
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-EUTOPH = 299
-EXLSXU = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-FEFJTA = "".join(chr(c) for c in [78, 69, 87])
-FEGZUQ = "".join(chr(c) for c in [79, 51])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-FFTTID = 285
-FIKJPU = "".join(chr(c) for c in [65, 85, 88])
-FJBIAM = 281
-FMNHTB = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-FSROGM = 459
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-FTTIDU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-FXQGLR = "".join(chr(c) for c in [85, 100, 80, 53])
-FYLJUI = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-FZCZOL = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-FZDGKE = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-GDSBDJ = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-GETIXQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-GKEAKS = 331
-GLRAHE = "".join(chr(c) for c in [85, 100, 66, 76])
-GMDDPM = 461
-GQPLSP = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-GSELHB = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-GTYIYW = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-GVUNXN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-GYOUSP = "".join(chr(c) for c in [78, 79])
-GZUQEX = "".join(chr(c) for c in [76, 49, 50, 48])
-HBQNRX = "".join(chr(c) for c in [78, 65])
-HBSKSO = 363
-HBVWVU = "".join(chr(c) for c in [68, 74, 83, 52])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 369
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-HTBJEU = 296
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 55])
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-HUOJRJ = 305
-HWDAFI = "".join(chr(c) for c in [80, 52, 72])
-HXEKVK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-HZVOAC = 344
-IACQFF = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IAMJMA = 352
-IBHZVO = 343
-IBXTIA = 314
-IBXYBQ = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-ICXQIE = 0
-IDNIBX = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-IDUBSS = 288
-IEFXQG = "".join(chr(c) for c in [85, 100, 80, 51])
-IFJBIA = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-IGYOUS = 313
-IHBXIB = 341
-IIDNIB = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IJUGSE = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-IKFWRK = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-ILXWAJ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-INEJNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-IPIVLA = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-IPMDMP = 375
-IPOUYN = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-IRYXBQ = "".join(chr(c) for c in [72, 69, 65, 84])
-IUSOOQ = "".join(chr(c) for c in [80, 49])
-IUXFEF = "".join(chr(c) for c in [73, 68, 76, 69])
-IVDNQG = "".join(chr(c) for c in [75, 52])
-IVEMVC = 479
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-IXQVXO = 332
-IYWSKW = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-JBIAMJ = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-JHIUSO = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JIGYOU = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-JJJVYF = "".join(chr(c) for c in [85, 76])
-JJVYFC = "".join(chr(c) for c in [67, 69])
-JLOINE = 466
-JMAOAW = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-JMCBFE = 260
-JNIBXY = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-JPUNRJ = 321
-JQRJJJ = "".join(chr(c) for c in [54, 52, 75])
-JRJHIU = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-JTACCP = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-JUGSEL = 376
-JUIKFW = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-JUTYEK = "".join(chr(c) for c in [70, 85, 76, 76])
-JVDQLA = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-JVHFTH = 274
-JWMNZM = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-JYKLGQ = 355
-JYMOUN = 272
-JZTATD = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-KCWAON = 365
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-KFWRKI = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-KHTZBB = 454
-KINEJN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KJPUNR = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KLGQPL = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-KMLOIJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-KPHUOJ = 304
-KQTDKH = 452
-KQXPIC = 259
-KSOKPH = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-KSTSEM = 325
-KVKZIL = 351
-KWIVDN = "".join(chr(c) for c in [75, 56, 53])
-KXSJWM = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LAIIDN = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-LASSAK = "".join(chr(c) for c in [83, 79, 65, 75])
-LGQPLS = 275
-LHBQNR = 320
-LIUXFE = 263
-LJUIKF = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-LKXSJW = 273
-LNMHXE = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-LOIJUG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-LRAHEO = "".join(chr(c) for c in [79, 78])
-LSXUJU = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-LWUEUH = 469
-LXWAJV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-MAOAWB = 384
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-MCVDSS = 347
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-MFZDGK = 329
-MHXEKV = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-MJIGYO = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-MJMAOA = 377
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 52])
-MLOIJU = 360
-MNHTBJ = 295
-MNZMJI = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MVCYWO = 371
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-NBLKXS = 381
-NEJNIB = 350
-NELWUE = 468
-NFZCZO = 374
-NHTBJE = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NIBXTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-NIBXYB = 383
-NKMLOI = 358
-NMHXEK = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-NNXWEE = 472
-NPYYLI = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-NQGVUN = "".join(chr(c) for c in [75, 49, 48, 48])
-NQJYMO = 271
-NQLNMH = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-NRJZTA = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-NRSJMC = "".join(chr(c) for c in [80, 51])
-NRXCHW = "".join(chr(c) for c in [80, 50, 72])
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-NZMJIG = 282
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-OAWBSI = 378
-OCTHBS = "".join(chr(c) for c in [85, 100, 76, 105])
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-OIJUGS = 361
-OINELW = 467
-OJRJHI = 306
-OKPHUO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-OLSIPM = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-ONFZCZ = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-ONPYYL = 262
-OOQNRS = "".join(chr(c) for c in [76, 79, 87])
-OPHUGT = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-OUNBLK = 380
-OUSPBW = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-OUYNQJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-PBWJYK = 353
-PFTSIF = 279
-PHUGTY = 301
-PHUOJR = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-PIVLAS = 257
-PLSPFT = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-PMDMPS = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-PMXFUB = 463
-POUYNQ = 268
-PQIPOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-PUNRJZ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-PYYLIU = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-QFFTTI = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QFYLJU = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-QGVUNX = "".join(chr(c) for c in [75, 56, 48, 48])
-QIEFXQ = 2
-QIPOUY = 267
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-QLAIID = 309
-QLNMHX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-QNRSJM = "".join(chr(c) for c in [80, 50])
-QNRXCH = "".join(chr(c) for c in [80, 49, 76])
-QPLSPF = 277
-QSNQLN = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 53])
-QTMFZD = 328
-QVXOIH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-QXPICX = "".join(chr(c) for c in [76, 79])
-RAZMKQ = 450
-RJHIUS = 362
-RJJJVY = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-RJZTAT = 323
-RKINEJ = 284
-ROGMDD = 460
-RSJMCB = "".join(chr(c) for c in [80, 52])
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-RURAZM = 449
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-RXCHWD = "".join(chr(c) for c in [80, 50, 76])
-RYXBQF = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-SAKQXP = "".join(chr(c) for c in [65, 76, 76])
-SBDJQR = "".join(chr(c) for c in [49, 54, 75])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SIFJBI = 280
-SIPMDM = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-SIRYXB = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-SJMCBF = "".join(chr(c) for c in [80, 53])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-SKSOKP = 370
-SKWIVD = "".join(chr(c) for c in [75, 52, 48, 48])
-SNQLNM = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-SOKPHU = 303
-SOOQNR = "".join(chr(c) for c in [72, 73, 71, 72])
-SPBWJY = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-SPFTSI = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-SRURAZ = "".join(chr(c) for c in [67, 70, 71, 49])
-SSRURA = 448
-SSUHBV = "".join(chr(c) for c in [105, 110, 88, 69])
-STSEMC = "".join(chr(c) for c in [70, 97, 110])
-SUHBVW = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-SXUJUT = 310
-TACCPQ = 264
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TDKHTZ = 453
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-TDZXNQ = "".join(chr(c) for c in [72, 84, 82])
-TFMNHT = 294
-TGCRHY = 479
-THBSKS = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-TIDUBS = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-TIXQVX = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-TOPHUG = 300
-TSIFJB = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-TTGCRH = 256
-TTIDUB = 287
-TYEKCW = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-TYIYWS = "".join(chr(c) for c in [70, 117, 108, 108])
-TZBBEK = 455
-UBJLOI = 465
-UBSSUH = 289
-UBYGDS = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-UEUHNN = 470
-UGSELH = "".join(chr(c) for c in [45, 45, 45])
-UGTYIY = 316
-UHBVWV = "".join(chr(c) for c in [77, 73, 65])
-UHNNXW = 471
-UIKFWR = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-UJUTYE = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-UNRJZT = 322
-UNXNKM = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-UOJRJH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-UQEXLS = 5
-URAZMK = "".join(chr(c) for c in [67, 70, 71, 50])
-USOOQN = 261
-UTOPHU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-UXFEFJ = "".join(chr(c) for c in [83, 84, 79, 80])
-UYNQJY = 270
-VCYWON = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-VDNQGV = "".join(chr(c) for c in [75, 53])
-VDQLAI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-VDSSRU = 348
-VEMVCY = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-VHFTHE = 6
-VKZILX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-VLASSA = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-VOACMC = 345
-VUBYGD = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-VUNXNK = "".join(chr(c) for c in [75, 51, 48, 48])
-VWVUBY = "".join(chr(c) for c in [105, 110, 88, 77])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-WAONPY = 367
-WBSIRY = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-WDAFIK = "".join(chr(c) for c in [80, 52, 76])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-WIVDNQ = "".join(chr(c) for c in [75, 56])
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-WMNZMJ = "".join(chr(c) for c in [67, 80, 79, 84])
-WONFZC = 373
-WRKINE = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WSKWIV = "".join(chr(c) for c in [75, 50, 48, 48])
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-WVUBYG = "".join(chr(c) for c in [75, 54, 48, 48])
-XAIVEM = 478
-XBQFYL = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-XCHWDA = "".join(chr(c) for c in [80, 51, 72])
-XEKVKZ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-XFEFJT = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-XFUBJL = 464
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-XLSXUJ = 7
-XNKMLO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-XNQTMF = 327
-XOIHBX = 340
-XPICXQ = "".join(chr(c) for c in [72, 73])
-XQGLRA = 258
-XQIEFX = "".join(chr(c) for c in [85, 100, 80, 50])
-XSJWMN = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-XTIACQ = 315
-XUJUTY = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-XWAJVD = 354
-XWEEZF = 473
-XYBQSN = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-YBQSNQ = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-YEKCWA = 364
-YFCRTF = 291
-YKLGQP = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-YLIUXF = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-YLJUIK = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-YMOUNB = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-YNQJYM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-YOUSPB = "".join(chr(c) for c in [77, 69, 68])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-YWSKWI = 357
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 56])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-ZDGKEA = 330
-ZFETDR = 475
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-ZMJIGY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-ZMKQTD = 451
-ZOLSIP = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-ZTATDZ = 324
-ZUQEXL = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-ZVOACM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-AIIDNI = [HECVYY, LAIIDN, LAIIDN, LAIIDN]
-DZXNQT = [
-    HBQNRX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TDZXNQ,
-]
-FJTACC = [IUXFEF, UXFEFJ, XFEFJT, FEFJTA, EFJTAC]
-FWRKIN = [
-    IUXFEF,
-    QFYLJU,
-    FYLJUI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    YLJUIK,
-    LJUIKF,
-    JUIKFW,
-    UIKFWR,
-    IKFWRK,
-    KFWRKI,
-]
-IKJPUN = [
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-    WDAFIK,
-    SJMCBF,
-    DAFIKJ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    AFIKJP,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    FIKJPU,
-]
-JVYFCR = [JJJVYF, JJVYFC]
-LSIPMD = [FZCZOL, ZCZOLS, CZOLSI, ZOLSIP, OLSIPM]
-LSPFTS = [HECVYY, PLSPFT, PLSPFT, PLSPFT]
-MCBFEG = [ASSAKQ, SOOQNR]
-MDMPSC = []
-MPSCTT = [
-    IUSOOQ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    ZUQEXL,
-    QEXLSX,
-    EXLSXU,
-    LSXUJU,
-    TYEKCW,
-    EKCWAO,
-    CWAONP,
-    DMPSCT,
-]
-NXNKML = [
-    WSKWIV,
-    SKWIVD,
-    KWIVDN,
-    WIVDNQ,
-    IVDNQG,
-    VDNQGV,
-    DNQGVU,
-    NQGVUN,
-    QGVUNX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-]
-OQNRSJ = [ASSAKQ, SOOQNR, OOQNRS]
-PICXQI = [ASSAKQ, QXPICX, XPICXQ]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PSCTTG = [
-    AKQXPI,
-    XQIEFX,
-    IEFXQG,
-    EFXQGL,
-    FXQGLR,
-    GLRAHE,
-    HEOCTH,
-    OCTHBS,
-    THBSKS,
-    BSKSOK,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-]
-QGLRAH = [ASSAKQ, XPICXQ]
-QRJJJV = [SBDJQR, BDJQRJ, DJQRJJ, JQRJJJ]
-RAHEOC = [ASSAKQ, LRAHEO]
-SCTTGC = [
-    IACQFF,
-    VKZILX,
-    ILXWAJ,
-    NQLNMH,
-    YKLGQP,
-    IIDNIB,
-    TIACQF,
-    ACQFFT,
-    SPFTSI,
-    JWMNZM,
-    XEKVKZ,
-    NMHXEK,
-    IBXYBQ,
-    BIAMJM,
-    BXTIAC,
-    LNMHXE,
-    EKVKZI,
-    HXEKVK,
-    QSNQLN,
-    LXWAJV,
-    YBQSNQ,
-    BXYBQS,
-    KZILXW,
-    JVDQLA,
-    ZILXWA,
-    XYBQSN,
-    MHXEKV,
-    QLNMHX,
-    SNQLNM,
-]
-SELHBQ = [UGSELH, GSELHB]
-SSAKQX = [IVLASS, VLASSA, LASSAK, ASSAKQ]
-TSEMCG = [
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-    WDAFIK,
-    SJMCBF,
-    DAFIKJ,
-    BFEGZU,
-    FEGZUQ,
-    GZUQEX,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    AFIKJP,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EXLSXU,
-    FIKJPU,
-]
-USPBWJ = [GYOUSP, QXPICX, YOUSPB, XPICXQ, OUSPBW]
-UTYEKC = [XUJUTY, UJUTYE, JUTYEK]
-XQVXOI = [
-    HBQNRX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    BFEGZU,
-]
-YGDSBD = [
-    BSSUHB,
-    SSUHBV,
-    SUHBVW,
-    UHBVWV,
-    HBVWVU,
-    BVWVUB,
-    VWVUBY,
-    WVUBYG,
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-]
-YIYWSK = [GTYIYW, TYIYWS]
-YXBQFY = [IRYXBQ, RYXBQF]
-YYLIUX = [NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1344,328 +19,1233 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return CTTGCR
+        return 62
 
     @property
     def begin(self):
-        return TTGCRH
+        return 256
 
     @property
     def end(self):
-        return TGCRHY
+        return 479
 
     @property
     def all_device_keys(self):
-        return MPSCTT
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return PSCTTG
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return SCTTGC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, SSAKQX, None, None, SAKQXP
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, ICXQIE, PICXQI, None, CXQIEF, SAKQXP
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, KQXPIC, QIEFXQ, PICXQI, None, CXQIEF, SAKQXP
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, KQXPIC, CXQIEF, PICXQI, None, CXQIEF, SAKQXP
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, KQXPIC, VHFTHE, PICXQI, None, CXQIEF, SAKQXP
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, ICXQIE, QGLRAH, None, QIEFXQ, SAKQXP
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XQGLRA, AHEOCT, RAHEOC, None, QIEFXQ, SAKQXP
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, None, RAHEOC, None, None, SAKQXP
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            OCTHBS: GeckoEnumStructAccessor(
-                self.struct, OCTHBS, CTHBSK, None, QGLRAH, None, None, SAKQXP
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, None, RAHEOC, None, None, SAKQXP
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, SKSOKP, None, RAHEOC, None, None, SAKQXP
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            KSOKPH: GeckoByteStructAccessor(self.struct, KSOKPH, SOKPHU, SAKQXP),
-            OKPHUO: GeckoByteStructAccessor(self.struct, OKPHUO, KPHUOJ, SAKQXP),
-            PHUOJR: GeckoByteStructAccessor(self.struct, PHUOJR, HUOJRJ, SAKQXP),
-            UOJRJH: GeckoByteStructAccessor(self.struct, UOJRJH, OJRJHI, SAKQXP),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, SAKQXP),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, SAKQXP),
-            IUSOOQ: GeckoEnumStructAccessor(
-                self.struct, IUSOOQ, USOOQN, ICXQIE, OQNRSJ, None, CXQIEF, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            QNRSJM: GeckoEnumStructAccessor(
-                self.struct, QNRSJM, USOOQN, QIEFXQ, OQNRSJ, None, CXQIEF, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, USOOQN, CXQIEF, OQNRSJ, None, CXQIEF, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, USOOQN, VHFTHE, OQNRSJ, None, CXQIEF, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, ICXQIE, MCBFEG, None, QIEFXQ, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, JMCBFE, AHEOCT, RAHEOC, None, QIEFXQ, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, JMCBFE, QIEFXQ, RAHEOC, None, QIEFXQ, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, EGZUQE, RAHEOC, None, QIEFXQ, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, CXQIEF, RAHEOC, None, QIEFXQ, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, JMCBFE, UQEXLS, RAHEOC, None, QIEFXQ, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, JMCBFE, VHFTHE, RAHEOC, None, QIEFXQ, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, JMCBFE, XLSXUJ, RAHEOC, None, QIEFXQ, None
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, SXUJUT, None, UTYEKC, None, None, SAKQXP
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, YEKCWA, None, UTYEKC, None, None, None
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            EKCWAO: GeckoWordStructAccessor(self.struct, EKCWAO, KCWAON, None),
-            CWAONP: GeckoWordStructAccessor(self.struct, CWAONP, WAONPY, SAKQXP),
-            AONPYY: GeckoEnumStructAccessor(
-                self.struct, AONPYY, ONPYYL, ICXQIE, YYLIUX, None, QIEFXQ, SAKQXP
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, FJTACC, None, None, SAKQXP
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoTimeStructAccessor(self.struct, JTACCP, TACCPQ, SAKQXP),
-            ACCPQI: GeckoByteStructAccessor(self.struct, ACCPQI, CCPQIP, SAKQXP),
-            CPQIPO: GeckoEnumStructAccessor(
-                self.struct, CPQIPO, ONPYYL, QIEFXQ, YYLIUX, None, QIEFXQ, SAKQXP
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            PQIPOU: GeckoEnumStructAccessor(
-                self.struct, PQIPOU, QIPOUY, None, FJTACC, None, None, SAKQXP
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            IPOUYN: GeckoTimeStructAccessor(self.struct, IPOUYN, POUYNQ, SAKQXP),
-            OUYNQJ: GeckoByteStructAccessor(self.struct, OUYNQJ, UYNQJY, SAKQXP),
-            YNQJYM: GeckoByteStructAccessor(self.struct, YNQJYM, NQJYMO, SAKQXP),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, SAKQXP),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, ONPYYL, AHEOCT, YYLIUX, None, QIEFXQ, SAKQXP
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, FJTACC, None, None, SAKQXP
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, SAKQXP),
-            BLKXSJ: GeckoBoolStructAccessor(self.struct, BLKXSJ, LKXSJW, ICXQIE, None),
-            KXSJWM: GeckoBoolStructAccessor(self.struct, KXSJWM, LKXSJW, QIEFXQ, None),
-            XSJWMN: GeckoBoolStructAccessor(self.struct, XSJWMN, LKXSJW, EGZUQE, None),
-            SJWMNZ: GeckoBoolStructAccessor(self.struct, SJWMNZ, LKXSJW, CXQIEF, None),
-            JWMNZM: GeckoBoolStructAccessor(self.struct, JWMNZM, LKXSJW, UQEXLS, None),
-            WMNZMJ: GeckoBoolStructAccessor(self.struct, WMNZMJ, JVHFTH, QIEFXQ, None),
-            MNZMJI: GeckoBoolStructAccessor(self.struct, MNZMJI, NZMJIG, EGZUQE, None),
-            ZMJIGY: GeckoBoolStructAccessor(self.struct, ZMJIGY, NZMJIG, UQEXLS, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, NZMJIG, VHFTHE, None),
-            JIGYOU: GeckoEnumStructAccessor(
-                self.struct, JIGYOU, IGYOUS, None, USPBWJ, None, None, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, PBWJYK, UQEXLS, None),
-            BWJYKL: GeckoBoolStructAccessor(self.struct, BWJYKL, PBWJYK, VHFTHE, None),
-            WJYKLG: GeckoWordStructAccessor(self.struct, WJYKLG, JYKLGQ, None),
-            YKLGQP: GeckoBoolStructAccessor(self.struct, YKLGQP, JVHFTH, AHEOCT, None),
-            KLGQPL: GeckoTempStructAccessor(self.struct, KLGQPL, LGQPLS, None),
-            GQPLSP: GeckoTempStructAccessor(self.struct, GQPLSP, QPLSPF, None),
-            PLSPFT: GeckoEnumStructAccessor(
-                self.struct, PLSPFT, JMCBFE, UQEXLS, LSPFTS, None, CXQIEF, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            SPFTSI: GeckoBoolStructAccessor(self.struct, SPFTSI, PFTSIF, QIEFXQ, None),
-            FTSIFJ: GeckoBoolStructAccessor(self.struct, FTSIFJ, PFTSIF, VHFTHE, None),
-            TSIFJB: GeckoBoolStructAccessor(self.struct, TSIFJB, SIFJBI, QIEFXQ, None),
-            IFJBIA: GeckoBoolStructAccessor(self.struct, IFJBIA, FJBIAM, AHEOCT, None),
-            JBIAMJ: GeckoBoolStructAccessor(
-                self.struct, JBIAMJ, FJBIAM, QIEFXQ, SAKQXP
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, AHEOCT, None),
-            AMJMAO: GeckoByteStructAccessor(self.struct, AMJMAO, MJMAOA, None),
-            JMAOAW: GeckoBoolStructAccessor(self.struct, JMAOAW, MAOAWB, ICXQIE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, ICXQIE, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, OAWBSI, CXQIEF, None),
-            WBSIRY: GeckoBoolStructAccessor(self.struct, WBSIRY, OAWBSI, UQEXLS, None),
-            BSIRYX: GeckoBoolStructAccessor(self.struct, BSIRYX, OAWBSI, VHFTHE, None),
-            SIRYXB: GeckoEnumStructAccessor(
-                self.struct, SIRYXB, OAWBSI, XLSXUJ, YXBQFY, None, QIEFXQ, SAKQXP
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            XBQFYL: GeckoEnumStructAccessor(
-                self.struct, XBQFYL, BQFYLJ, None, FWRKIN, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            WRKINE: GeckoBoolStructAccessor(self.struct, WRKINE, RKINEJ, ICXQIE, None),
-            KINEJN: GeckoBoolStructAccessor(self.struct, KINEJN, RKINEJ, AHEOCT, None),
-            INEJNI: GeckoBoolStructAccessor(self.struct, INEJNI, NEJNIB, ICXQIE, None),
-            EJNIBX: GeckoBoolStructAccessor(self.struct, EJNIBX, NEJNIB, AHEOCT, None),
-            JNIBXY: GeckoBoolStructAccessor(self.struct, JNIBXY, NIBXYB, ICXQIE, None),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, JVHFTH, EGZUQE, None),
-            BXYBQS: GeckoBoolStructAccessor(self.struct, BXYBQS, NZMJIG, ICXQIE, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, NZMJIG, AHEOCT, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, QIEFXQ, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, EGZUQE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, RKINEJ, EGZUQE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, RKINEJ, CXQIEF, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, RKINEJ, UQEXLS, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, RKINEJ, VHFTHE, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, NEJNIB, EGZUQE, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, NEJNIB, CXQIEF, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, NEJNIB, UQEXLS, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, NEJNIB, VHFTHE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, KVKZIL, QIEFXQ, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KVKZIL, EGZUQE, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, IAMJMA, EGZUQE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, PBWJYK, ICXQIE, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, PBWJYK, AHEOCT, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, XWAJVD, ICXQIE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, SIFJBI, ICXQIE, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, BQSNQL, ICXQIE, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, BQSNQL, AHEOCT, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, BQSNQL, CXQIEF, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, QLAIID, ICXQIE, None),
-            LAIIDN: GeckoEnumStructAccessor(
-                self.struct, LAIIDN, QLAIID, AHEOCT, AIIDNI, None, CXQIEF, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, QLAIID, EGZUQE, None),
-            IDNIBX: GeckoWordStructAccessor(self.struct, IDNIBX, DNIBXT, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, IBXTIA, ICXQIE, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, XTIACQ, ICXQIE, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, XTIACQ, AHEOCT, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, KVKZIL, ICXQIE, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, KVKZIL, AHEOCT, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, KVKZIL, CXQIEF, None),
-            QFFTTI: GeckoWordStructAccessor(self.struct, QFFTTI, FFTTID, None),
-            FTTIDU: GeckoByteStructAccessor(self.struct, FTTIDU, TTIDUB, None),
-            TIDUBS: GeckoByteStructAccessor(self.struct, TIDUBS, IDUBSS, None),
-            DUBSSU: GeckoEnumStructAccessor(
-                self.struct, DUBSSU, UBSSUH, None, YGDSBD, None, None, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            GDSBDJ: GeckoEnumStructAccessor(
-                self.struct, GDSBDJ, DSBDJQ, ICXQIE, QRJJJV, None, CXQIEF, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            RJJJVY: GeckoEnumStructAccessor(
-                self.struct, RJJJVY, DSBDJQ, QIEFXQ, JVYFCR, None, QIEFXQ, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            VYFCRT: GeckoWordStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoByteStructAccessor(self.struct, RTFMNH, TFMNHT, None),
-            FMNHTB: GeckoByteStructAccessor(self.struct, FMNHTB, MNHTBJ, None),
-            NHTBJE: GeckoByteStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoWordStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoWordStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, None, YIYWSK, None, QIEFXQ, SAKQXP
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            IYWSKW: GeckoEnumStructAccessor(
-                self.struct, IYWSKW, YWSKWI, None, NXNKML, None, None, None
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            XNKMLO: GeckoWordStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoByteStructAccessor(self.struct, KMLOIJ, MLOIJU, None),
-            LOIJUG: GeckoByteStructAccessor(self.struct, LOIJUG, OIJUGS, None),
-            IJUGSE: GeckoEnumStructAccessor(
-                self.struct, IJUGSE, JUGSEL, None, SELHBQ, None, None, SAKQXP
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            ELHBQN: GeckoEnumStructAccessor(
-                self.struct, ELHBQN, LHBQNR, None, IKJPUN, None, None, SAKQXP
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            KJPUNR: GeckoEnumStructAccessor(
-                self.struct, KJPUNR, JPUNRJ, None, IKJPUN, None, None, SAKQXP
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, IKJPUN, None, None, SAKQXP
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            NRJZTA: GeckoEnumStructAccessor(
-                self.struct, NRJZTA, RJZTAT, None, IKJPUN, None, None, SAKQXP
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            JZTATD: GeckoEnumStructAccessor(
-                self.struct, JZTATD, ZTATDZ, None, IKJPUN, None, None, SAKQXP
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, ATDZXN, None, DZXNQT, None, None, SAKQXP
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            ZXNQTM: GeckoByteStructAccessor(self.struct, ZXNQTM, XNQTMF, SAKQXP),
-            NQTMFZ: GeckoByteStructAccessor(self.struct, NQTMFZ, QTMFZD, SAKQXP),
-            TMFZDG: GeckoByteStructAccessor(self.struct, TMFZDG, MFZDGK, SAKQXP),
-            FZDGKE: GeckoByteStructAccessor(self.struct, FZDGKE, ZDGKEA, SAKQXP),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, SAKQXP),
-            KEAKST: GeckoByteStructAccessor(self.struct, KEAKST, EAKSTS, SAKQXP),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, TSEMCG, None, None, SAKQXP
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, ATDZXN, None, TSEMCG, None, None, SAKQXP
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, XNQTMF, None, TSEMCG, None, None, SAKQXP
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, QTMFZD, None, TSEMCG, None, None, SAKQXP
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, MFZDGK, None, TSEMCG, None, None, SAKQXP
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ZDGKEA, None, TSEMCG, None, None, SAKQXP
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, GKEAKS, None, TSEMCG, None, None, SAKQXP
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            TIXQVX: GeckoEnumStructAccessor(
-                self.struct, TIXQVX, IXQVXO, None, XQVXOI, None, None, SAKQXP
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, EAKSTS, None, XQVXOI, None, None, SAKQXP
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, SAKQXP),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, SAKQXP),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, SAKQXP),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, SAKQXP),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, SAKQXP),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, SAKQXP),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, SAKQXP),
-            CMCVDS: GeckoByteStructAccessor(self.struct, CMCVDS, MCVDSS, SAKQXP),
-            CVDSSR: GeckoByteStructAccessor(self.struct, CVDSSR, VDSSRU, SAKQXP),
-            VEMVCY: GeckoBoolStructAccessor(self.struct, VEMVCY, JVHFTH, UQEXLS, None),
-            EMVCYW: GeckoByteStructAccessor(self.struct, EMVCYW, MVCYWO, SAKQXP),
-            VCYWON: GeckoByteStructAccessor(self.struct, VCYWON, CYWONF, SAKQXP),
-            YWONFZ: GeckoByteStructAccessor(self.struct, YWONFZ, WONFZC, SAKQXP),
-            ONFZCZ: GeckoEnumStructAccessor(
-                self.struct, ONFZCZ, NFZCZO, None, LSIPMD, None, None, SAKQXP
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            SIPMDM: GeckoBoolStructAccessor(
-                self.struct, SIPMDM, IPMDMP, ICXQIE, SAKQXP
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
             ),
-            PMDMPS: GeckoBoolStructAccessor(self.struct, PMDMPS, JUGSEL, ICXQIE, None),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-63.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-63.py
@@ -12,1384 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [73, 68, 76, 69])
-ACMCVD = 342
-ACQFFT = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-AFIKJP = "".join(chr(c) for c in [80, 49, 76])
-AHEOCT = "".join(chr(c) for c in [85, 100, 80, 51])
-AIIDNI = 354
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-AJVDQL = 351
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-AMJMAO = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-AOAWBS = 281
-AONPYY = "".join(chr(c) for c in [70, 85, 76, 76])
-ATDZXN = 321
-AWBSIR = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-AXNCUG = 256
-AZMKQT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-BBEKBD = 452
-BDFSRO = 454
-BDJQRJ = "".join(chr(c) for c in [75, 54, 48, 48])
-BEKBDF = "".join(chr(c) for c in [67, 70, 71, 53])
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-BIAMJM = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-BJEUTO = 293
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-BLKXSJ = 271
-BMJVHF = 256
-BQFYLJ = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-BQNRXC = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-BQSNQL = 350
-BSIRYX = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-BSSUHB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-BVWVUB = 288
-BWJYKL = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-BXIBHZ = 332
-BXTIAC = 309
-BXYBQS = 284
-BYGDSB = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-CBFEGZ = "".join(chr(c) for c in [76, 79, 87])
-CCPQIP = "".join(chr(c) for c in [83, 84, 79, 80])
-CGETIX = 333
-CHWDAF = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-CMCVDS = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-CPQIPO = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-CQBMJV = 317
-CQFFTT = 311
-CRHYUA = "".join(chr(c) for c in [76, 73])
-CTTGCR = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-CVDSSR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-CXQIEF = "".join(chr(c) for c in [79, 70, 70])
-CYWONF = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-DAFIKJ = "".join(chr(c) for c in [80, 49, 72])
-DDPMXF = 458
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 55])
-DGKEAK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-DJQRJJ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-DKHTZB = "".join(chr(c) for c in [67, 70, 71, 50])
-DMPSCT = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-DNIBXT = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-DNQGVU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-DQLAII = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-DRXAIV = 473
-DSBDJQ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-DSSRUR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-DUBSSU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-DZXNQT = 322
-EAKSTS = 328
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 470
-EFJTAC = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-EFXQGL = "".join(chr(c) for c in [76, 79])
-EGZUQE = "".join(chr(c) for c in [80, 51])
-EJNIBX = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-EKBDFS = 453
-EKCWAO = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-EKVKZI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-ELHBQN = 360
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-EMCGET = 331
-EMVCYW = 476
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 53])
-ETDRXA = 472
-ETIXQV = 325
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-EUTOPH = 294
-EXLSXU = "".join(chr(c) for c in [66, 76])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-FCRTFM = "".join(chr(c) for c in [54, 52, 75])
-FEFJTA = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-FEGZUQ = "".join(chr(c) for c in [80, 50])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-FFTTID = 314
-FIKJPU = "".join(chr(c) for c in [80, 50, 72])
-FJBIAM = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-FMNHTB = "".join(chr(c) for c in [67, 69])
-FSROGM = 455
-FTHECV = 319
-FTSIFJ = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-FTTIDU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-FWRKIN = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-FXQGLR = "".join(chr(c) for c in [72, 73])
-FYLJUI = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-FZCZOL = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-FZDGKE = "".join(chr(c) for c in [72, 84, 82])
-GDSBDJ = "".join(chr(c) for c in [68, 74, 83, 52])
-GETIXQ = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-GKEAKS = 327
-GLRAHE = 4
-GMDDPM = 457
-GQPLSP = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-GSELHB = 358
-GTYIYW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GVUNXN = "".join(chr(c) for c in [75, 52, 48, 48])
-GYOUSP = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-GZUQEX = "".join(chr(c) for c in [80, 52])
-HBQNRX = 361
-HBSKSO = "".join(chr(c) for c in [79, 78])
-HBVWVU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-HBXIBH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = "".join(chr(c) for c in [85, 100, 80, 52])
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = 304
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-HTBJEU = 291
-HTZBBE = "".join(chr(c) for c in [67, 70, 71, 51])
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-HUOJRJ = 363
-HWDAFI = 320
-HXEKVK = 283
-HZVOAC = 340
-IACQFF = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-IAMJMA = 279
-IBHZVO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-IBXTIA = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-IBXYBQ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-ICXQIE = "".join(chr(c) for c in [83, 79, 65, 75])
-IDNIBX = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IDUBSS = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-IEFXQG = 259
-IFJBIA = 277
-IGYOUS = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-IIDNIB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IJUGSE = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-IKFWRK = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-IKJPUN = "".join(chr(c) for c in [80, 50, 76])
-ILXWAJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-INEJNI = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-INELWU = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = 374
-IRYXBQ = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-IUSOOQ = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-IUXFEF = 367
-IVDNQG = "".join(chr(c) for c in [70, 117, 108, 108])
-IVEMVC = 475
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IYWSKW = 300
-JEUTOP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-JHIUSO = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-JIGYOU = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-JJJVYF = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-JJVYFC = 290
-JLOINE = 462
-JMAOAW = 280
-JMCBFE = 261
-JNIBXY = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-JPUNRJ = "".join(chr(c) for c in [80, 51, 76])
-JQRJJJ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-JRJHIU = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-JTACCP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-JUIKFW = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-JUTYEK = 5
-JVDQLA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [49, 54, 75])
-JWMNZM = 380
-JYKLGQ = "".join(chr(c) for c in [78, 79])
-JYMOUN = 267
-JZTATD = "".join(chr(c) for c in [65, 85, 88])
-KBDFSR = "".join(chr(c) for c in [67, 70, 71, 54])
-KCWAON = 310
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KFWRKI = 379
-KHTZBB = 450
-KINEJN = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-KJPUNR = "".join(chr(c) for c in [80, 51, 72])
-KLGQPL = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-KMLOIJ = "".join(chr(c) for c in [75, 49, 48, 48])
-KPHUOJ = 307
-KQTDKH = 448
-KQXPIC = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-KSOKPH = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KSTSEM = 329
-KVKZIL = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-KWIVDN = 316
-KXSJWM = 272
-KZILXW = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-LAIIDN = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LHBQNR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-LIUXFE = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-LJUIKF = "".join(chr(c) for c in [72, 69, 65, 84])
-LKXSJW = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-LNMHXE = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LOIJUG = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-LRAHEO = "".join(chr(c) for c in [85, 100, 80, 50])
-LSIPMD = 373
-LSPFTS = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-LSXUJU = "".join(chr(c) for c in [79, 51])
-LWUEUH = 465
-LXWAJV = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-MAOAWB = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-MCBFEG = "".join(chr(c) for c in [72, 73, 71, 72])
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-MCVDSS = 343
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-MDMPSC = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-MFZDGK = 326
-MHXEKV = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-MJIGYO = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-MJMAOA = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [67, 70, 71, 48])
-MLOIJU = "".join(chr(c) for c in [75, 56, 48, 48])
-MNZMJI = 381
-MOUNBL = 268
-MPSCTT = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-MVCYWO = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-NBLKXS = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-NEJNIB = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-NELWUE = 464
-NFZCZO = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-NHTBJE = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-NIBXTI = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-NKMLOI = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-NMHXEK = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-NNXWEE = 468
-NPYYLI = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-NQGVUN = 357
-NQJYMO = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-NQLNMH = 383
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-NRJZTA = "".join(chr(c) for c in [66, 76, 79])
-NRSJMC = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-NRXCHW = "".join(chr(c) for c in [45, 45, 45])
-NXNKML = "".join(chr(c) for c in [75, 52])
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-NZMJIG = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-OAWBSI = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-OCTHBS = 258
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 57])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-OIJUGS = "".join(chr(c) for c in [75, 51, 48, 48])
-OINELW = 463
-OJRJHI = 370
-OKPHUO = "".join(chr(c) for c in [85, 100, 76, 105])
-OLSIPM = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-ONFZCZ = 479
-OOQNRS = 306
-OPHUGT = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-OQNRSJ = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-OUNBLK = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-OUSPBW = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-OUYNQJ = 264
-PBWJYK = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-PFTSIF = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-PHUGTY = 296
-PHUOJR = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-PICXQI = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-PIVLAS = 385
-PLSPFT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PMDMPS = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-PMXFUB = 459
-POUYNQ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-PQIPOU = "".join(chr(c) for c in [78, 69, 87])
-PSCTTG = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-PUNRJZ = "".join(chr(c) for c in [80, 52, 72])
-PYYLIU = 364
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QFFTTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-QFYLJU = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-QGLRAH = 0
-QGVUNX = "".join(chr(c) for c in [75, 50, 48, 48])
-QIEFXQ = "".join(chr(c) for c in [85, 100, 80, 49])
-QIPOUY = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-QJYMOU = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-QLAIID = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-QLNMHX = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-QNRSJM = 362
-QNRXCH = 376
-QPLSPF = 353
-QRJJJV = "".join(chr(c) for c in [105, 110, 89, 84])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-QTDKHT = "".join(chr(c) for c in [67, 70, 71, 49])
-QTMFZD = 324
-QVXOIH = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-QXPICX = 257
-RAHEOC = 2
-RAZMKQ = 347
-RJHIUS = 303
-RJZTAT = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-RKINEJ = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-ROGMDD = 456
-RSJMCB = 369
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-RURAZM = 346
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-RXCHWD = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-RYXBQF = 384
-SAKQXP = 386
-SBDJQR = "".join(chr(c) for c in [105, 110, 88, 77])
-SELHBQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-SIFJBI = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-SIPMDM = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-SIRYXB = 377
-SJMCBF = "".join(chr(c) for c in [80, 49])
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        79,
-        110,
-        122,
-        101,
-        110,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-SKSOKP = 1
-SKWIVD = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-SOKPHU = 308
-SOOQNR = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-SPBWJY = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-SPFTSI = 355
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 56])
-SRURAZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = 345
-SSUHBV = 285
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-SUHBVW = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-SXUJUT = 3
-TACCPQ = 263
-TATDZX = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-TBJEUT = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TDKHTZ = 449
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-TDZXNQ = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-TFMNHT = "".join(chr(c) for c in [85, 76])
-TGCRHY = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-THBSKS = "".join(chr(c) for c in [85, 100, 66, 76])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIDUBS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-TIXQVX = "".join(chr(c) for c in [70, 97, 110])
-TMFZDG = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-TOPHUG = 295
-TSEMCG = 330
-TSIFJB = 275
-TTGCRH = 375
-TTIDUB = 315
-TYEKCW = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-TYIYWS = 299
-TZBBEK = 451
-UAXNCU = 63
-UBJLOI = 461
-UBSSUH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-UBYGDS = "".join(chr(c) for c in [105, 110, 88, 69])
-UEUHNN = 466
-UGSELH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UGTYIY = 297
-UHBVWV = 287
-UHNNXW = 467
-UJUTYE = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-UNBLKX = 270
-UNRJZT = "".join(chr(c) for c in [80, 52, 76])
-UNXNKM = "".join(chr(c) for c in [75, 56])
-UOJRJH = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-UQEXLS = 260
-URAZMK = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-USOOQN = 305
-USPBWJ = 282
-UTOPHU = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-UTYEKC = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-UXFEFJ = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-VCYWON = 477
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-VDSSRU = 344
-VEMVCY = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = 341
-VUBYGD = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-VUNXNK = "".join(chr(c) for c in [75, 56, 53])
-VWVUBY = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-VYFCRT = "".join(chr(c) for c in [51, 50, 75])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-WAONPY = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-WBSIRY = 352
-WDAFIK = "".join(chr(c) for c in [78, 65])
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-WIVDNQ = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-WJYKLG = 313
-WMNZMJ = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 79, 110, 122, 101, 110, 68, 117, 114]
-)
-WONFZC = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-WRKINE = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-WSKWIV = 301
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-WVUBYG = 289
-XAIVEM = 474
-XBQFYL = 378
-XEKVKZ = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-XFEFJT = 262
-XFUBJL = 460
-XLSXUJ = "".join(chr(c) for c in [67, 80])
-XNCUGU = 479
-XNKMLO = "".join(chr(c) for c in [75, 53])
-XNQTMF = 323
-XOIHBX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-XPICXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-XSJWMN = "".join(chr(c) for c in [79, 110, 122, 101, 110, 65, 99, 99, 101, 115, 115])
-XTIACQ = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-XUJUTY = "".join(chr(c) for c in [76, 49, 50, 48])
-XWAJVD = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-XWEEZF = 469
-XYBQSN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-YEKCWA = 7
-YFCRTF = "".join(chr(c) for c in [52, 56, 75])
-YGDSBD = "".join(chr(c) for c in [77, 73, 65])
-YIYWSK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-YKLGQP = "".join(chr(c) for c in [77, 69, 68])
-YLIUXF = 365
-YLJUIK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-YMOUNB = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-YNQJYM = 266
-YOUSPB = "".join(chr(c) for c in [67, 80, 79, 84])
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YWONFZ = 478
-YWSKWI = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-YXBQFY = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-YYLIUX = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [67, 70, 71, 52])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = 371
-ZFETDR = 471
-ZILXWA = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-ZMJIGY = 273
-ZMKQTD = 348
-ZOLSIP = 372
-ZUQEXL = "".join(chr(c) for c in [80, 53])
-ZVOACM = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-ZXNQTM = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-BFEGZU = [CXQIEF, MCBFEG, CBFEGZ]
-BSKSOK = [CXQIEF, HBSKSO]
-CRTFMN = [JVYFCR, VYFCRT, YFCRTF, FCRTFM]
-CTHBSK = [CXQIEF, FXQGLR]
-FJTACC = [FEFJTA, EFJTAC]
-GCRHYU = []
-HYUAXN = [
-    QIEFXQ,
-    LRAHEO,
-    AHEOCT,
-    HEOCTH,
-    EOCTHB,
-    THBSKS,
-    KSOKPH,
-    OKPHUO,
-    PHUOJR,
-    UOJRJH,
-    JRJHIU,
-    JHIUSO,
-    IUSOOQ,
-    SOOQNR,
-    OQNRSJ,
-    NRSJMC,
-]
-IPOUYN = [ACCPQI, CCPQIP, CPQIPO, PQIPOU, QIPOUY]
-IXQVXO = [
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    ZUQEXL,
-    NRJZTA,
-    XLSXUJ,
-    LSXUJU,
-    XUJUTY,
-    HECVYY,
-    HECVYY,
-    TIXQVX,
-    HECVYY,
-    HECVYY,
-    RJZTAT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TYEKCW,
-    JZTATD,
-]
-JBIAMJ = [HECVYY, FJBIAM, FJBIAM, FJBIAM]
-JUGSEL = [
-    QGVUNX,
-    GVUNXN,
-    VUNXNK,
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-]
-LGQPLS = [JYKLGQ, EFXQGL, YKLGQP, FXQGLR, KLGQPL]
-MNHTBJ = [TFMNHT, FMNHTB]
-NIBXYB = [
-    ACCPQI,
-    FWRKIN,
-    WRKINE,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RKINEJ,
-    KINEJN,
-    INEJNI,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-]
-ONPYYL = [CWAONP, WAONPY, AONPYY]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-QEXLSX = [CXQIEF, MCBFEG]
-RHYUAX = [
-    SJMCBF,
-    FEGZUQ,
-    EGZUQE,
-    GZUQEX,
-    ZUQEXL,
-    EXLSXU,
-    XLSXUJ,
-    LSXUJU,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    NPYYLI,
-    YYLIUX,
-    LIUXFE,
-    CRHYUA,
-]
-RJJJVY = [
-    VUBYGD,
-    UBYGDS,
-    BYGDSB,
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-]
-SCTTGC = [PMDMPS, MDMPSC, DMPSCT, MPSCTT, PSCTTG]
-TIACQF = [HECVYY, XTIACQ, XTIACQ, XTIACQ]
-UIKFWR = [LJUIKF, JUIKFW]
-VDNQGV = [WIVDNQ, IVDNQG]
-XCHWDA = [NRXCHW, RXCHWD]
-XIBHZV = [
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XLSXUJ,
-]
-XQGLRA = [CXQIEF, EFXQGL, FXQGLR]
-XQIEFX = [XPICXQ, PICXQI, ICXQIE, CXQIEF]
-YUAXNC = [
-    IDUBSS,
-    JVDQLA,
-    QLAIID,
-    KVKZIL,
-    PFTSIF,
-    IACQFF,
-    TIDUBS,
-    DUBSSU,
-    BIAMJM,
-    GYOUSP,
-    XWAJVD,
-    ZILXWA,
-    QLNMHX,
-    AWBSIR,
-    FTTIDU,
-    KZILXW,
-    WAJVDQ,
-    LXWAJV,
-    XEKVKZ,
-    LAIIDN,
-    MHXEKV,
-    LNMHXE,
-    VDQLAI,
-    DNIBXT,
-    DQLAII,
-    NMHXEK,
-    ILXWAJ,
-    VKZILX,
-    EKVKZI,
-]
-ZDGKEA = [
-    WDAFIK,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    FZDGKE,
-]
-ZTATDZ = [
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    ZUQEXL,
-    NRJZTA,
-    XLSXUJ,
-    LSXUJU,
-    XUJUTY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    RJZTAT,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TYEKCW,
-    JZTATD,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1397,332 +19,1246 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return UAXNCU
+        return 63
 
     @property
     def begin(self):
-        return AXNCUG
+        return 256
 
     @property
     def end(self):
-        return XNCUGU
+        return 479
 
     @property
     def all_device_keys(self):
-        return RHYUAX
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return HYUAXN
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return YUAXNC
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, XQIEFX, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QIEFXQ: GeckoEnumStructAccessor(
-                self.struct, QIEFXQ, IEFXQG, QGLRAH, XQGLRA, None, GLRAHE, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            LRAHEO: GeckoEnumStructAccessor(
-                self.struct, LRAHEO, IEFXQG, RAHEOC, XQGLRA, None, GLRAHE, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            AHEOCT: GeckoEnumStructAccessor(
-                self.struct, AHEOCT, IEFXQG, GLRAHE, XQGLRA, None, GLRAHE, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, IEFXQG, VHFTHE, XQGLRA, None, GLRAHE, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, OCTHBS, QGLRAH, CTHBSK, None, RAHEOC, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, OCTHBS, SKSOKP, BSKSOK, None, RAHEOC, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, SOKPHU, None, BSKSOK, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OKPHUO: GeckoEnumStructAccessor(
-                self.struct, OKPHUO, KPHUOJ, None, CTHBSK, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            PHUOJR: GeckoEnumStructAccessor(
-                self.struct, PHUOJR, HUOJRJ, None, BSKSOK, None, None, AKQXPI
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            UOJRJH: GeckoEnumStructAccessor(
-                self.struct, UOJRJH, OJRJHI, None, BSKSOK, None, None, AKQXPI
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            JRJHIU: GeckoByteStructAccessor(self.struct, JRJHIU, RJHIUS, AKQXPI),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, AKQXPI),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, AKQXPI),
-            SOOQNR: GeckoByteStructAccessor(self.struct, SOOQNR, OOQNRS, AKQXPI),
-            OQNRSJ: GeckoByteStructAccessor(self.struct, OQNRSJ, QNRSJM, AKQXPI),
-            NRSJMC: GeckoByteStructAccessor(self.struct, NRSJMC, RSJMCB, AKQXPI),
-            SJMCBF: GeckoEnumStructAccessor(
-                self.struct, SJMCBF, JMCBFE, QGLRAH, BFEGZU, None, GLRAHE, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            FEGZUQ: GeckoEnumStructAccessor(
-                self.struct, FEGZUQ, JMCBFE, RAHEOC, BFEGZU, None, GLRAHE, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EGZUQE: GeckoEnumStructAccessor(
-                self.struct, EGZUQE, JMCBFE, GLRAHE, BFEGZU, None, GLRAHE, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            GZUQEX: GeckoEnumStructAccessor(
-                self.struct, GZUQEX, JMCBFE, VHFTHE, BFEGZU, None, GLRAHE, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, UQEXLS, QGLRAH, QEXLSX, None, RAHEOC, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, UQEXLS, SKSOKP, BSKSOK, None, RAHEOC, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            XLSXUJ: GeckoEnumStructAccessor(
-                self.struct, XLSXUJ, UQEXLS, RAHEOC, BSKSOK, None, RAHEOC, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            LSXUJU: GeckoEnumStructAccessor(
-                self.struct, LSXUJU, UQEXLS, SXUJUT, BSKSOK, None, RAHEOC, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, UQEXLS, GLRAHE, BSKSOK, None, RAHEOC, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, UQEXLS, JUTYEK, BSKSOK, None, RAHEOC, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, UQEXLS, VHFTHE, BSKSOK, None, RAHEOC, None
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, UQEXLS, YEKCWA, BSKSOK, None, RAHEOC, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, KCWAON, None, ONPYYL, None, None, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            NPYYLI: GeckoEnumStructAccessor(
-                self.struct, NPYYLI, PYYLIU, None, ONPYYL, None, None, None
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YYLIUX: GeckoWordStructAccessor(self.struct, YYLIUX, YLIUXF, None),
-            LIUXFE: GeckoWordStructAccessor(self.struct, LIUXFE, IUXFEF, AKQXPI),
-            UXFEFJ: GeckoEnumStructAccessor(
-                self.struct, UXFEFJ, XFEFJT, QGLRAH, FJTACC, None, RAHEOC, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            JTACCP: GeckoEnumStructAccessor(
-                self.struct, JTACCP, TACCPQ, None, IPOUYN, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            POUYNQ: GeckoTimeStructAccessor(self.struct, POUYNQ, OUYNQJ, AKQXPI),
-            UYNQJY: GeckoByteStructAccessor(self.struct, UYNQJY, YNQJYM, AKQXPI),
-            NQJYMO: GeckoEnumStructAccessor(
-                self.struct, NQJYMO, XFEFJT, RAHEOC, FJTACC, None, RAHEOC, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, None, IPOUYN, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            YMOUNB: GeckoTimeStructAccessor(self.struct, YMOUNB, MOUNBL, AKQXPI),
-            OUNBLK: GeckoByteStructAccessor(self.struct, OUNBLK, UNBLKX, AKQXPI),
-            NBLKXS: GeckoByteStructAccessor(self.struct, NBLKXS, BLKXSJ, AKQXPI),
-            LKXSJW: GeckoByteStructAccessor(self.struct, LKXSJW, KXSJWM, AKQXPI),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, XFEFJT, SKSOKP, FJTACC, None, RAHEOC, AKQXPI
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            SJWMNZ: GeckoEnumStructAccessor(
-                self.struct, SJWMNZ, JWMNZM, None, IPOUYN, None, None, AKQXPI
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            WMNZMJ: GeckoTimeStructAccessor(self.struct, WMNZMJ, MNZMJI, AKQXPI),
-            NZMJIG: GeckoBoolStructAccessor(self.struct, NZMJIG, ZMJIGY, QGLRAH, None),
-            MJIGYO: GeckoBoolStructAccessor(self.struct, MJIGYO, ZMJIGY, RAHEOC, None),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, ZMJIGY, SXUJUT, None),
-            IGYOUS: GeckoBoolStructAccessor(self.struct, IGYOUS, ZMJIGY, GLRAHE, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, ZMJIGY, JUTYEK, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, JVHFTH, RAHEOC, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, USPBWJ, SXUJUT, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, USPBWJ, JUTYEK, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, USPBWJ, VHFTHE, None),
-            BWJYKL: GeckoEnumStructAccessor(
-                self.struct, BWJYKL, WJYKLG, None, LGQPLS, None, None, None
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            GQPLSP: GeckoBoolStructAccessor(self.struct, GQPLSP, QPLSPF, JUTYEK, None),
-            PLSPFT: GeckoBoolStructAccessor(self.struct, PLSPFT, QPLSPF, VHFTHE, None),
-            LSPFTS: GeckoWordStructAccessor(self.struct, LSPFTS, SPFTSI, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, JVHFTH, SKSOKP, None),
-            FTSIFJ: GeckoTempStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoTempStructAccessor(self.struct, SIFJBI, IFJBIA, None),
-            FJBIAM: GeckoEnumStructAccessor(
-                self.struct, FJBIAM, UQEXLS, JUTYEK, JBIAMJ, None, GLRAHE, None
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            BIAMJM: GeckoBoolStructAccessor(self.struct, BIAMJM, IAMJMA, RAHEOC, None),
-            AMJMAO: GeckoBoolStructAccessor(self.struct, AMJMAO, IAMJMA, VHFTHE, None),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, RAHEOC, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, AOAWBS, SKSOKP, None),
-            OAWBSI: GeckoBoolStructAccessor(
-                self.struct, OAWBSI, AOAWBS, RAHEOC, AKQXPI
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, SKSOKP, None),
-            BSIRYX: GeckoByteStructAccessor(self.struct, BSIRYX, SIRYXB, None),
-            IRYXBQ: GeckoBoolStructAccessor(self.struct, IRYXBQ, RYXBQF, QGLRAH, None),
-            YXBQFY: GeckoBoolStructAccessor(self.struct, YXBQFY, XBQFYL, QGLRAH, None),
-            BQFYLJ: GeckoBoolStructAccessor(self.struct, BQFYLJ, XBQFYL, GLRAHE, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, XBQFYL, JUTYEK, None),
-            FYLJUI: GeckoBoolStructAccessor(self.struct, FYLJUI, XBQFYL, VHFTHE, None),
-            YLJUIK: GeckoEnumStructAccessor(
-                self.struct, YLJUIK, XBQFYL, YEKCWA, UIKFWR, None, RAHEOC, AKQXPI
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, KFWRKI, None, NIBXYB, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            IBXYBQ: GeckoBoolStructAccessor(self.struct, IBXYBQ, BXYBQS, QGLRAH, None),
-            XYBQSN: GeckoBoolStructAccessor(self.struct, XYBQSN, BXYBQS, SKSOKP, None),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, QGLRAH, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, SKSOKP, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, NQLNMH, QGLRAH, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, JVHFTH, SXUJUT, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, USPBWJ, QGLRAH, None),
-            NMHXEK: GeckoBoolStructAccessor(self.struct, NMHXEK, USPBWJ, SKSOKP, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, HXEKVK, RAHEOC, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, HXEKVK, SXUJUT, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, BXYBQS, SXUJUT, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, BXYBQS, GLRAHE, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, BXYBQS, JUTYEK, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, BXYBQS, VHFTHE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, BQSNQL, SXUJUT, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, BQSNQL, GLRAHE, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, BQSNQL, JUTYEK, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, BQSNQL, VHFTHE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, RAHEOC, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, AJVDQL, SXUJUT, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, WBSIRY, SXUJUT, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, QPLSPF, QGLRAH, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, QPLSPF, SKSOKP, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, AIIDNI, QGLRAH, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, JMAOAW, QGLRAH, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, HXEKVK, QGLRAH, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, HXEKVK, SKSOKP, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, HXEKVK, GLRAHE, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, QGLRAH, None),
-            XTIACQ: GeckoEnumStructAccessor(
-                self.struct, XTIACQ, BXTIAC, SKSOKP, TIACQF, None, GLRAHE, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, BXTIAC, SXUJUT, None),
-            ACQFFT: GeckoWordStructAccessor(self.struct, ACQFFT, CQFFTT, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, FFTTID, QGLRAH, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, TTIDUB, QGLRAH, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, TTIDUB, SKSOKP, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, AJVDQL, QGLRAH, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, AJVDQL, SKSOKP, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, AJVDQL, GLRAHE, None),
-            BSSUHB: GeckoWordStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoByteStructAccessor(self.struct, SUHBVW, UHBVWV, None),
-            HBVWVU: GeckoByteStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoEnumStructAccessor(
-                self.struct, VWVUBY, WVUBYG, None, RJJJVY, None, None, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, QGLRAH, CRTFMN, None, GLRAHE, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, JJVYFC, RAHEOC, MNHTBJ, None, RAHEOC, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            NHTBJE: GeckoWordStructAccessor(self.struct, NHTBJE, HTBJEU, None),
-            TBJEUT: GeckoByteStructAccessor(self.struct, TBJEUT, BJEUTO, None),
-            JEUTOP: GeckoByteStructAccessor(self.struct, JEUTOP, EUTOPH, None),
-            UTOPHU: GeckoByteStructAccessor(self.struct, UTOPHU, TOPHUG, None),
-            OPHUGT: GeckoByteStructAccessor(self.struct, OPHUGT, PHUGTY, None),
-            HUGTYI: GeckoWordStructAccessor(self.struct, HUGTYI, UGTYIY, None),
-            GTYIYW: GeckoByteStructAccessor(self.struct, GTYIYW, TYIYWS, None),
-            YIYWSK: GeckoByteStructAccessor(self.struct, YIYWSK, IYWSKW, None),
-            YWSKWI: GeckoWordStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoEnumStructAccessor(
-                self.struct, SKWIVD, KWIVDN, None, VDNQGV, None, RAHEOC, AKQXPI
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DNQGVU: GeckoEnumStructAccessor(
-                self.struct, DNQGVU, NQGVUN, None, JUGSEL, None, None, None
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            UGSELH: GeckoWordStructAccessor(self.struct, UGSELH, GSELHB, None),
-            SELHBQ: GeckoByteStructAccessor(self.struct, SELHBQ, ELHBQN, None),
-            LHBQNR: GeckoByteStructAccessor(self.struct, LHBQNR, HBQNRX, None),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, XCHWDA, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            CHWDAF: GeckoEnumStructAccessor(
-                self.struct, CHWDAF, HWDAFI, None, ZTATDZ, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            TATDZX: GeckoEnumStructAccessor(
-                self.struct, TATDZX, ATDZXN, None, ZTATDZ, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            TDZXNQ: GeckoEnumStructAccessor(
-                self.struct, TDZXNQ, DZXNQT, None, ZTATDZ, None, None, AKQXPI
+            "OnzenAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "OnzenAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZXNQTM: GeckoEnumStructAccessor(
-                self.struct, ZXNQTM, XNQTMF, None, ZTATDZ, None, None, AKQXPI
+            "RemoteOnzenAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteOnzenAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, None, ZTATDZ, None, None, AKQXPI
+            "RemoteOnzenDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteOnzenDur", 381, "ALL"
             ),
-            TMFZDG: GeckoEnumStructAccessor(
-                self.struct, TMFZDG, MFZDGK, None, ZDGKEA, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            DGKEAK: GeckoByteStructAccessor(self.struct, DGKEAK, GKEAKS, AKQXPI),
-            KEAKST: GeckoByteStructAccessor(self.struct, KEAKST, EAKSTS, AKQXPI),
-            AKSTSE: GeckoByteStructAccessor(self.struct, AKSTSE, KSTSEM, AKQXPI),
-            STSEMC: GeckoByteStructAccessor(self.struct, STSEMC, TSEMCG, AKQXPI),
-            SEMCGE: GeckoByteStructAccessor(self.struct, SEMCGE, EMCGET, AKQXPI),
-            MCGETI: GeckoByteStructAccessor(self.struct, MCGETI, CGETIX, AKQXPI),
-            GETIXQ: GeckoEnumStructAccessor(
-                self.struct, GETIXQ, ETIXQV, None, IXQVXO, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            XQVXOI: GeckoEnumStructAccessor(
-                self.struct, XQVXOI, MFZDGK, None, IXQVXO, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, GKEAKS, None, IXQVXO, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            VXOIHB: GeckoEnumStructAccessor(
-                self.struct, VXOIHB, EAKSTS, None, IXQVXO, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, KSTSEM, None, IXQVXO, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            OIHBXI: GeckoEnumStructAccessor(
-                self.struct, OIHBXI, TSEMCG, None, IXQVXO, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, EMCGET, None, IXQVXO, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            HBXIBH: GeckoEnumStructAccessor(
-                self.struct, HBXIBH, BXIBHZ, None, XIBHZV, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, CGETIX, None, XIBHZV, None, None, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            BHZVOA: GeckoByteStructAccessor(self.struct, BHZVOA, HZVOAC, AKQXPI),
-            ZVOACM: GeckoByteStructAccessor(self.struct, ZVOACM, VOACMC, AKQXPI),
-            OACMCV: GeckoByteStructAccessor(self.struct, OACMCV, ACMCVD, AKQXPI),
-            CMCVDS: GeckoByteStructAccessor(self.struct, CMCVDS, MCVDSS, AKQXPI),
-            CVDSSR: GeckoByteStructAccessor(self.struct, CVDSSR, VDSSRU, AKQXPI),
-            DSSRUR: GeckoByteStructAccessor(self.struct, DSSRUR, SSRURA, AKQXPI),
-            SRURAZ: GeckoByteStructAccessor(self.struct, SRURAZ, RURAZM, AKQXPI),
-            URAZMK: GeckoByteStructAccessor(self.struct, URAZMK, RAZMKQ, AKQXPI),
-            AZMKQT: GeckoByteStructAccessor(self.struct, AZMKQT, ZMKQTD, AKQXPI),
-            NFZCZO: GeckoBoolStructAccessor(self.struct, NFZCZO, JVHFTH, JUTYEK, None),
-            FZCZOL: GeckoByteStructAccessor(self.struct, FZCZOL, ZCZOLS, AKQXPI),
-            CZOLSI: GeckoByteStructAccessor(self.struct, CZOLSI, ZOLSIP, AKQXPI),
-            OLSIPM: GeckoByteStructAccessor(self.struct, OLSIPM, LSIPMD, AKQXPI),
-            SIPMDM: GeckoEnumStructAccessor(
-                self.struct, SIPMDM, IPMDMP, None, SCTTGC, None, None, AKQXPI
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            CTTGCR: GeckoBoolStructAccessor(
-                self.struct, CTTGCR, TTGCRH, QGLRAH, AKQXPI
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
             ),
-            TGCRHY: GeckoBoolStructAccessor(self.struct, TGCRHY, QNRXCH, QGLRAH, None),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-64.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-64.py
@@ -12,1458 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-AFIKJP = 320
-AIIDNI = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-AIVEMV = 473
-AJVDQL = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = 327
-AOAWBS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-AONPYY = 310
-ATDZXN = "".join(chr(c) for c in [65, 85, 88])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-AZMKQT = 346
-BBEKBD = "".join(chr(c) for c in [67, 70, 71, 51])
-BDFSRO = "".join(chr(c) for c in [67, 70, 71, 53])
-BDJQRJ = "".join(chr(c) for c in [68, 74, 83, 52])
-BEKBDF = 451
-BFEGZU = 261
-BHZVOA = 332
-BIAMJM = 277
-BJEUTO = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BJLOIN = 460
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 384
-BQNRXC = 360
-BQSNQL = 284
-BSIRYX = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BSKSOK = 258
-BSSUHB = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-BVWVUB = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-BWJYKL = 282
-BXIBHZ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-BXTIAC = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-BXYBQS = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-BYGDSB = 289
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-CHWDAF = "".join(chr(c) for c in [45, 45, 45])
-CMCVDS = 341
-CPQIPO = 263
-CQBMJV = 317
-CRHYUA = 375
-CRTFMN = "".join(chr(c) for c in [51, 50, 75])
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-CUGUCY = 256
-CVDSSR = 342
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYWONF = 476
-CZOLSI = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-DAFIKJ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-DDPMXF = "".join(chr(c) for c in [67, 70, 71, 57])
-DFSROG = 453
-DGKEAK = 326
-DJQRJJ = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-DKHTZB = 448
-DMPSCT = 374
-DNIBXT = 354
-DNQGVU = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-DPMXFU = 457
-DQLAII = 351
-DRXAIV = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-DSBDJQ = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-DSSRUR = 343
-DUBSSU = 315
-DZXNQT = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EAKSTS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-EKBDFS = "".join(chr(c) for c in [67, 70, 71, 52])
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-ELHBQN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-ELWUEU = 463
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-EMVCYW = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-EUHNNX = 465
-EUTOPH = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = 469
-FCRTFM = "".join(chr(c) for c in [49, 54, 75])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = 470
-FFTTID = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-FIKJPU = "".join(chr(c) for c in [78, 65])
-FJBIAM = 275
-FJTACC = 262
-FSROGM = "".join(chr(c) for c in [67, 70, 71, 54])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-FTTIDU = 311
-FUBJLO = 459
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 378
-FZCZOL = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-FZDGKE = 324
-GCRHYU = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-GDSBDJ = "".join(chr(c) for c in [105, 110, 88, 69])
-GETIXQ = 331
-GKEAKS = "".join(chr(c) for c in [72, 84, 82])
-GLRAHE = 259
-GMDDPM = "".join(chr(c) for c in [67, 70, 71, 56])
-GQPLSP = "".join(chr(c) for c in [77, 69, 68])
-GSELHB = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-GTYIYW = 296
-GVUNXN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-GYOUSP = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-HBQNRX = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = 285
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = 466
-HTBJEU = "".join(chr(c) for c in [67, 69])
-HTZBBE = 449
-HUGTYI = 295
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-HXEKVK = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-IACQFF = 309
-IAMJMA = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IBHZVO = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-IBXTIA = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-IBXYBQ = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-ICXQIE = 1
-IDNIBX = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-IDUBSS = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IGYOUS = 273
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-IIDNIB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IJUGSE = "".join(chr(c) for c in [75, 56, 48, 48])
-IKFWRK = "".join(chr(c) for c in [72, 69, 65, 84])
-IKJPUN = "".join(chr(c) for c in [80, 49, 72])
-ILXWAJ = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-INEJNI = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-INELWU = 462
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 352
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-IVEMVC = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-IYWSKW = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-JBIAMJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JEUTOP = 291
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-JJVYFC = "".join(chr(c) for c in [105, 110, 89, 84])
-JLOINE = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-JMAOAW = 279
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-JPUNRJ = "".join(chr(c) for c in [80, 50, 72])
-JQRJJJ = "".join(chr(c) for c in [105, 110, 88, 77])
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-JUIKFW = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-JUTYEK = 3
-JVDQLA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-JVHFTH = 274
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYMOUN = 266
-JZTATD = "".join(chr(c) for c in [80, 52, 76])
-KBDFSR = 452
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KFWRKI = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-KHTZBB = "".join(chr(c) for c in [67, 70, 71, 49])
-KINEJN = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-KJPUNR = "".join(chr(c) for c in [80, 49, 76])
-KLGQPL = 313
-KMLOIJ = "".join(chr(c) for c in [75, 52])
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-KVKZIL = 283
-KWIVDN = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-KZILXW = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-LAIIDN = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(chr(c) for c in [78, 79])
-LHBQNR = 358
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-LKXSJW = 270
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-LOIJUG = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-LOINEL = 461
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LWUEUH = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-LXWAJV = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-MAOAWB = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = 369
-MCGETI = 330
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-MDDPMX = 456
-MDMPSC = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-MFZDGK = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-MHXEKV = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-MJIGYO = 381
-MJMAOA = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 347
-MLOIJU = "".join(chr(c) for c in [75, 53])
-MNHTBJ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-MVCYWO = 475
-MXFUBJ = 458
-NBLKXS = 268
-NCUGUC = 64
-NEJNIB = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-NELWUE = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-NFZCZO = 478
-NHTBJE = "".join(chr(c) for c in [85, 76])
-NIBXTI = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-NIBXYB = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-NKMLOI = "".join(chr(c) for c in [75, 56])
-NMHXEK = 383
-NNXWEE = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = "".join(chr(c) for c in [70, 117, 108, 108])
-NQJYMO = 264
-NQLNMH = 350
-NQTMFZ = 322
-NRJZTA = "".join(chr(c) for c in [80, 51, 76])
-NRSJMC = 306
-NRXCHW = 361
-NXNKML = "".join(chr(c) for c in [75, 52, 48, 48])
-NXWEEZ = 467
-NZMJIG = 380
-OACMCV = 340
-OAWBSI = 280
-OCTHBS = 2
-OGMDDP = 455
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-OIJUGS = "".join(chr(c) for c in [75, 49, 48, 48])
-OINELW = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 371
-ONFZCZ = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = 294
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PHUGTY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PMDMPS = 373
-PMXFUB = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-PUNRJZ = "".join(chr(c) for c in [80, 50, 76])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-QPLSPF = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QRJJJV = "".join(chr(c) for c in [75, 54, 48, 48])
-QSNQLN = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-QTDKHT = 348
-QTMFZD = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-QVXOIH = "".join(chr(c) for c in [70, 97, 110])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAZMKQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-RHYUAX = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-RJZTAT = "".join(chr(c) for c in [80, 52, 72])
-RKINEJ = 379
-ROGMDD = "".join(chr(c) for c in [67, 70, 71, 55])
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [52, 56, 75])
-RURAZM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-RXAIVE = 472
-RXCHWD = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SAKQXP = 386
-SBDJQR = "".join(chr(c) for c in [77, 73, 65])
-SCTTGC = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-SEMCGE = 329
-SIFJBI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SIPMDM = 372
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = 300
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(chr(c) for c in [67, 80, 79, 84])
-SPFTSI = 353
-SROGMD = 454
-SRURAZ = 344
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-SSUHBV = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-STSEMC = 328
-SUHBVW = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-TDKHTZ = "".join(chr(c) for c in [67, 70, 71, 48])
-TDRXAI = 471
-TFMNHT = "".join(chr(c) for c in [54, 52, 75])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-TIDUBS = 314
-TIXQVX = 333
-TMFZDG = 323
-TOPHUG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-TSEMCG = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-TSIFJB = 355
-TTGCRH = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-TTIDUB = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TYIYWS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-TZBBEK = "".join(chr(c) for c in [67, 70, 71, 50])
-UBJLOI = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-UBSSUH = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-UBYGDS = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-UEUHNN = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-UGSELH = "".join(chr(c) for c in [75, 51, 48, 48])
-UGTYIY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-UGUCYR = 479
-UHBVWV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-UHNNXW = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-UIKFWR = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = "".join(chr(c) for c in [80, 51, 72])
-UNXNKM = "".join(chr(c) for c in [75, 50, 48, 48])
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = 345
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-UTOPHU = 293
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-VDNQGV = 316
-VDQLAI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-VDSSRU = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-VEMVCY = 474
-VHFTHE = 6
-VKZILX = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-VUBYGD = 288
-VUNXNK = 357
-VWVUBY = 287
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = 281
-WEEZFE = 468
-WIVDNQ = 301
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = 477
-WRKINE = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-WSKWIV = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-WUEUHN = 464
-WVUBYG = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-XAIVEM = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-XBQFYL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = 376
-XEKVKZ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-XLSXUJ = 260
-XNKMLO = "".join(chr(c) for c in [75, 56, 53])
-XNQTMF = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-XOIHBX = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = 325
-XSJWMN = 271
-XTIACQ = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-XWEEZF = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-YBQSNQ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-YEKCWA = 5
-YFCRTF = 290
-YGDSBD = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-YIYWSK = 297
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YUAXNC = "".join(chr(c) for c in [76, 73])
-YWONFZ = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-YWSKWI = 299
-YXBQFY = 377
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 450
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = 479
-ZDGKEA = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-ZFETDR = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-ZILXWA = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-ZOLSIP = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-ZTATDZ = "".join(chr(c) for c in [66, 76, 79])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-ZXNQTM = 321
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-AMJMAO = [HECVYY, IAMJMA, IAMJMA, IAMJMA]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-AXNCUG = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-CQFFTT = [HECVYY, ACQFFT, ACQFFT, ACQFFT]
-FMNHTB = [FCRTFM, CRTFMN, RTFMNH, TFMNHT]
-FWRKIN = [IKFWRK, KFWRKI]
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-HYUAXN = []
-HZVOAC = [
-    FIKJPU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-JVYFCR = [
-    YGDSBD,
-    GDSBDJ,
-    DSBDJQ,
-    SBDJQR,
-    BDJQRJ,
-    DJQRJJ,
-    JQRJJJ,
-    QRJJJV,
-    RJJJVY,
-    JJJVYF,
-    JJVYFC,
-]
-KEAKST = [
-    FIKJPU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GKEAKS,
-]
-LSXUJU = [FXQGLR, FEGZUQ]
-OKPHUO = [FXQGLR, SOKPHU]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PLSPFT = [LGQPLS, LRAHEO, GQPLSP, RAHEOC, QPLSPF]
-QGVUNX = [DNQGVU, NQGVUN]
-SELHBQ = [
-    UNXNKM,
-    NXNKML,
-    XNKMLO,
-    NKMLOI,
-    KMLOIJ,
-    MLOIJU,
-    LOIJUG,
-    OIJUGS,
-    IJUGSE,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    JUGSEL,
-    UGSELH,
-    GSELHB,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-TBJEUT = [NHTBJE, HTBJEU]
-TDZXNQ = [
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-    EXLSXU,
-    ZTATDZ,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    TATDZX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    ATDZXN,
-]
-TGCRHY = [MPSCTT, PSCTTG, SCTTGC, CTTGCR, TTGCRH]
-UAXNCU = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    YUAXNC,
-]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VXOIHB = [
-    FIKJPU,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-    PUNRJZ,
-    UNRJZT,
-    NRJZTA,
-    RJZTAT,
-    JZTATD,
-    EXLSXU,
-    ZTATDZ,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    QVXOIH,
-    HECVYY,
-    HECVYY,
-    TATDZX,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    ATDZXN,
-]
-WDAFIK = [CHWDAF, HWDAFI]
-XNCUGU = [
-    BSSUHB,
-    QLAIID,
-    IIDNIB,
-    ZILXWA,
-    SIFJBI,
-    QFFTTI,
-    UBSSUH,
-    SSUHBV,
-    MJMAOA,
-    USPBWJ,
-    JVDQLA,
-    XWAJVD,
-    MHXEKV,
-    SIRYXB,
-    IDUBSS,
-    LXWAJV,
-    VDQLAI,
-    AJVDQL,
-    VKZILX,
-    IDNIBX,
-    EKVKZI,
-    HXEKVK,
-    LAIIDN,
-    BXTIAC,
-    AIIDNI,
-    XEKVKZ,
-    WAJVDQ,
-    ILXWAJ,
-    KZILXW,
-]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-XYBQSN = [
-    PQIPOU,
-    KINEJN,
-    INEJNI,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    NEJNIB,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-]
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1471,334 +19,1252 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return NCUGUC
+        return 64
 
     @property
     def begin(self):
-        return CUGUCY
+        return 256
 
     @property
     def end(self):
-        return UGUCYR
+        return 479
 
     @property
     def all_device_keys(self):
-        return UAXNCU
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return AXNCUG
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return XNCUGU
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, OCTHBS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, JUTYEK, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, HEOCTH, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, YEKCWA, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, OCTHBS, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, JUTYEK, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, YEKCWA, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, BWJYKL, VHFTHE, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, PLSPFT, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, YEKCWA, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, VHFTHE, None),
-            FTSIFJ: GeckoWordStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, JVHFTH, ICXQIE, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, XLSXUJ, YEKCWA, AMJMAO, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, ICXQIE, None),
-            BSIRYX: GeckoBoolStructAccessor(
-                self.struct, BSIRYX, WBSIRY, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, XPICXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, XPICXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, HEOCTH, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FYLJUI, YEKCWA, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FYLJUI, VHFTHE, None),
-            UIKFWR: GeckoEnumStructAccessor(
-                self.struct, UIKFWR, FYLJUI, CWAONP, FWRKIN, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            WRKINE: GeckoEnumStructAccessor(
-                self.struct, WRKINE, RKINEJ, None, XYBQSN, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            YBQSNQ: GeckoBoolStructAccessor(self.struct, YBQSNQ, BQSNQL, XPICXQ, None),
-            QSNQLN: GeckoBoolStructAccessor(self.struct, QSNQLN, BQSNQL, ICXQIE, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, NQLNMH, XPICXQ, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, NQLNMH, ICXQIE, None),
-            LNMHXE: GeckoBoolStructAccessor(self.struct, LNMHXE, NMHXEK, XPICXQ, None),
-            MHXEKV: GeckoBoolStructAccessor(self.struct, MHXEKV, JVHFTH, JUTYEK, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, BWJYKL, XPICXQ, None),
-            XEKVKZ: GeckoBoolStructAccessor(self.struct, XEKVKZ, BWJYKL, ICXQIE, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, KVKZIL, OCTHBS, None),
-            VKZILX: GeckoBoolStructAccessor(self.struct, VKZILX, KVKZIL, JUTYEK, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, BQSNQL, JUTYEK, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, BQSNQL, HEOCTH, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, BQSNQL, YEKCWA, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, BQSNQL, VHFTHE, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, NQLNMH, JUTYEK, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, NQLNMH, HEOCTH, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, NQLNMH, YEKCWA, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, NQLNMH, VHFTHE, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, DQLAII, OCTHBS, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, DQLAII, JUTYEK, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, IRYXBQ, JUTYEK, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, SPFTSI, XPICXQ, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, SPFTSI, ICXQIE, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, DNIBXT, XPICXQ, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, OAWBSI, XPICXQ, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, KVKZIL, XPICXQ, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, KVKZIL, ICXQIE, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, KVKZIL, HEOCTH, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, IACQFF, XPICXQ, None),
-            ACQFFT: GeckoEnumStructAccessor(
-                self.struct, ACQFFT, IACQFF, ICXQIE, CQFFTT, None, HEOCTH, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, IACQFF, JUTYEK, None),
-            FFTTID: GeckoWordStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, TIDUBS, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, DUBSSU, XPICXQ, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, DUBSSU, ICXQIE, None),
-            BSSUHB: GeckoBoolStructAccessor(self.struct, BSSUHB, DQLAII, XPICXQ, None),
-            SSUHBV: GeckoBoolStructAccessor(self.struct, SSUHBV, DQLAII, ICXQIE, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, DQLAII, HEOCTH, None),
-            UHBVWV: GeckoWordStructAccessor(self.struct, UHBVWV, HBVWVU, None),
-            BVWVUB: GeckoByteStructAccessor(self.struct, BVWVUB, VWVUBY, None),
-            WVUBYG: GeckoByteStructAccessor(self.struct, WVUBYG, VUBYGD, None),
-            UBYGDS: GeckoEnumStructAccessor(
-                self.struct, UBYGDS, BYGDSB, None, JVYFCR, None, None, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            VYFCRT: GeckoEnumStructAccessor(
-                self.struct, VYFCRT, YFCRTF, XPICXQ, FMNHTB, None, HEOCTH, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            MNHTBJ: GeckoEnumStructAccessor(
-                self.struct, MNHTBJ, YFCRTF, OCTHBS, TBJEUT, None, OCTHBS, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            BJEUTO: GeckoWordStructAccessor(self.struct, BJEUTO, JEUTOP, None),
-            EUTOPH: GeckoByteStructAccessor(self.struct, EUTOPH, UTOPHU, None),
-            TOPHUG: GeckoByteStructAccessor(self.struct, TOPHUG, OPHUGT, None),
-            PHUGTY: GeckoByteStructAccessor(self.struct, PHUGTY, HUGTYI, None),
-            UGTYIY: GeckoByteStructAccessor(self.struct, UGTYIY, GTYIYW, None),
-            TYIYWS: GeckoWordStructAccessor(self.struct, TYIYWS, YIYWSK, None),
-            IYWSKW: GeckoByteStructAccessor(self.struct, IYWSKW, YWSKWI, None),
-            WSKWIV: GeckoByteStructAccessor(self.struct, WSKWIV, SKWIVD, None),
-            KWIVDN: GeckoWordStructAccessor(self.struct, KWIVDN, WIVDNQ, None),
-            IVDNQG: GeckoEnumStructAccessor(
-                self.struct, IVDNQG, VDNQGV, None, QGVUNX, None, OCTHBS, AKQXPI
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            GVUNXN: GeckoEnumStructAccessor(
-                self.struct, GVUNXN, VUNXNK, None, SELHBQ, None, None, None
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ELHBQN: GeckoWordStructAccessor(self.struct, ELHBQN, LHBQNR, None),
-            HBQNRX: GeckoByteStructAccessor(self.struct, HBQNRX, BQNRXC, None),
-            QNRXCH: GeckoByteStructAccessor(self.struct, QNRXCH, NRXCHW, None),
-            RXCHWD: GeckoEnumStructAccessor(
-                self.struct, RXCHWD, XCHWDA, None, WDAFIK, None, None, AKQXPI
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DAFIKJ: GeckoEnumStructAccessor(
-                self.struct, DAFIKJ, AFIKJP, None, TDZXNQ, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            DZXNQT: GeckoEnumStructAccessor(
-                self.struct, DZXNQT, ZXNQTM, None, TDZXNQ, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            XNQTMF: GeckoEnumStructAccessor(
-                self.struct, XNQTMF, NQTMFZ, None, TDZXNQ, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            QTMFZD: GeckoEnumStructAccessor(
-                self.struct, QTMFZD, TMFZDG, None, TDZXNQ, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            MFZDGK: GeckoEnumStructAccessor(
-                self.struct, MFZDGK, FZDGKE, None, TDZXNQ, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            ZDGKEA: GeckoEnumStructAccessor(
-                self.struct, ZDGKEA, DGKEAK, None, KEAKST, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            EAKSTS: GeckoByteStructAccessor(self.struct, EAKSTS, AKSTSE, AKQXPI),
-            KSTSEM: GeckoByteStructAccessor(self.struct, KSTSEM, STSEMC, AKQXPI),
-            TSEMCG: GeckoByteStructAccessor(self.struct, TSEMCG, SEMCGE, AKQXPI),
-            EMCGET: GeckoByteStructAccessor(self.struct, EMCGET, MCGETI, AKQXPI),
-            CGETIX: GeckoByteStructAccessor(self.struct, CGETIX, GETIXQ, AKQXPI),
-            ETIXQV: GeckoByteStructAccessor(self.struct, ETIXQV, TIXQVX, AKQXPI),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, XQVXOI, None, VXOIHB, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            XOIHBX: GeckoEnumStructAccessor(
-                self.struct, XOIHBX, DGKEAK, None, VXOIHB, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            OIHBXI: GeckoEnumStructAccessor(
-                self.struct, OIHBXI, AKSTSE, None, VXOIHB, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            IHBXIB: GeckoEnumStructAccessor(
-                self.struct, IHBXIB, STSEMC, None, VXOIHB, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            HBXIBH: GeckoEnumStructAccessor(
-                self.struct, HBXIBH, SEMCGE, None, VXOIHB, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            BXIBHZ: GeckoEnumStructAccessor(
-                self.struct, BXIBHZ, MCGETI, None, VXOIHB, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            XIBHZV: GeckoEnumStructAccessor(
-                self.struct, XIBHZV, GETIXQ, None, VXOIHB, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            IBHZVO: GeckoEnumStructAccessor(
-                self.struct, IBHZVO, BHZVOA, None, HZVOAC, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            ZVOACM: GeckoEnumStructAccessor(
-                self.struct, ZVOACM, TIXQVX, None, HZVOAC, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            VOACMC: GeckoByteStructAccessor(self.struct, VOACMC, OACMCV, AKQXPI),
-            ACMCVD: GeckoByteStructAccessor(self.struct, ACMCVD, CMCVDS, AKQXPI),
-            MCVDSS: GeckoByteStructAccessor(self.struct, MCVDSS, CVDSSR, AKQXPI),
-            VDSSRU: GeckoByteStructAccessor(self.struct, VDSSRU, DSSRUR, AKQXPI),
-            SSRURA: GeckoByteStructAccessor(self.struct, SSRURA, SRURAZ, AKQXPI),
-            RURAZM: GeckoByteStructAccessor(self.struct, RURAZM, URAZMK, AKQXPI),
-            RAZMKQ: GeckoByteStructAccessor(self.struct, RAZMKQ, AZMKQT, AKQXPI),
-            ZMKQTD: GeckoByteStructAccessor(self.struct, ZMKQTD, MKQTDK, AKQXPI),
-            KQTDKH: GeckoByteStructAccessor(self.struct, KQTDKH, QTDKHT, AKQXPI),
-            CZOLSI: GeckoBoolStructAccessor(self.struct, CZOLSI, JVHFTH, YEKCWA, None),
-            ZOLSIP: GeckoByteStructAccessor(self.struct, ZOLSIP, OLSIPM, AKQXPI),
-            LSIPMD: GeckoByteStructAccessor(self.struct, LSIPMD, SIPMDM, AKQXPI),
-            IPMDMP: GeckoByteStructAccessor(self.struct, IPMDMP, PMDMPS, AKQXPI),
-            MDMPSC: GeckoEnumStructAccessor(
-                self.struct, MDMPSC, DMPSCT, None, TGCRHY, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            GCRHYU: GeckoBoolStructAccessor(
-                self.struct, GCRHYU, CRHYUA, XPICXQ, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            RHYUAX: GeckoBoolStructAccessor(self.struct, RHYUAX, XCHWDA, XPICXQ, None),
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
+            ),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-65.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-65.py
@@ -12,1568 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-ACQFFT = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-AFIKJP = 358
-AIIDNI = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-AIVEMV = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-AJVDQL = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-AOAWBS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-AOESVZ = 479
-AONPYY = 310
-ATDZXN = "".join(chr(c) for c in [78, 65])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-AXNCUG = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-AZMKQT = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-BBEKBD = 346
-BDFSRO = 348
-BDJQRJ = 285
-BEKBDF = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-BFEGZU = 261
-BHZVOA = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-BIAMJM = 277
-BJEUTO = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-BJLOIN = "".join(chr(c) for c in [67, 70, 71, 55])
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 384
-BQNRXC = "".join(chr(c) for c in [75, 53])
-BQSNQL = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-BSIRYX = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BSKSOK = 258
-BSSUHB = 309
-BVWVUB = 311
-BWJYKL = 282
-BXIBHZ = 331
-BXTIAC = 351
-BXYBQS = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-BYGDSB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = 326
-CHWDAF = "".join(chr(c) for c in [75, 51, 48, 48])
-CMCVDS = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-CPQIPO = 263
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-CRHYUA = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-CRTFMN = "".join(chr(c) for c in [68, 74, 83, 52])
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-CUGUCY = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-CVDSSR = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-CYWONF = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-CZOLSI = 474
-DAFIKJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-DDPMXF = 451
-DFSROG = "".join(chr(c) for c in [67, 70, 71, 48])
-DGKEAK = "".join(chr(c) for c in [65, 85, 88])
-DJQRJJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-DKHTZB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-DMPSCT = 478
-DNIBXT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-DNQGVU = 296
-DPMXFU = "".join(chr(c) for c in [67, 70, 71, 52])
-DQLAII = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-DRXAIV = 466
-DSBDJQ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-DSSRUR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-DUBSSU = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-DZXNQT = "".join(chr(c) for c in [80, 49, 76])
-EAKSTS = 321
-EAOESV = 256
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = 463
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-EKBDFS = 347
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-ELHBQN = "".join(chr(c) for c in [75, 56, 53])
-ELWUEU = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-EMCGET = 324
-EMVCYW = 469
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = 465
-EUHNNX = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EUTOPH = "".join(chr(c) for c in [49, 54, 75])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-FCRTFM = "".join(chr(c) for c in [77, 73, 65])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-FFTTID = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-FIKJPU = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-FJBIAM = 275
-FJTACC = 262
-FMNHTB = "".join(chr(c) for c in [75, 54, 48, 48])
-FSROGM = 448
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-FTTIDU = 387
-FUBJLO = "".join(chr(c) for c in [67, 70, 71, 54])
-FWRKIN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 378
-FZCZOL = 473
-FZDGKE = "".join(chr(c) for c in [66, 76, 79])
-GCRHYU = 372
-GDSBDJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-GETIXQ = "".join(chr(c) for c in [72, 84, 82])
-GLRAHE = 259
-GMDDPM = 450
-GQPLSP = "".join(chr(c) for c in [77, 69, 68])
-GSELHB = "".join(chr(c) for c in [75, 50, 48, 48])
-GTYIYW = "".join(chr(c) for c in [67, 69])
-GUCYRA = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-GVUNXN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-GYOUSP = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-HBQNRX = "".join(chr(c) for c in [75, 52])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-HBXIBH = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-HTBJEU = "".join(chr(c) for c in [105, 110, 89, 84])
-HTZBBE = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-HXEKVK = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-HYUAXN = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-HZVOAC = 325
-IACQFF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-IAMJMA = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IBHZVO = 333
-IBXTIA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-IBXYBQ = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-ICXQIE = 1
-IDNIBX = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-IDUBSS = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IGYOUS = 273
-IHBXIB = 330
-IIDNIB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-IKFWRK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-IKJPUN = 360
-ILXWAJ = 383
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-INELWU = "".join(chr(c) for c in [67, 70, 71, 57])
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 352
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = 295
-IVEMVC = 468
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = 327
-IYWSKW = 291
-JBIAMJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JEUTOP = 290
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-JJVYFC = 289
-JLOINE = 455
-JMAOAW = 279
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-JPUNRJ = 361
-JQRJJJ = 287
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-JUIKFW = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-JUTYEK = 3
-JVDQLA = 283
-JVHFTH = 274
-JVYFCR = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYMOUN = 266
-KBDFSR = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KEAKST = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-KFWRKI = "".join(chr(c) for c in [72, 69, 65, 84])
-KHTZBB = 344
-KINEJN = 379
-KJPUNR = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-KLGQPL = 313
-KMLOIJ = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQTDKH = 342
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = 322
-KVKZIL = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-KWIVDN = 294
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-LAIIDN = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(chr(c) for c in [78, 79])
-LHBQNR = "".join(chr(c) for c in [75, 56])
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-LKXSJW = 270
-LOIJUG = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-LOINEL = "".join(chr(c) for c in [67, 70, 71, 56])
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LWUEUH = 458
-LXWAJV = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-MAOAWB = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = 369
-MCGETI = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-MDDPMX = "".join(chr(c) for c in [67, 70, 71, 51])
-MDMPSC = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-MEAOES = 65
-MFZDGK = "".join(chr(c) for c in [80, 52, 76])
-MHXEKV = 390
-MJIGYO = 381
-MJMAOA = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-MLOIJU = 316
-MNHTBJ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-MVCYWO = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-MXFUBJ = "".join(chr(c) for c in [67, 70, 71, 53])
-NBLKXS = 268
-NCUGUC = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-NELWUE = 457
-NFZCZO = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-NHTBJE = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-NIBXTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-NIBXYB = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-NKMLOI = 301
-NMHXEK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-NNXWEE = 461
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NQJYMO = 264
-NQLNMH = "".join(chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87])
-NQTMFZ = "".join(chr(c) for c in [80, 51, 72])
-NRJZTA = "".join(chr(c) for c in [45, 45, 45])
-NRSJMC = 306
-NRXCHW = "".join(chr(c) for c in [75, 49, 48, 48])
-NXNKML = 300
-NXWEEZ = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-NZMJIG = 380
-OACMCV = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-OAWBSI = 280
-OCTHBS = 2
-OGMDDP = "".join(chr(c) for c in [67, 70, 71, 50])
-OIHBXI = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-OIJUGS = "".join(chr(c) for c in [70, 117, 108, 108])
-OINELW = 456
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = 475
-ONFZCZ = 472
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = "".join(chr(c) for c in [54, 52, 75])
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PMDMPS = 477
-PMXFUB = 452
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = 479
-PUNRJZ = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = 354
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = 297
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-QLNMHX = "".join(chr(c) for c in [71, 69, 67, 75, 79, 55, 53, 48, 48, 87])
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-QPLSPF = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QRJJJV = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-QSNQLN = 389
-QTDKHT = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-QTMFZD = "".join(chr(c) for c in [80, 51, 76])
-QVXOIH = 328
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = "".join(chr(c) for c in [76, 73])
-RAZMKQ = 340
-RHYUAX = 373
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = 288
-RJZTAT = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-RKINEJ = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-ROGMDD = 449
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-RURAZM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-RXAIVE = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-RXCHWD = "".join(chr(c) for c in [75, 56, 48, 48])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SAKQXP = 386
-SBDJQR = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-SCTTGC = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-SELHBQ = "".join(chr(c) for c in [75, 52, 48, 48])
-SEMCGE = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-SIFJBI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SIPMDM = 476
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-SNQLNM = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(chr(c) for c in [67, 80, 79, 84])
-SPFTSI = 353
-SROGMD = "".join(chr(c) for c in [67, 70, 71, 49])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSRURA = 332
-SSUHBV = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-STSEMC = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = 320
-TDKHTZ = 343
-TDRXAI = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-TDZXNQ = "".join(chr(c) for c in [80, 49, 72])
-TFMNHT = "".join(chr(c) for c in [105, 110, 88, 77])
-TGCRHY = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TIDUBS = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-TIXQVX = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-TMFZDG = "".join(chr(c) for c in [80, 52, 72])
-TOPHUG = "".join(chr(c) for c in [52, 56, 75])
-TSEMCG = 323
-TSIFJB = 355
-TTGCRH = 371
-TTIDUB = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TZBBEK = 345
-UAXNCU = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-UBJLOI = 454
-UBSSUH = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-UBYGDS = 315
-UCYRAP = 375
-UEUHNN = 459
-UGSELH = 357
-UGTYIY = "".join(chr(c) for c in [85, 76])
-UHBVWV = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-UHNNXW = 460
-UIKFWR = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = 376
-UNXNKM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [51, 50, 75])
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = 470
-VDNQGV = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-VDQLAI = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-VDSSRU = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-VEMVCY = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-VHFTHE = 6
-VKZILX = 350
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VUBYGD = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-VUNXNK = 299
-VWVUBY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-VXOIHB = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-VYFCRT = "".join(chr(c) for c in [105, 110, 88, 69])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = 281
-WEEZFE = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-WIVDNQ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-WSKWIV = 293
-WUEUHN = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-WVUBYG = 314
-XAIVEM = 467
-XBQFYL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-XEKVKZ = 284
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = 453
-XIBHZV = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-XLSXUJ = 260
-XNCUGU = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-XNKMLO = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-XNQTMF = "".join(chr(c) for c in [80, 50, 76])
-XOIHBX = 329
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-XSJWMN = 271
-XTIACQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-XWEEZF = 462
-XYBQSN = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-YEKCWA = 5
-YFCRTF = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-YGDSBD = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-YIYWSK = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YUAXNC = 374
-YWONFZ = 471
-YWSKWI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-YXBQFY = 377
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-ZDGKEA = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-ZFETDR = 464
-ZILXWA = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = 341
-ZOLSIP = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-ZTATDZ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = "".join(chr(c) for c in [70, 97, 110])
-ZXNQTM = "".join(chr(c) for c in [80, 50, 72])
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-AMJMAO = [HECVYY, IAMJMA, IAMJMA, IAMJMA]
-APUMEA = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    RAPUME,
-]
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-ETIXQV = [
-    ATDZXN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    GETIXQ,
-]
-GKEAKS = [
-    ATDZXN,
-    TDZXNQ,
-    DZXNQT,
-    ZXNQTM,
-    XNQTMF,
-    NQTMFZ,
-    QTMFZD,
-    TMFZDG,
-    MFZDGK,
-    EXLSXU,
-    FZDGKE,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ZDGKEA,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    DGKEAK,
-]
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-IJUGSE = [LOIJUG, OIJUGS]
-JZTATD = [NRJZTA, RJZTAT]
-LNMHXE = [SNQLNM, NQLNMH, QLNMHX]
-LSXUJU = [FXQGLR, FEGZUQ]
-OKPHUO = [FXQGLR, SOKPHU]
-PHUGTY = [EUTOPH, UTOPHU, TOPHUG, OPHUGT]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PLSPFT = [LGQPLS, LRAHEO, GQPLSP, RAHEOC, QPLSPF]
-PUMEAO = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-SRURAZ = [
-    ATDZXN,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-SUHBVW = [HECVYY, SSUHBV, SSUHBV, SSUHBV]
-TBJEUT = [
-    JVYFCR,
-    VYFCRT,
-    YFCRTF,
-    FCRTFM,
-    CRTFMN,
-    RTFMNH,
-    TFMNHT,
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-]
-TYIYWS = [UGTYIY, GTYIYW]
-UGUCYR = [UAXNCU, AXNCUG, XNCUGU, NCUGUC, CUGUCY]
-UMEAOE = [
-    YGDSBD,
-    XTIACQ,
-    ACQFFT,
-    QLAIID,
-    SIFJBI,
-    UHBVWV,
-    BYGDSB,
-    GDSBDJ,
-    MJMAOA,
-    USPBWJ,
-    NIBXTI,
-    IIDNIB,
-    LXWAJV,
-    SIRYXB,
-    VUBYGD,
-    AIIDNI,
-    IBXTIA,
-    DNIBXT,
-    VDQLAI,
-    CQFFTT,
-    AJVDQL,
-    XWAJVD,
-    TIACQF,
-    IDUBSS,
-    IACQFF,
-    WAJVDQ,
-    FFTTID,
-    IDNIBX,
-    LAIIDN,
-    DQLAII,
-]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VOACMC = [
-    ATDZXN,
-    TDZXNQ,
-    DZXNQT,
-    ZXNQTM,
-    XNQTMF,
-    NQTMFZ,
-    QTMFZD,
-    TMFZDG,
-    MFZDGK,
-    EXLSXU,
-    FZDGKE,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    ZVOACM,
-    HECVYY,
-    HECVYY,
-    ZDGKEA,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    DGKEAK,
-]
-WDAFIK = [
-    GSELHB,
-    SELHBQ,
-    ELHBQN,
-    LHBQNR,
-    HBQNRX,
-    BQNRXC,
-    QNRXCH,
-    NRXCHW,
-    RXCHWD,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-]
-WRKINE = [KFWRKI, FWRKIN]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-YBQSNQ = [
-    PQIPOU,
-    INEJNI,
-    NEJNIB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-]
-YRAPUM = []
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1581,340 +19,1272 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return MEAOES
+        return 65
 
     @property
     def begin(self):
-        return EAOESV
+        return 256
 
     @property
     def end(self):
-        return AOESVZ
+        return 479
 
     @property
     def all_device_keys(self):
-        return APUMEA
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return PUMEAO
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return UMEAOE
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, OCTHBS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, JUTYEK, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, HEOCTH, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, YEKCWA, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, OCTHBS, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, JUTYEK, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, YEKCWA, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, BWJYKL, VHFTHE, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, PLSPFT, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, YEKCWA, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, VHFTHE, None),
-            FTSIFJ: GeckoWordStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, JVHFTH, ICXQIE, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, XLSXUJ, YEKCWA, AMJMAO, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, ICXQIE, None),
-            BSIRYX: GeckoBoolStructAccessor(
-                self.struct, BSIRYX, WBSIRY, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, XPICXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, XPICXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FYLJUI, HEOCTH, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FYLJUI, YEKCWA, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, FYLJUI, VHFTHE, None),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, FYLJUI, CWAONP, WRKINE, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, YBQSNQ, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            BQSNQL: GeckoEnumStructAccessor(
-                self.struct, BQSNQL, QSNQLN, None, LNMHXE, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            NMHXEK: GeckoWordStructAccessor(self.struct, NMHXEK, MHXEKV, None),
-            HXEKVK: GeckoBoolStructAccessor(self.struct, HXEKVK, XEKVKZ, XPICXQ, None),
-            EKVKZI: GeckoBoolStructAccessor(self.struct, EKVKZI, XEKVKZ, ICXQIE, None),
-            KVKZIL: GeckoBoolStructAccessor(self.struct, KVKZIL, VKZILX, XPICXQ, None),
-            KZILXW: GeckoBoolStructAccessor(self.struct, KZILXW, VKZILX, ICXQIE, None),
-            ZILXWA: GeckoBoolStructAccessor(self.struct, ZILXWA, ILXWAJ, XPICXQ, None),
-            LXWAJV: GeckoBoolStructAccessor(self.struct, LXWAJV, JVHFTH, JUTYEK, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, BWJYKL, XPICXQ, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, BWJYKL, ICXQIE, None),
-            AJVDQL: GeckoBoolStructAccessor(self.struct, AJVDQL, JVDQLA, OCTHBS, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, JVDQLA, JUTYEK, None),
-            DQLAII: GeckoBoolStructAccessor(self.struct, DQLAII, XEKVKZ, JUTYEK, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, XEKVKZ, HEOCTH, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, XEKVKZ, YEKCWA, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, XEKVKZ, VHFTHE, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, VKZILX, JUTYEK, None),
-            IDNIBX: GeckoBoolStructAccessor(self.struct, IDNIBX, VKZILX, HEOCTH, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, VKZILX, YEKCWA, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, VKZILX, VHFTHE, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, BXTIAC, OCTHBS, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, BXTIAC, JUTYEK, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, IRYXBQ, JUTYEK, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, SPFTSI, XPICXQ, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, SPFTSI, ICXQIE, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, QFFTTI, XPICXQ, None),
-            FFTTID: GeckoByteStructAccessor(self.struct, FFTTID, FTTIDU, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, OAWBSI, XPICXQ, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, JVDQLA, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, JVDQLA, ICXQIE, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, JVDQLA, HEOCTH, None),
-            UBSSUH: GeckoBoolStructAccessor(self.struct, UBSSUH, BSSUHB, XPICXQ, None),
-            SSUHBV: GeckoEnumStructAccessor(
-                self.struct, SSUHBV, BSSUHB, ICXQIE, SUHBVW, None, HEOCTH, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, BSSUHB, JUTYEK, None),
-            HBVWVU: GeckoWordStructAccessor(self.struct, HBVWVU, BVWVUB, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, WVUBYG, XPICXQ, None),
-            VUBYGD: GeckoBoolStructAccessor(self.struct, VUBYGD, UBYGDS, XPICXQ, None),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, UBYGDS, ICXQIE, None),
-            YGDSBD: GeckoBoolStructAccessor(self.struct, YGDSBD, BXTIAC, XPICXQ, None),
-            GDSBDJ: GeckoBoolStructAccessor(self.struct, GDSBDJ, BXTIAC, ICXQIE, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, BXTIAC, HEOCTH, None),
-            SBDJQR: GeckoWordStructAccessor(self.struct, SBDJQR, BDJQRJ, None),
-            DJQRJJ: GeckoByteStructAccessor(self.struct, DJQRJJ, JQRJJJ, None),
-            QRJJJV: GeckoByteStructAccessor(self.struct, QRJJJV, RJJJVY, None),
-            JJJVYF: GeckoEnumStructAccessor(
-                self.struct, JJJVYF, JJVYFC, None, TBJEUT, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            BJEUTO: GeckoEnumStructAccessor(
-                self.struct, BJEUTO, JEUTOP, XPICXQ, PHUGTY, None, HEOCTH, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, JEUTOP, OCTHBS, TYIYWS, None, OCTHBS, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            YIYWSK: GeckoWordStructAccessor(self.struct, YIYWSK, IYWSKW, None),
-            YWSKWI: GeckoByteStructAccessor(self.struct, YWSKWI, WSKWIV, None),
-            SKWIVD: GeckoByteStructAccessor(self.struct, SKWIVD, KWIVDN, None),
-            WIVDNQ: GeckoByteStructAccessor(self.struct, WIVDNQ, IVDNQG, None),
-            VDNQGV: GeckoByteStructAccessor(self.struct, VDNQGV, DNQGVU, None),
-            NQGVUN: GeckoWordStructAccessor(self.struct, NQGVUN, QGVUNX, None),
-            GVUNXN: GeckoByteStructAccessor(self.struct, GVUNXN, VUNXNK, None),
-            UNXNKM: GeckoByteStructAccessor(self.struct, UNXNKM, NXNKML, None),
-            XNKMLO: GeckoWordStructAccessor(self.struct, XNKMLO, NKMLOI, None),
-            KMLOIJ: GeckoEnumStructAccessor(
-                self.struct, KMLOIJ, MLOIJU, None, IJUGSE, None, OCTHBS, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            JUGSEL: GeckoEnumStructAccessor(
-                self.struct, JUGSEL, UGSELH, None, WDAFIK, None, None, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            DAFIKJ: GeckoWordStructAccessor(self.struct, DAFIKJ, AFIKJP, None),
-            FIKJPU: GeckoByteStructAccessor(self.struct, FIKJPU, IKJPUN, None),
-            KJPUNR: GeckoByteStructAccessor(self.struct, KJPUNR, JPUNRJ, None),
-            PUNRJZ: GeckoEnumStructAccessor(
-                self.struct, PUNRJZ, UNRJZT, None, JZTATD, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            ZTATDZ: GeckoEnumStructAccessor(
-                self.struct, ZTATDZ, TATDZX, None, GKEAKS, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            KEAKST: GeckoEnumStructAccessor(
-                self.struct, KEAKST, EAKSTS, None, GKEAKS, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            AKSTSE: GeckoEnumStructAccessor(
-                self.struct, AKSTSE, KSTSEM, None, GKEAKS, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            STSEMC: GeckoEnumStructAccessor(
-                self.struct, STSEMC, TSEMCG, None, GKEAKS, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            SEMCGE: GeckoEnumStructAccessor(
-                self.struct, SEMCGE, EMCGET, None, GKEAKS, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            MCGETI: GeckoEnumStructAccessor(
-                self.struct, MCGETI, CGETIX, None, ETIXQV, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            TIXQVX: GeckoByteStructAccessor(self.struct, TIXQVX, IXQVXO, AKQXPI),
-            XQVXOI: GeckoByteStructAccessor(self.struct, XQVXOI, QVXOIH, AKQXPI),
-            VXOIHB: GeckoByteStructAccessor(self.struct, VXOIHB, XOIHBX, AKQXPI),
-            OIHBXI: GeckoByteStructAccessor(self.struct, OIHBXI, IHBXIB, AKQXPI),
-            HBXIBH: GeckoByteStructAccessor(self.struct, HBXIBH, BXIBHZ, AKQXPI),
-            XIBHZV: GeckoByteStructAccessor(self.struct, XIBHZV, IBHZVO, AKQXPI),
-            BHZVOA: GeckoEnumStructAccessor(
-                self.struct, BHZVOA, HZVOAC, None, VOACMC, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            OACMCV: GeckoEnumStructAccessor(
-                self.struct, OACMCV, CGETIX, None, VOACMC, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            ACMCVD: GeckoEnumStructAccessor(
-                self.struct, ACMCVD, IXQVXO, None, VOACMC, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            CMCVDS: GeckoEnumStructAccessor(
-                self.struct, CMCVDS, QVXOIH, None, VOACMC, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            MCVDSS: GeckoEnumStructAccessor(
-                self.struct, MCVDSS, XOIHBX, None, VOACMC, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            CVDSSR: GeckoEnumStructAccessor(
-                self.struct, CVDSSR, IHBXIB, None, VOACMC, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            VDSSRU: GeckoEnumStructAccessor(
-                self.struct, VDSSRU, BXIBHZ, None, VOACMC, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            DSSRUR: GeckoEnumStructAccessor(
-                self.struct, DSSRUR, SSRURA, None, SRURAZ, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, IBHZVO, None, SRURAZ, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            URAZMK: GeckoByteStructAccessor(self.struct, URAZMK, RAZMKQ, AKQXPI),
-            AZMKQT: GeckoByteStructAccessor(self.struct, AZMKQT, ZMKQTD, AKQXPI),
-            MKQTDK: GeckoByteStructAccessor(self.struct, MKQTDK, KQTDKH, AKQXPI),
-            QTDKHT: GeckoByteStructAccessor(self.struct, QTDKHT, TDKHTZ, AKQXPI),
-            DKHTZB: GeckoByteStructAccessor(self.struct, DKHTZB, KHTZBB, AKQXPI),
-            HTZBBE: GeckoByteStructAccessor(self.struct, HTZBBE, TZBBEK, AKQXPI),
-            ZBBEKB: GeckoByteStructAccessor(self.struct, ZBBEKB, BBEKBD, AKQXPI),
-            BEKBDF: GeckoByteStructAccessor(self.struct, BEKBDF, EKBDFS, AKQXPI),
-            KBDFSR: GeckoByteStructAccessor(self.struct, KBDFSR, BDFSRO, AKQXPI),
-            SCTTGC: GeckoBoolStructAccessor(self.struct, SCTTGC, JVHFTH, YEKCWA, None),
-            CTTGCR: GeckoByteStructAccessor(self.struct, CTTGCR, TTGCRH, AKQXPI),
-            TGCRHY: GeckoByteStructAccessor(self.struct, TGCRHY, GCRHYU, AKQXPI),
-            CRHYUA: GeckoByteStructAccessor(self.struct, CRHYUA, RHYUAX, AKQXPI),
-            HYUAXN: GeckoEnumStructAccessor(
-                self.struct, HYUAXN, YUAXNC, None, UGUCYR, None, None, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            GUCYRA: GeckoBoolStructAccessor(
-                self.struct, GUCYRA, UCYRAP, XPICXQ, AKQXPI
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            CYRAPU: GeckoBoolStructAccessor(self.struct, CYRAPU, UNRJZT, XPICXQ, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                ["GENERIC", "GECKO_5000W", "GECKO7500W"],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2-log-66.py
+++ b/src/geckolib/driver/packs/inyt-v2-log-66.py
@@ -12,1694 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACMCVD = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114, 67, 117, 114])
-ACQFFT = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 72, 116, 114, 83, 116, 117, 99, 107]
-)
-AFIKJP = "".join(chr(c) for c in [75, 49, 48, 48])
-AIIDNI = "".join(
-    chr(c) for c in [65, 109, 98, 105, 97, 110, 116, 79, 72, 76, 101, 118, 101, 108, 50]
-)
-AIVEMV = 464
-AJVDQL = 350
-AKQXPI = "".join(chr(c) for c in [65, 76, 76])
-AKSTSE = "".join(chr(c) for c in [80, 52, 76])
-AOAWBS = "".join(chr(c) for c in [67, 104, 101, 99, 107, 70, 108, 111])
-AONPYY = 310
-APUMEA = "".join(chr(c) for c in [72, 69, 65, 84, 73, 78, 71, 95, 70, 65, 73, 76])
-ATDZXN = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 115, 101, 116])
-AWBSIR = "".join(
-    chr(c) for c in [80, 114, 111, 103, 69, 99, 111, 110, 65, 99, 116, 105, 118, 101]
-)
-AXNCUG = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        105,
-        110,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-AZMKQT = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50])
-BBEKBD = "".join(chr(c) for c in [83, 79, 117, 116, 57, 67, 117, 114])
-BDFSRO = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49, 67, 117, 114])
-BDJQRJ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-BEKBDF = 343
-BFEGZU = 261
-BHZVOA = 329
-BIAMJM = 277
-BJEUTO = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-BJLOIN = 451
-BLKXSJ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        67,
-        111,
-        110,
-        102,
-        105,
-        103,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-BMJVHF = 256
-BQFYLJ = 384
-BQNRXC = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-BQSNQL = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        79,
-        117,
-        116,
-        108,
-        101,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-BSIRYX = "".join(chr(c) for c in [69, 99, 111, 110, 65, 99, 116, 105, 118, 101])
-BSKSOK = 258
-BSSUHB = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        69,
-        114,
-        114,
-        111,
-        114,
-        73,
-        68,
-    ]
-)
-BVWVUB = "".join(chr(c) for c in [82, 104, 82, 101, 103, 83, 108, 111, 112, 101])
-BWJYKL = 282
-BXIBHZ = "".join(chr(c) for c in [83, 79, 117, 116, 50, 67, 117, 114])
-BXTIAC = "".join(chr(c) for c in [72, 101, 97, 116, 101, 114, 83, 116, 117, 99, 107])
-BXYBQS = "".join(chr(c) for c in [80, 82, 69, 83, 83, 85, 82, 69, 95, 69, 82, 82])
-BYGDSB = "".join(chr(c) for c in [70, 76, 67, 69, 114, 114])
-CBFEGZ = "".join(chr(c) for c in [80, 49])
-CCPQIP = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-CGETIX = "".join(chr(c) for c in [83, 79, 117, 116, 51])
-CHWDAF = "".join(chr(c) for c in [75, 56])
-CMCVDS = 333
-CPQIPO = 263
-CQBMJV = 317
-CQFFTT = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 108, 97, 121, 83, 116, 117, 99, 107]
-)
-CRHYUA = "".join(chr(c) for c in [67, 70, 71, 51, 49])
-CRTFMN = 288
-CTHBSK = "".join(chr(c) for c in [85, 100, 80, 51])
-CTTGCR = "".join(chr(c) for c in [67, 70, 71, 50, 57])
-CUGUCY = 373
-CVDSSR = 325
-CVYYPI = "".join(chr(c) for c in [68, 101, 97, 108, 101, 114, 79, 112, 116])
-CWAONP = 7
-CXQIEF = "".join(chr(c) for c in [81, 117, 105, 101, 116, 83, 116, 97, 116, 101])
-CYRAPU = "".join(chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 70, 65, 73, 76])
-CYWONF = 467
-CZOLSI = "".join(chr(c) for c in [67, 70, 71, 50, 51])
-DAFIKJ = "".join(chr(c) for c in [75, 54, 48, 48, 76, 69])
-DDPMXF = "".join(chr(c) for c in [67, 70, 71, 48])
-DFSROG = 345
-DGKEAK = "".join(chr(c) for c in [80, 50, 76])
-DJQRJJ = 315
-DKHTZB = 340
-DMPSCT = "".join(chr(c) for c in [67, 70, 71, 50, 55])
-DNIBXT = "".join(chr(c) for c in [82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116])
-DNQGVU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-DPMXFU = 448
-DQLAII = 383
-DRXAIV = "".join(chr(c) for c in [67, 70, 71, 49, 53])
-DSBDJQ = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-DUBSSU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 77, 105, 115, 115, 105, 110, 103, 69, 114, 114]
-)
-DZXNQT = "".join(chr(c) for c in [45, 45, 45])
-EAKSTS = "".join(chr(c) for c in [80, 52, 72])
-EAOESV = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 74, 117, 115, 116, 82, 101, 115, 101, 116]
-)
-ECVYYP = "".join(
-    chr(c) for c in [73, 110, 115, 116, 97, 108, 108, 101, 114, 79, 112, 116]
-)
-EEZFET = "".join(chr(c) for c in [67, 70, 71, 49, 50])
-EFJTAC = "".join(
-    chr(c) for c in [70, 105, 108, 116, 101, 114, 65, 99, 99, 101, 115, 115]
-)
-EFXQGL = "".join(chr(c) for c in [83, 79, 65, 75])
-EGZUQE = "".join(chr(c) for c in [76, 79, 87])
-EJNIBX = "".join(
-    chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 82, 69, 81, 85, 69, 83, 84]
-)
-EKBDFS = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48, 67, 117, 114])
-EKCWAO = "".join(chr(c) for c in [83, 76, 86, 95, 72, 69, 65, 84, 69, 82])
-EKVKZI = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87, 95, 85, 76]
-)
-ELHBQN = "".join(chr(c) for c in [82, 101, 115, 116, 114, 105, 99, 116, 101, 100])
-ELWUEU = 454
-EMCGET = "".join(chr(c) for c in [83, 79, 117, 116, 50])
-EMVCYW = "".join(chr(c) for c in [67, 70, 71, 49, 56])
-EOCTHB = "".join(chr(c) for c in [85, 100, 80, 50])
-ETDRXA = "".join(chr(c) for c in [67, 70, 71, 49, 52])
-ETIXQV = "".join(chr(c) for c in [83, 79, 117, 116, 52])
-EUHNNX = 456
-EUTOPH = "".join(chr(c) for c in [75, 54, 48, 48])
-EXLSXU = "".join(chr(c) for c in [80, 53])
-EZFETD = 460
-FCRTFM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-FEFJTA = 367
-FEGZUQ = "".join(chr(c) for c in [72, 73, 71, 72])
-FETDRX = 461
-FFTTID = 351
-FIKJPU = "".join(chr(c) for c in [75, 56, 48, 48])
-FJBIAM = 275
-FJTACC = 262
-FMNHTB = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-FSROGM = "".join(chr(c) for c in [83, 79, 117, 116, 49, 50, 67, 117, 114])
-FTHECV = 319
-FTSIFJ = "".join(chr(c) for c in [83, 119, 109, 65, 100, 99])
-FTTIDU = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 79, 118, 101, 114, 72, 101, 97, 116]
-)
-FUBJLO = 450
-FWRKIN = "".join(chr(c) for c in [67, 72, 73, 76, 76])
-FXQGLR = "".join(chr(c) for c in [79, 70, 70])
-FYLJUI = 378
-FZCZOL = "".join(chr(c) for c in [67, 70, 71, 50, 50])
-FZDGKE = "".join(chr(c) for c in [80, 49, 76])
-GCRHYU = 478
-GDSBDJ = 311
-GETIXQ = 322
-GKEAKS = "".join(chr(c) for c in [80, 51, 72])
-GLRAHE = 259
-GMDDPM = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50, 67, 117, 114])
-GQPLSP = "".join(chr(c) for c in [77, 69, 68])
-GSELHB = "".join(chr(c) for c in [80, 97, 99, 107, 76, 111, 103, 84, 114, 105, 103])
-GTYIYW = "".join(chr(c) for c in [49, 54, 75])
-GUCYRA = 374
-GVUNXN = 294
-GYOUSP = "".join(chr(c) for c in [80, 117, 114, 103, 101])
-HBSKSO = "".join(chr(c) for c in [85, 100, 80, 53])
-HBVWVU = "".join(
-    chr(c) for c in [82, 104, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-HBXIBH = 327
-HECVYY = "".join(chr(c) for c in [])
-HEOCTH = 4
-HFTHEC = "".join(chr(c) for c in [77, 101, 110, 117])
-HIUSOO = "".join(chr(c) for c in [85, 100, 80, 117, 109, 112, 84, 105, 109, 101])
-HNNXWE = 457
-HTBJEU = "".join(chr(c) for c in [77, 73, 65])
-HTZBBE = 341
-HUGTYI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-HUOJRJ = "".join(chr(c) for c in [85, 100, 76, 105])
-HWDAFI = "".join(chr(c) for c in [75, 52])
-HXEKVK = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 53, 48, 48, 48, 87, 95, 67, 69]
-)
-HYUAXN = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        80,
-        114,
-        101,
-        115,
-        115,
-        117,
-        114,
-        101,
-        83,
-        119,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-HZVOAC = "".join(chr(c) for c in [83, 79, 117, 116, 52, 67, 117, 114])
-IACQFF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 50, 72, 83, 116, 117, 99, 107]
-)
-IAMJMA = "".join(chr(c) for c in [72, 101, 97, 116, 105, 110, 103])
-IBHZVO = "".join(chr(c) for c in [83, 79, 117, 116, 51, 67, 117, 114])
-IBXTIA = "".join(chr(c) for c in [80, 50, 72, 83, 116, 117, 99, 107])
-IBXYBQ = "".join(chr(c) for c in [69, 69, 49, 95, 69, 69, 50, 95, 69, 82, 82])
-ICXQIE = 1
-IDNIBX = 283
-IDUBSS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        65,
-        109,
-        98,
-        105,
-        97,
-        110,
-        116,
-        79,
-        72,
-        76,
-        101,
-        118,
-        101,
-        108,
-        50,
-    ]
-)
-IEFXQG = "".join(chr(c) for c in [68, 82, 65, 73, 78])
-IFJBIA = "".join(
-    chr(c) for c in [82, 101, 97, 108, 83, 101, 116, 80, 111, 105, 110, 116, 71]
-)
-IGYOUS = 273
-IHBXIB = "".join(chr(c) for c in [83, 79, 117, 116, 49, 67, 117, 114])
-IIDNIB = "".join(chr(c) for c in [75, 105, 110, 80, 117, 109, 112, 79, 102, 102])
-IJUGSE = 300
-IKFWRK = "".join(chr(c) for c in [72, 80, 67, 65, 117, 116, 111, 77, 111, 100, 101])
-IKJPUN = "".join(chr(c) for c in [75, 54, 48, 48, 72, 69])
-ILXWAJ = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-INEJNI = "".join(chr(c) for c in [72, 69, 65, 84, 95, 79, 78])
-INELWU = 453
-IPIVLA = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-IPMDMP = 473
-IPOUYN = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-IRYXBQ = 352
-IUSOOQ = 303
-IUXFEF = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 101, 101, 100]
-)
-IVDNQG = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-IVEMVC = "".join(chr(c) for c in [67, 70, 71, 49, 55])
-IVLASS = "".join(chr(c) for c in [78, 79, 84, 95, 73, 78, 83, 84, 65, 76, 76, 69, 68])
-IXQVXO = "".join(chr(c) for c in [83, 79, 117, 116, 53])
-IYWSKW = "".join(chr(c) for c in [54, 52, 75])
-JBIAMJ = "".join(
-    chr(c) for c in [68, 105, 115, 112, 108, 97, 121, 101, 100, 84, 101, 109, 112, 71]
-)
-JEUTOP = "".join(chr(c) for c in [105, 110, 88, 77])
-JHIUSO = 370
-JIGYOU = "".join(chr(c) for c in [67, 108, 101, 97, 110])
-JJJVYF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 82, 101, 103, 83, 108, 111, 112, 101]
-)
-JJVYFC = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JLOINE = "".join(chr(c) for c in [67, 70, 71, 52])
-JMAOAW = 279
-JMCBFE = "".join(chr(c) for c in [85, 100, 65, 117, 120, 84, 105, 109, 101])
-JNIBXY = "".join(
-    chr(c) for c in [67, 79, 73, 76, 95, 83, 69, 78, 83, 79, 82, 95, 69, 82, 82]
-)
-JPUNRJ = "".join(chr(c) for c in [73, 78, 86, 65, 76, 73, 68, 95, 84, 89, 80, 69])
-JQRJJJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 78, 111, 70, 108, 111, 69, 114, 114]
-)
-JRJHIU = 363
-JTACCP = "".join(chr(c) for c in [73, 78, 84, 69, 82, 78, 65, 76])
-JUGSEL = "".join(
-    chr(c)
-    for c in [80, 97, 99, 107, 78, 117, 109, 98, 101, 114, 79, 102, 67, 111, 110, 102]
-)
-JUIKFW = "".join(
-    chr(c) for c in [72, 80, 67, 72, 101, 97, 116, 82, 101, 113, 117, 101, 115, 116]
-)
-JUTYEK = 3
-JVDQLA = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-JVHFTH = 274
-JVYFCR = 285
-JWMNZM = 272
-JYKLGQ = "".join(chr(c) for c in [83, 119, 109, 65, 99, 116, 105, 118, 101])
-JYMOUN = 266
-JZTATD = 360
-KBDFSR = 344
-KCWAON = "".join(chr(c) for c in [87, 97, 116, 101, 114, 102, 97, 108, 108])
-KEAKST = "".join(chr(c) for c in [80, 51, 76])
-KFWRKI = "".join(chr(c) for c in [72, 69, 65, 84])
-KHTZBB = "".join(chr(c) for c in [83, 79, 117, 116, 55, 67, 117, 114])
-KINEJN = 379
-KJPUNR = "".join(chr(c) for c in [75, 51, 48, 48])
-KLGQPL = 313
-KMLOIJ = 297
-KPHUOJ = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48])
-KQXPIC = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-KSOKPH = "".join(chr(c) for c in [85, 100, 66, 76])
-KSTSEM = "".join(chr(c) for c in [66, 76, 79])
-KVKZIL = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 55, 53, 48, 48, 87, 95, 85, 76]
-)
-KWIVDN = "".join(chr(c) for c in [67, 69])
-KXSJWM = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 78, 98, 79, 102, 80, 104, 97, 115, 101, 115]
-)
-KZILXW = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-    ]
-)
-LAIIDN = "".join(
-    chr(c)
-    for c in [84, 104, 101, 114, 109, 105, 115, 116, 97, 110, 99, 101, 69, 114, 114]
-)
-LASSAK = "".join(chr(c) for c in [84, 82, 69, 65, 68, 77, 73, 76, 76])
-LGQPLS = "".join(chr(c) for c in [78, 79])
-LHBQNR = "".join(chr(c) for c in [70, 117, 108, 108])
-LIUXFE = 364
-LJUIKF = "".join(
-    chr(c)
-    for c in [
-        72,
-        80,
-        67,
-        82,
-        101,
-        115,
-        72,
-        101,
-        97,
-        116,
-        101,
-        114,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-    ]
-)
-LKXSJW = 270
-LNMHXE = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        84,
-        121,
-        112,
-        101,
-    ]
-)
-LOIJUG = 299
-LOINEL = 452
-LRAHEO = "".join(chr(c) for c in [76, 79])
-LSIPMD = 472
-LSPFTS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 80, 117, 114, 103, 101]
-)
-LWUEUH = "".join(chr(c) for c in [67, 70, 71, 55])
-LXWAJV = 284
-MAOAWB = "".join(
-    chr(c)
-    for c in [69, 120, 116, 80, 114, 111, 98, 101, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MCBFEG = 369
-MCGETI = 321
-MCVDSS = "".join(chr(c) for c in [83, 79, 117, 116, 54])
-MDDPMX = 348
-MDMPSC = 474
-MEAOES = 375
-MFZDGK = "".join(chr(c) for c in [80, 49, 72])
-MHXEKV = "".join(chr(c) for c in [71, 69, 78, 69, 82, 73, 67])
-MJIGYO = 381
-MJMAOA = "".join(
-    chr(c) for c in [84, 101, 109, 112, 78, 111, 116, 86, 97, 108, 105, 100]
-)
-MJVHFT = "".join(
-    chr(c) for c in [83, 116, 105, 99, 107, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-MKQTDK = 332
-MLOIJU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 118])
-MNHTBJ = "".join(chr(c) for c in [105, 110, 88, 69])
-MNZMJI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        65,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-MOUNBL = "".join(
-    chr(c)
-    for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 65, 99, 116, 105, 111, 110]
-)
-MPSCTT = 475
-MVCYWO = 466
-MXFUBJ = 449
-NBLKXS = 268
-NCUGUC = "".join(
-    chr(c)
-    for c in [
-        105,
-        110,
-        70,
-        108,
-        111,
-        82,
-        97,
-        116,
-        105,
-        111,
-        77,
-        97,
-        120,
-        105,
-        109,
-        117,
-        109,
-    ]
-)
-NEJNIB = "".join(chr(c) for c in [67, 72, 73, 76, 76, 95, 79, 78])
-NELWUE = "".join(chr(c) for c in [67, 70, 71, 54])
-NFZCZO = 469
-NHTBJE = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-NIBXTI = "".join(chr(c) for c in [80, 49, 72, 83, 116, 117, 99, 107])
-NIBXYB = "".join(
-    chr(c) for c in [65, 77, 66, 73, 69, 78, 84, 95, 84, 69, 77, 80, 95, 69, 82, 82]
-)
-NKMLOI = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 73, 68])
-NMHXEK = 389
-NNXWEE = "".join(chr(c) for c in [67, 70, 71, 49, 48])
-NPYYLI = "".join(chr(c) for c in [80, 65, 82, 84, 73, 65, 76])
-NQGVUN = 293
-NQJYMO = 264
-NQLNMH = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        82,
-        101,
-        113,
-        117,
-        101,
-        115,
-        116,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-NQTMFZ = "".join(chr(c) for c in [83, 79, 117, 116, 49])
-NRJZTA = 358
-NRSJMC = 306
-NRXCHW = "".join(chr(c) for c in [75, 50, 48, 48])
-NXNKML = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-NXWEEZ = 458
-NZMJIG = 380
-OACMCV = 331
-OAWBSI = 280
-OCTHBS = 2
-OESVZS = "".join(chr(c) for c in [76, 73])
-OGMDDP = 347
-OIJUGS = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 82, 101, 108])
-OINELW = "".join(chr(c) for c in [67, 70, 71, 53])
-OJRJHI = "".join(chr(c) for c in [85, 100, 87, 97, 116, 101, 114, 102, 97, 108, 108])
-OLSIPM = "".join(chr(c) for c in [67, 70, 71, 50, 52])
-ONFZCZ = "".join(chr(c) for c in [67, 70, 71, 50, 49])
-ONPYYL = "".join(chr(c) for c in [85, 78, 76, 79, 67, 75])
-OOQNRS = "".join(chr(c) for c in [85, 100, 76, 105, 103, 104, 116, 84, 105, 109, 101])
-OPHUGT = "".join(chr(c) for c in [105, 110, 89, 84])
-OQNRSJ = 305
-OUNBLK = 267
-OUSPBW = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        79,
-        84,
-    ]
-)
-OUYNQJ = "".join(chr(c) for c in [65, 67, 84, 73, 86, 69])
-PBWJYK = "".join(
-    chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101, 83, 117, 115, 112]
-)
-PFTSIF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 83, 119, 109, 65, 99, 116, 105, 118, 101]
-)
-PHUOJR = 308
-PICXQI = "".join(
-    chr(c)
-    for c in [
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        85,
-        115,
-        101,
-        114,
-        79,
-        102,
-        102,
-    ]
-)
-PIVLAS = 385
-PMDMPS = "".join(chr(c) for c in [67, 70, 71, 50, 54])
-PMXFUB = "".join(chr(c) for c in [67, 70, 71, 49])
-POUYNQ = "".join(chr(c) for c in [78, 69, 87])
-PQIPOU = "".join(chr(c) for c in [73, 68, 76, 69])
-PSCTTG = "".join(chr(c) for c in [67, 70, 71, 50, 56])
-PYYLIU = "".join(chr(c) for c in [70, 85, 76, 76])
-QBMJVH = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-QEXLSX = "".join(chr(c) for c in [80, 52])
-QFFTTI = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 75, 105, 110, 80, 117, 109, 112, 79, 102, 102]
-)
-QFYLJU = "".join(
-    chr(c)
-    for c in [
-        67,
-        111,
-        111,
-        108,
-        90,
-        111,
-        110,
-        101,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-QGLRAH = "".join(chr(c) for c in [85, 100, 80, 49])
-QGVUNX = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-QIEFXQ = "".join(chr(c) for c in [78, 79, 84, 95, 83, 69, 84])
-QIPOUY = "".join(chr(c) for c in [83, 84, 79, 80])
-QJYMOU = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        70,
-        105,
-        108,
-        116,
-        68,
-        117,
-        114,
-        80,
-        101,
-        114,
-        68,
-        97,
-        121,
-    ]
-)
-QLAIID = "".join(
-    chr(c) for c in [84, 104, 101, 114, 109, 70, 117, 115, 101, 69, 114, 114]
-)
-QLNMHX = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-        67,
-        104,
-        101,
-        99,
-        107,
-        70,
-        108,
-        111,
-        119,
-    ]
-)
-QNRSJM = "".join(chr(c) for c in [85, 100, 76, 49, 50, 48, 84, 105, 109, 101])
-QNRXCH = 357
-QPLSPF = "".join(chr(c) for c in [69, 88, 84, 82, 69, 77, 69])
-QRJJJV = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 76, 69, 114, 114])
-QSNQLN = 392
-QTDKHT = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 50])
-QTMFZD = 320
-QVXOIH = "".join(chr(c) for c in [83, 79, 117, 116, 72, 116, 114])
-QXPICX = 388
-RAHEOC = "".join(chr(c) for c in [72, 73])
-RAPUME = "".join(
-    chr(c)
-    for c in [
-        77,
-        79,
-        68,
-        69,
-        95,
-        49,
-        95,
-        65,
-        78,
-        68,
-        95,
-        72,
-        69,
-        65,
-        84,
-        73,
-        78,
-        71,
-        95,
-        70,
-        65,
-        73,
-        76,
-    ]
-)
-RAZMKQ = "".join(chr(c) for c in [83, 79, 117, 116, 49, 49])
-RHYUAX = 479
-RJHIUS = "".join(chr(c) for c in [85, 100, 65, 117, 120])
-RJJJVY = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 82, 101, 103, 80, 114, 111, 98, 101, 69, 114, 114]
-)
-RJZTAT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-RKINEJ = "".join(chr(c) for c in [72, 80, 67, 83, 116, 97, 116, 101])
-ROGMDD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116, 67, 117, 114])
-RSJMCB = "".join(
-    chr(c)
-    for c in [85, 100, 87, 97, 116, 101, 114, 70, 97, 108, 108, 84, 105, 109, 101]
-)
-RTFMNH = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-RURAZM = "".join(chr(c) for c in [83, 79, 117, 116, 57])
-RXAIVE = 463
-RXCHWD = "".join(chr(c) for c in [75, 52, 48, 48])
-RYXBQF = "".join(
-    chr(c)
-    for c in [83, 105, 100, 101, 72, 101, 97, 116, 105, 110, 103, 68, 101, 103, 71]
-)
-SAKQXP = 386
-SBDJQR = 314
-SBVNAX = 479
-SCTTGC = 476
-SELHBQ = 316
-SIFJBI = "".join(chr(c) for c in [79, 118, 101, 114, 84, 101, 109, 112])
-SIPMDM = "".join(chr(c) for c in [67, 70, 71, 50, 53])
-SIRYXB = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 118, 101, 114, 84, 101, 109, 112]
-)
-SJMCBF = 362
-SJWMNZ = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        66,
-        114,
-        101,
-        97,
-        107,
-        101,
-        114,
-        73,
-        110,
-        100,
-        101,
-        120,
-    ]
-)
-SKWIVD = "".join(chr(c) for c in [85, 76])
-SNQLNM = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        80,
-        67,
-        65,
-        109,
-        98,
-        105,
-        101,
-        110,
-        116,
-        80,
-        114,
-        111,
-        116,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-SOKPHU = "".join(chr(c) for c in [79, 78])
-SOOQNR = 304
-SPBWJY = "".join(chr(c) for c in [67, 80, 79, 84])
-SPFTSI = 353
-SROGMD = 346
-SRURAZ = "".join(chr(c) for c in [83, 79, 117, 116, 56])
-SSAKQX = "".join(
-    chr(c)
-    for c in [
-        69,
-        120,
-        101,
-        114,
-        99,
-        105,
-        115,
-        101,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-SSBVNA = 256
-SSRURA = "".join(chr(c) for c in [83, 79, 117, 116, 55])
-SSUHBV = 387
-STSEMC = "".join(chr(c) for c in [70, 117, 108, 108, 79, 110])
-SUHBVW = "".join(
-    chr(c) for c in [82, 104, 70, 108, 111, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-SXUJUT = "".join(chr(c) for c in [66, 76])
-TACCPQ = "".join(chr(c) for c in [82, 69, 77, 79, 84, 69])
-TATDZX = 361
-TBJEUT = "".join(chr(c) for c in [68, 74, 83, 52])
-TDKHTZ = "".join(chr(c) for c in [83, 79, 117, 116, 54, 67, 117, 114])
-TDRXAI = 462
-TDZXNQ = 376
-TFMNHT = 289
-TGCRHY = "".join(chr(c) for c in [67, 70, 71, 51, 48])
-THBSKS = "".join(chr(c) for c in [85, 100, 80, 52])
-THECVY = "".join(chr(c) for c in [78, 79, 82, 77, 65, 76])
-TIACQF = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 80, 49, 72, 83, 116, 117, 99, 107]
-)
-TIDUBS = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        105,
-        115,
-        116,
-        97,
-        110,
-        99,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TIXQVX = 323
-TMFZDG = "".join(chr(c) for c in [78, 65])
-TOPHUG = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-TSEMCG = "".join(chr(c) for c in [65, 85, 88])
-TSIFJB = 355
-TTGCRH = 477
-TTIDUB = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        84,
-        104,
-        101,
-        114,
-        109,
-        70,
-        117,
-        115,
-        101,
-        69,
-        114,
-        114,
-    ]
-)
-TYEKCW = "".join(chr(c) for c in [77, 83, 84, 82, 95, 72, 69, 65, 84, 69, 82])
-TYIYWS = "".join(chr(c) for c in [51, 50, 75])
-TZBBEK = "".join(chr(c) for c in [83, 79, 117, 116, 56, 67, 117, 114])
-UAXNCU = 371
-UBJLOI = "".join(chr(c) for c in [67, 70, 71, 51])
-UBSSUH = 354
-UCYRAP = "".join(chr(c) for c in [70, 76, 79, 87, 95, 79, 75])
-UEUHNN = "".join(chr(c) for c in [67, 70, 71, 56])
-UGSELH = 301
-UGTYIY = 290
-UGUCYR = "".join(
-    chr(c) for c in [105, 110, 70, 108, 111, 69, 114, 114, 111, 114, 84, 121, 112, 101]
-)
-UHBVWV = "".join(chr(c) for c in [82, 104, 72, 119, 72, 76])
-UHNNXW = "".join(chr(c) for c in [67, 70, 71, 57])
-UIKFWR = "".join(
-    chr(c)
-    for c in [72, 80, 67, 67, 104, 105, 108, 108, 82, 101, 113, 117, 101, 115, 116]
-)
-UJUTYE = "".join(chr(c) for c in [79, 51])
-UMEAOE = "".join(
-    chr(c) for c in [70, 111, 114, 99, 101, 67, 104, 101, 99, 107, 70, 108, 111]
-)
-UNBLKX = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 69, 99, 111, 110, 68, 117, 114]
-)
-UNRJZT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-UNXNKM = 295
-UOJRJH = 307
-UQEXLS = "".join(chr(c) for c in [80, 51])
-URAZMK = "".join(chr(c) for c in [83, 79, 117, 116, 49, 48])
-USOOQN = "".join(chr(c) for c in [85, 100, 81, 117, 105, 101, 116, 84, 105, 109, 101])
-USPBWJ = "".join(
-    chr(c)
-    for c in [
-        70,
-        105,
-        108,
-        116,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        101,
-        100,
-        66,
-        121,
-        69,
-        114,
-        114,
-    ]
-)
-UTOPHU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-UTYEKC = "".join(chr(c) for c in [76, 49, 50, 48])
-UXFEFJ = 365
-VCYWON = "".join(chr(c) for c in [67, 70, 71, 49, 57])
-VDNQGV = 291
-VDQLAI = "".join(
-    chr(c)
-    for c in [
-        83,
-        105,
-        108,
-        101,
-        110,
-        116,
-        77,
-        111,
-        100,
-        101,
-        65,
-        99,
-        116,
-        105,
-        118,
-        101,
-    ]
-)
-VDSSRU = "".join(chr(c) for c in [70, 97, 110])
-VEMVCY = 465
-VHFTHE = 6
-VLASSA = "".join(chr(c) for c in [83, 87, 73, 77, 95, 69, 88, 69, 82, 67, 73, 83, 69])
-VOACMC = "".join(chr(c) for c in [83, 79, 117, 116, 53, 67, 117, 114])
-VUBYGD = "".join(
-    chr(c) for c in [82, 104, 78, 111, 70, 108, 111, 88, 84, 114, 105, 101, 115]
-)
-VUNXNK = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-VWVUBY = "".join(
-    chr(c) for c in [82, 104, 72, 114, 75, 105, 110, 78, 111, 70, 108, 111]
-)
-VXOIHB = 326
-VYFCRT = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-VYYPIP = "".join(
-    chr(c) for c in [65, 99, 99, 101, 115, 115, 111, 114, 121, 79, 112, 116]
-)
-WAJVDQ = "".join(
-    chr(c)
-    for c in [
-        83,
-        108,
-        97,
-        118,
-        101,
-        72,
-        116,
-        114,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-WAONPY = "".join(chr(c) for c in [76, 111, 99, 107, 77, 111, 100, 101])
-WBSIRY = 281
-WDAFIK = "".join(chr(c) for c in [75, 53])
-WEEZFE = 459
-WJYKLG = "".join(chr(c) for c in [83, 119, 109, 80, 117, 114, 103, 101])
-WMNZMJ = "".join(
-    chr(c)
-    for c in [80, 114, 111, 103, 79, 117, 116, 112, 117, 116, 65, 99, 99, 101, 115, 115]
-)
-WONFZC = 468
-WSKWIV = "".join(chr(c) for c in [80, 97, 99, 107, 82, 101, 103, 105, 111, 110])
-WUEUHN = 455
-WVUBYG = 309
-XAIVEM = "".join(chr(c) for c in [67, 70, 71, 49, 54])
-XBQFYL = "".join(
-    chr(c) for c in [73, 110, 71, 114, 105, 100, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-XCHWDA = "".join(chr(c) for c in [75, 56, 53])
-XEKVKZ = "".join(
-    chr(c) for c in [71, 69, 67, 75, 79, 95, 55, 53, 48, 48, 87, 95, 67, 69]
-)
-XFEFJT = "".join(
-    chr(c) for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 75, 101, 121]
-)
-XFUBJL = "".join(chr(c) for c in [67, 70, 71, 50])
-XIBHZV = 328
-XLSXUJ = 260
-XNCUGU = 372
-XNKMLO = 296
-XOIHBX = "".join(chr(c) for c in [72, 84, 82])
-XPICXQ = 0
-XQIEFX = 257
-XQVXOI = 324
-XSJWMN = 271
-XTIACQ = "".join(chr(c) for c in [82, 101, 108, 97, 121, 83, 116, 117, 99, 107])
-XUJUTY = "".join(chr(c) for c in [67, 80])
-XWAJVD = "".join(
-    chr(c)
-    for c in [
-        72,
-        116,
-        114,
-        50,
-        83,
-        117,
-        115,
-        112,
-        101,
-        110,
-        100,
-        66,
-        121,
-        80,
-        119,
-        114,
-        77,
-        110,
-        103,
-    ]
-)
-XWEEZF = "".join(chr(c) for c in [67, 70, 71, 49, 49])
-XYBQSN = "".join(chr(c) for c in [79, 84, 72, 69, 82, 95, 69, 82, 82])
-YEKCWA = 5
-YFCRTF = 287
-YGDSBD = "".join(chr(c) for c in [105, 110, 84, 67, 105, 112, 68, 101, 108, 97, 121])
-YIYWSK = "".join(chr(c) for c in [52, 56, 75])
-YKLGQP = "".join(chr(c) for c in [83, 119, 109, 82, 105, 115, 107])
-YLIUXF = "".join(
-    chr(c)
-    for c in [68, 101, 97, 108, 101, 114, 76, 111, 99, 107, 83, 116, 97, 116, 117, 115]
-)
-YLJUIK = "".join(
-    chr(c)
-    for c in [
-        77,
-        111,
-        100,
-        98,
-        117,
-        115,
-        72,
-        101,
-        97,
-        116,
-        80,
-        117,
-        109,
-        112,
-        68,
-        101,
-        116,
-        101,
-        99,
-        116,
-        101,
-        100,
-    ]
-)
-YMOUNB = "".join(
-    chr(c) for c in [69, 99, 111, 110, 111, 109, 121, 65, 99, 99, 101, 115, 115]
-)
-YNQJYM = "".join(
-    chr(c) for c in [82, 101, 109, 111, 116, 101, 70, 105, 108, 116, 68, 117, 114]
-)
-YOUSPB = "".join(
-    chr(c)
-    for c in [70, 105, 108, 116, 83, 117, 115, 112, 101, 110, 100, 66, 121, 85, 68]
-)
-YPIPIV = "".join(chr(c) for c in [83, 116, 105, 99, 107, 66, 97, 110, 107])
-YRAPUM = "".join(
-    chr(c) for c in [77, 79, 68, 69, 95, 49, 95, 65, 78, 68, 95, 50, 95, 70, 65, 73, 76]
-)
-YUAXNC = "".join(chr(c) for c in [105, 110, 70, 108, 111, 82, 97, 116, 105, 111])
-YWONFZ = "".join(chr(c) for c in [67, 70, 71, 50, 48])
-YXBQFY = 377
-YYPIPI = "".join(
-    chr(c) for c in [67, 111, 110, 102, 105, 103, 83, 101, 108, 101, 99, 116]
-)
-ZBBEKB = 342
-ZCQBMJ = "".join(chr(c) for c in [82, 104, 87, 97, 116, 101, 114, 84, 101, 109, 112])
-ZCZOLS = 470
-ZDGKEA = "".join(chr(c) for c in [80, 50, 72])
-ZFETDR = "".join(chr(c) for c in [67, 70, 71, 49, 51])
-ZILXWA = 390
-ZMJIGY = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        111,
-        116,
-        101,
-        80,
-        114,
-        111,
-        103,
-        79,
-        117,
-        116,
-        112,
-        117,
-        116,
-        68,
-        117,
-        114,
-    ]
-)
-ZMKQTD = "".join(chr(c) for c in [83, 68, 105, 114, 101, 99, 116])
-ZOLSIP = 471
-ZSSBVN = 66
-ZTATDZ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-ZUQEXL = "".join(chr(c) for c in [80, 50])
-ZVOACM = 330
-ZXNQTM = "".join(chr(c) for c in [82, 69, 83, 69, 84])
-ACCPQI = [JTACCP, TACCPQ]
-AHEOCT = [FXQGLR, LRAHEO, RAHEOC]
-AMJMAO = [HECVYY, IAMJMA, IAMJMA, IAMJMA]
-AOESVZ = []
-ASSAKQ = [IVLASS, VLASSA, LASSAK]
-DSSRUR = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    VDSSRU,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-ESVZSS = [
-    CBFEGZ,
-    ZUQEXL,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    TYEKCW,
-    EKCWAO,
-    KCWAON,
-    WAONPY,
-    YLIUXF,
-    IUXFEF,
-    XFEFJT,
-    OESVZS,
-]
-GZUQEX = [FXQGLR, FEGZUQ, EGZUQE]
-HBQNRX = [ELHBQN, LHBQNR]
-KQTDKH = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XUJUTY,
-]
-LSXUJU = [FXQGLR, FEGZUQ]
-OIHBXI = [
-    TMFZDG,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    XOIHBX,
-]
-OKPHUO = [FXQGLR, SOKPHU]
-PHUGTY = [
-    FMNHTB,
-    MNHTBJ,
-    NHTBJE,
-    HTBJEU,
-    TBJEUT,
-    BJEUTO,
-    JEUTOP,
-    EUTOPH,
-    UTOPHU,
-    TOPHUG,
-    OPHUGT,
-]
-PIPIVL = [
-    THECVY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-    HECVYY,
-    YPIPIV,
-]
-PLSPFT = [LGQPLS, LRAHEO, GQPLSP, RAHEOC, QPLSPF]
-PUMEAO = [UCYRAP, CYRAPU, YRAPUM, RAPUME, APUMEA]
-PUNRJZ = [
-    NRXCHW,
-    RXCHWD,
-    XCHWDA,
-    CHWDAF,
-    HWDAFI,
-    WDAFIK,
-    DAFIKJ,
-    AFIKJP,
-    FIKJPU,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    IKJPUN,
-    KJPUNR,
-    JPUNRJ,
-]
-SEMCGE = [
-    TMFZDG,
-    MFZDGK,
-    FZDGKE,
-    ZDGKEA,
-    DGKEAK,
-    GKEAKS,
-    KEAKST,
-    EAKSTS,
-    AKSTSE,
-    EXLSXU,
-    KSTSEM,
-    XUJUTY,
-    UJUTYE,
-    UTYEKC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    STSEMC,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    KCWAON,
-    TSEMCG,
-]
-SKSOKP = [FXQGLR, RAHEOC]
-SVZSSB = [
-    QGLRAH,
-    EOCTHB,
-    CTHBSK,
-    THBSKS,
-    HBSKSO,
-    KSOKPH,
-    KPHUOJ,
-    HUOJRJ,
-    OJRJHI,
-    RJHIUS,
-    HIUSOO,
-    USOOQN,
-    OOQNRS,
-    QNRSJM,
-    RSJMCB,
-    JMCBFE,
-]
-UBYGDS = [HECVYY, VUBYGD, VUBYGD, VUBYGD]
-UYNQJY = [PQIPOU, QIPOUY, IPOUYN, POUYNQ, OUYNQJ]
-VKZILX = [MHXEKV, HXEKVK, XEKVKZ, EKVKZI, KVKZIL]
-VZSSBV = [
-    QRJJJV,
-    FTTIDU,
-    IDUBSS,
-    IBXTIA,
-    SIFJBI,
-    BYGDSB,
-    JQRJJJ,
-    RJJJVY,
-    MJMAOA,
-    USPBWJ,
-    CQFFTT,
-    TIACQF,
-    QLAIID,
-    SIRYXB,
-    BDJQRJ,
-    XTIACQ,
-    QFFTTI,
-    ACQFFT,
-    DNIBXT,
-    DUBSSU,
-    IIDNIB,
-    LAIIDN,
-    TTIDUB,
-    HBVWVU,
-    TIDUBS,
-    AIIDNI,
-    BSSUHB,
-    IACQFF,
-    BXTIAC,
-    NIBXTI,
-]
-WIVDNQ = [SKWIVD, KWIVDN]
-WRKINE = [KFWRKI, FWRKIN]
-XNQTMF = [DZXNQT, ZXNQTM]
-XQGLRA = [QIEFXQ, IEFXQG, EFXQGL, FXQGLR]
-YBQSNQ = [
-    PQIPOU,
-    INEJNI,
-    NEJNIB,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    HECVYY,
-    EJNIBX,
-    JNIBXY,
-    NIBXYB,
-    IBXYBQ,
-    BXYBQS,
-    XYBQSN,
-]
-YWSKWI = [GTYIYW, TYIYWS, YIYWSK, IYWSKW]
-YYLIUX = [ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -1707,344 +19,1290 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return ZSSBVN
+        return 66
 
     @property
     def begin(self):
-        return SSBVNA
+        return 256
 
     @property
     def end(self):
-        return SBVNAX
+        return 479
 
     @property
     def all_device_keys(self):
-        return ESVZSS
+        return [
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "BL",
+            "CP",
+            "O3",
+            "L120",
+            "MSTR_HEATER",
+            "SLV_HEATER",
+            "Waterfall",
+            "LockMode",
+            "DealerLockStatus",
+            "DealerLockSeed",
+            "DealerLockKey",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return SVZSSB
+        return [
+            "UdP1",
+            "UdP2",
+            "UdP3",
+            "UdP4",
+            "UdP5",
+            "UdBL",
+            "UdL120",
+            "UdLi",
+            "UdWaterfall",
+            "UdAux",
+            "UdPumpTime",
+            "UdQuietTime",
+            "UdLightTime",
+            "UdL120Time",
+            "UdWaterFallTime",
+            "UdAuxTime",
+        ]
 
     @property
     def error_keys(self):
-        return VZSSBV
+        return [
+            "SlaveNoFloErr",
+            "AmbiantOHLevel2",
+            "RegOverHeat",
+            "ThermistanceErr",
+            "P1HStuck",
+            "SlaveRelayStuck",
+            "SlaveP2HStuck",
+            "SlaveAmbiantOHLevel2",
+            "SlaveRegProbeErr",
+            "FiltSuspendedByErr",
+            "SlaveKinPumpOff",
+            "ModbusHeatPumpErrorID",
+            "SlaveThermistanceErr",
+            "TempNotValid",
+            "FLCErr",
+            "SlaveP1HStuck",
+            "KinPumpOff",
+            "SlaveHtrStuck",
+            "SlaveOverTemp",
+            "ThermFuseErr",
+            "SlaveRegOverHeat",
+            "P2HStuck",
+            "SlaveHLErr",
+            "RelayStuck",
+            "RhRegProbeErr",
+            "SlaveMissingErr",
+            "HeaterStuck",
+            "SlaveThermFuseErr",
+            "SlaveKinNoFloErr",
+            "OverTemp",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, None),
-            QBMJVH: GeckoByteStructAccessor(self.struct, QBMJVH, BMJVHF, None),
-            MJVHFT: GeckoBoolStructAccessor(self.struct, MJVHFT, JVHFTH, VHFTHE, None),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, PIPIVL, None, None, None
+            "RhWaterTemp": GeckoTempStructAccessor(
+                self.struct, "RhWaterTemp", 317, None
             ),
-            IPIVLA: GeckoEnumStructAccessor(
-                self.struct, IPIVLA, PIVLAS, None, ASSAKQ, None, None, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "StickDetected": GeckoBoolStructAccessor(
+                self.struct, "StickDetected", 274, 6, None
             ),
-            SSAKQX: GeckoByteStructAccessor(self.struct, SSAKQX, SAKQXP, AKQXPI),
-            KQXPIC: GeckoBoolStructAccessor(self.struct, KQXPIC, QXPICX, XPICXQ, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, QXPICX, ICXQIE, None),
-            CXQIEF: GeckoEnumStructAccessor(
-                self.struct, CXQIEF, XQIEFX, None, XQGLRA, None, None, AKQXPI
+            "Menu": GeckoEnumStructAccessor(
+                self.struct,
+                "Menu",
+                319,
+                None,
+                [
+                    "NORMAL",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "InstallerOpt",
+                    "DealerOpt",
+                    "AccessoryOpt",
+                    "ConfigSelect",
+                    "",
+                    "StickBank",
+                ],
+                None,
+                None,
+                None,
             ),
-            QGLRAH: GeckoEnumStructAccessor(
-                self.struct, QGLRAH, GLRAHE, XPICXQ, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseDetectedType": GeckoEnumStructAccessor(
+                self.struct,
+                "ExerciseDetectedType",
+                385,
+                None,
+                ["NOT_INSTALLED", "SWIM_EXERCISE", "TREADMILL"],
+                None,
+                None,
+                None,
             ),
-            EOCTHB: GeckoEnumStructAccessor(
-                self.struct, EOCTHB, GLRAHE, OCTHBS, AHEOCT, None, HEOCTH, AKQXPI
+            "ExerciseIntensity": GeckoByteStructAccessor(
+                self.struct, "ExerciseIntensity", 386, "ALL"
             ),
-            CTHBSK: GeckoEnumStructAccessor(
-                self.struct, CTHBSK, GLRAHE, HEOCTH, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputRequest": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputRequest", 388, 0, None
             ),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, GLRAHE, VHFTHE, AHEOCT, None, HEOCTH, AKQXPI
+            "ProgOutputUserOff": GeckoBoolStructAccessor(
+                self.struct, "ProgOutputUserOff", 388, 1, None
             ),
-            HBSKSO: GeckoEnumStructAccessor(
-                self.struct, HBSKSO, BSKSOK, XPICXQ, SKSOKP, None, OCTHBS, AKQXPI
+            "QuietState": GeckoEnumStructAccessor(
+                self.struct,
+                "QuietState",
+                257,
+                None,
+                ["NOT_SET", "DRAIN", "SOAK", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoEnumStructAccessor(
-                self.struct, KSOKPH, BSKSOK, ICXQIE, OKPHUO, None, OCTHBS, AKQXPI
+            "UdP1": GeckoEnumStructAccessor(
+                self.struct, "UdP1", 259, 0, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            KPHUOJ: GeckoEnumStructAccessor(
-                self.struct, KPHUOJ, PHUOJR, None, OKPHUO, None, None, AKQXPI
+            "UdP2": GeckoEnumStructAccessor(
+                self.struct, "UdP2", 259, 2, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            HUOJRJ: GeckoEnumStructAccessor(
-                self.struct, HUOJRJ, UOJRJH, None, SKSOKP, None, None, AKQXPI
+            "UdP3": GeckoEnumStructAccessor(
+                self.struct, "UdP3", 259, 4, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            OJRJHI: GeckoEnumStructAccessor(
-                self.struct, OJRJHI, JRJHIU, None, OKPHUO, None, None, AKQXPI
+            "UdP4": GeckoEnumStructAccessor(
+                self.struct, "UdP4", 259, 6, ["OFF", "LO", "HI"], None, 4, "ALL"
             ),
-            RJHIUS: GeckoEnumStructAccessor(
-                self.struct, RJHIUS, JHIUSO, None, OKPHUO, None, None, AKQXPI
+            "UdP5": GeckoEnumStructAccessor(
+                self.struct, "UdP5", 258, 0, ["OFF", "HI"], None, 2, "ALL"
             ),
-            HIUSOO: GeckoByteStructAccessor(self.struct, HIUSOO, IUSOOQ, AKQXPI),
-            USOOQN: GeckoByteStructAccessor(self.struct, USOOQN, SOOQNR, AKQXPI),
-            OOQNRS: GeckoByteStructAccessor(self.struct, OOQNRS, OQNRSJ, AKQXPI),
-            QNRSJM: GeckoByteStructAccessor(self.struct, QNRSJM, NRSJMC, AKQXPI),
-            RSJMCB: GeckoByteStructAccessor(self.struct, RSJMCB, SJMCBF, AKQXPI),
-            JMCBFE: GeckoByteStructAccessor(self.struct, JMCBFE, MCBFEG, AKQXPI),
-            CBFEGZ: GeckoEnumStructAccessor(
-                self.struct, CBFEGZ, BFEGZU, XPICXQ, GZUQEX, None, HEOCTH, None
+            "UdBL": GeckoEnumStructAccessor(
+                self.struct, "UdBL", 258, 1, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ZUQEXL: GeckoEnumStructAccessor(
-                self.struct, ZUQEXL, BFEGZU, OCTHBS, GZUQEX, None, HEOCTH, None
+            "UdL120": GeckoEnumStructAccessor(
+                self.struct, "UdL120", 308, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            UQEXLS: GeckoEnumStructAccessor(
-                self.struct, UQEXLS, BFEGZU, HEOCTH, GZUQEX, None, HEOCTH, None
+            "UdLi": GeckoEnumStructAccessor(
+                self.struct, "UdLi", 307, None, ["OFF", "HI"], None, None, "ALL"
             ),
-            QEXLSX: GeckoEnumStructAccessor(
-                self.struct, QEXLSX, BFEGZU, VHFTHE, GZUQEX, None, HEOCTH, None
+            "UdWaterfall": GeckoEnumStructAccessor(
+                self.struct, "UdWaterfall", 363, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, XPICXQ, LSXUJU, None, OCTHBS, None
+            "UdAux": GeckoEnumStructAccessor(
+                self.struct, "UdAux", 370, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            SXUJUT: GeckoEnumStructAccessor(
-                self.struct, SXUJUT, XLSXUJ, ICXQIE, OKPHUO, None, OCTHBS, None
+            "UdPumpTime": GeckoByteStructAccessor(
+                self.struct, "UdPumpTime", 303, "ALL"
             ),
-            XUJUTY: GeckoEnumStructAccessor(
-                self.struct, XUJUTY, XLSXUJ, OCTHBS, OKPHUO, None, OCTHBS, None
+            "UdQuietTime": GeckoByteStructAccessor(
+                self.struct, "UdQuietTime", 304, "ALL"
             ),
-            UJUTYE: GeckoEnumStructAccessor(
-                self.struct, UJUTYE, XLSXUJ, JUTYEK, OKPHUO, None, OCTHBS, None
+            "UdLightTime": GeckoByteStructAccessor(
+                self.struct, "UdLightTime", 305, "ALL"
             ),
-            UTYEKC: GeckoEnumStructAccessor(
-                self.struct, UTYEKC, XLSXUJ, HEOCTH, OKPHUO, None, OCTHBS, None
+            "UdL120Time": GeckoByteStructAccessor(
+                self.struct, "UdL120Time", 306, "ALL"
             ),
-            TYEKCW: GeckoEnumStructAccessor(
-                self.struct, TYEKCW, XLSXUJ, YEKCWA, OKPHUO, None, OCTHBS, None
+            "UdWaterFallTime": GeckoByteStructAccessor(
+                self.struct, "UdWaterFallTime", 362, "ALL"
             ),
-            EKCWAO: GeckoEnumStructAccessor(
-                self.struct, EKCWAO, XLSXUJ, VHFTHE, OKPHUO, None, OCTHBS, None
+            "UdAuxTime": GeckoByteStructAccessor(self.struct, "UdAuxTime", 369, "ALL"),
+            "P1": GeckoEnumStructAccessor(
+                self.struct, "P1", 261, 0, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, XLSXUJ, CWAONP, OKPHUO, None, OCTHBS, None
+            "P2": GeckoEnumStructAccessor(
+                self.struct, "P2", 261, 2, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            WAONPY: GeckoEnumStructAccessor(
-                self.struct, WAONPY, AONPYY, None, YYLIUX, None, None, AKQXPI
+            "P3": GeckoEnumStructAccessor(
+                self.struct, "P3", 261, 4, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            YLIUXF: GeckoEnumStructAccessor(
-                self.struct, YLIUXF, LIUXFE, None, YYLIUX, None, None, None
+            "P4": GeckoEnumStructAccessor(
+                self.struct, "P4", 261, 6, ["OFF", "HIGH", "LOW"], None, 4, None
             ),
-            IUXFEF: GeckoWordStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoWordStructAccessor(self.struct, XFEFJT, FEFJTA, AKQXPI),
-            EFJTAC: GeckoEnumStructAccessor(
-                self.struct, EFJTAC, FJTACC, XPICXQ, ACCPQI, None, OCTHBS, AKQXPI
+            "P5": GeckoEnumStructAccessor(
+                self.struct, "P5", 260, 0, ["OFF", "HIGH"], None, 2, None
             ),
-            CCPQIP: GeckoEnumStructAccessor(
-                self.struct, CCPQIP, CPQIPO, None, UYNQJY, None, None, AKQXPI
+            "BL": GeckoEnumStructAccessor(
+                self.struct, "BL", 260, 1, ["OFF", "ON"], None, 2, None
             ),
-            YNQJYM: GeckoTimeStructAccessor(self.struct, YNQJYM, NQJYMO, AKQXPI),
-            QJYMOU: GeckoByteStructAccessor(self.struct, QJYMOU, JYMOUN, AKQXPI),
-            YMOUNB: GeckoEnumStructAccessor(
-                self.struct, YMOUNB, FJTACC, OCTHBS, ACCPQI, None, OCTHBS, AKQXPI
+            "CP": GeckoEnumStructAccessor(
+                self.struct, "CP", 260, 2, ["OFF", "ON"], None, 2, None
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, OUNBLK, None, UYNQJY, None, None, AKQXPI
+            "O3": GeckoEnumStructAccessor(
+                self.struct, "O3", 260, 3, ["OFF", "ON"], None, 2, None
             ),
-            UNBLKX: GeckoTimeStructAccessor(self.struct, UNBLKX, NBLKXS, AKQXPI),
-            BLKXSJ: GeckoByteStructAccessor(self.struct, BLKXSJ, LKXSJW, AKQXPI),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, AKQXPI),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, AKQXPI),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, FJTACC, ICXQIE, ACCPQI, None, OCTHBS, AKQXPI
+            "L120": GeckoEnumStructAccessor(
+                self.struct, "L120", 260, 4, ["OFF", "ON"], None, 2, None
             ),
-            MNZMJI: GeckoEnumStructAccessor(
-                self.struct, MNZMJI, NZMJIG, None, UYNQJY, None, None, AKQXPI
+            "MSTR_HEATER": GeckoEnumStructAccessor(
+                self.struct, "MSTR_HEATER", 260, 5, ["OFF", "ON"], None, 2, None
             ),
-            ZMJIGY: GeckoTimeStructAccessor(self.struct, ZMJIGY, MJIGYO, AKQXPI),
-            JIGYOU: GeckoBoolStructAccessor(self.struct, JIGYOU, IGYOUS, XPICXQ, None),
-            GYOUSP: GeckoBoolStructAccessor(self.struct, GYOUSP, IGYOUS, OCTHBS, None),
-            YOUSPB: GeckoBoolStructAccessor(self.struct, YOUSPB, IGYOUS, JUTYEK, None),
-            OUSPBW: GeckoBoolStructAccessor(self.struct, OUSPBW, IGYOUS, HEOCTH, None),
-            USPBWJ: GeckoBoolStructAccessor(self.struct, USPBWJ, IGYOUS, YEKCWA, None),
-            SPBWJY: GeckoBoolStructAccessor(self.struct, SPBWJY, JVHFTH, OCTHBS, None),
-            PBWJYK: GeckoBoolStructAccessor(self.struct, PBWJYK, BWJYKL, JUTYEK, None),
-            WJYKLG: GeckoBoolStructAccessor(self.struct, WJYKLG, BWJYKL, YEKCWA, None),
-            JYKLGQ: GeckoBoolStructAccessor(self.struct, JYKLGQ, BWJYKL, VHFTHE, None),
-            YKLGQP: GeckoEnumStructAccessor(
-                self.struct, YKLGQP, KLGQPL, None, PLSPFT, None, None, None
+            "SLV_HEATER": GeckoEnumStructAccessor(
+                self.struct, "SLV_HEATER", 260, 6, ["OFF", "ON"], None, 2, None
             ),
-            LSPFTS: GeckoBoolStructAccessor(self.struct, LSPFTS, SPFTSI, YEKCWA, None),
-            PFTSIF: GeckoBoolStructAccessor(self.struct, PFTSIF, SPFTSI, VHFTHE, None),
-            FTSIFJ: GeckoWordStructAccessor(self.struct, FTSIFJ, TSIFJB, None),
-            SIFJBI: GeckoBoolStructAccessor(self.struct, SIFJBI, JVHFTH, ICXQIE, None),
-            IFJBIA: GeckoTempStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoTempStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoEnumStructAccessor(
-                self.struct, IAMJMA, XLSXUJ, YEKCWA, AMJMAO, None, HEOCTH, None
+            "Waterfall": GeckoEnumStructAccessor(
+                self.struct, "Waterfall", 260, 7, ["OFF", "ON"], None, 2, None
             ),
-            MJMAOA: GeckoBoolStructAccessor(self.struct, MJMAOA, JMAOAW, OCTHBS, None),
-            MAOAWB: GeckoBoolStructAccessor(self.struct, MAOAWB, JMAOAW, VHFTHE, None),
-            AOAWBS: GeckoBoolStructAccessor(self.struct, AOAWBS, OAWBSI, OCTHBS, None),
-            AWBSIR: GeckoBoolStructAccessor(self.struct, AWBSIR, WBSIRY, ICXQIE, None),
-            BSIRYX: GeckoBoolStructAccessor(
-                self.struct, BSIRYX, WBSIRY, OCTHBS, AKQXPI
+            "LockMode": GeckoEnumStructAccessor(
+                self.struct,
+                "LockMode",
+                310,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                "ALL",
             ),
-            SIRYXB: GeckoBoolStructAccessor(self.struct, SIRYXB, IRYXBQ, ICXQIE, None),
-            RYXBQF: GeckoByteStructAccessor(self.struct, RYXBQF, YXBQFY, None),
-            XBQFYL: GeckoBoolStructAccessor(self.struct, XBQFYL, BQFYLJ, XPICXQ, None),
-            QFYLJU: GeckoBoolStructAccessor(self.struct, QFYLJU, FYLJUI, XPICXQ, None),
-            YLJUIK: GeckoBoolStructAccessor(self.struct, YLJUIK, FYLJUI, ICXQIE, None),
-            LJUIKF: GeckoBoolStructAccessor(self.struct, LJUIKF, FYLJUI, HEOCTH, None),
-            JUIKFW: GeckoBoolStructAccessor(self.struct, JUIKFW, FYLJUI, YEKCWA, None),
-            UIKFWR: GeckoBoolStructAccessor(self.struct, UIKFWR, FYLJUI, VHFTHE, None),
-            IKFWRK: GeckoEnumStructAccessor(
-                self.struct, IKFWRK, FYLJUI, CWAONP, WRKINE, None, OCTHBS, AKQXPI
+            "DealerLockStatus": GeckoEnumStructAccessor(
+                self.struct,
+                "DealerLockStatus",
+                364,
+                None,
+                ["UNLOCK", "PARTIAL", "FULL"],
+                None,
+                None,
+                None,
             ),
-            RKINEJ: GeckoEnumStructAccessor(
-                self.struct, RKINEJ, KINEJN, None, YBQSNQ, None, None, None
+            "DealerLockSeed": GeckoWordStructAccessor(
+                self.struct, "DealerLockSeed", 365, None
             ),
-            BQSNQL: GeckoBoolStructAccessor(self.struct, BQSNQL, QSNQLN, XPICXQ, None),
-            SNQLNM: GeckoBoolStructAccessor(self.struct, SNQLNM, QSNQLN, ICXQIE, None),
-            NQLNMH: GeckoBoolStructAccessor(self.struct, NQLNMH, QSNQLN, OCTHBS, None),
-            QLNMHX: GeckoBoolStructAccessor(self.struct, QLNMHX, QSNQLN, JUTYEK, None),
-            LNMHXE: GeckoEnumStructAccessor(
-                self.struct, LNMHXE, NMHXEK, None, VKZILX, None, None, None
+            "DealerLockKey": GeckoWordStructAccessor(
+                self.struct, "DealerLockKey", 367, "ALL"
             ),
-            KZILXW: GeckoWordStructAccessor(self.struct, KZILXW, ZILXWA, None),
-            ILXWAJ: GeckoBoolStructAccessor(self.struct, ILXWAJ, LXWAJV, XPICXQ, None),
-            XWAJVD: GeckoBoolStructAccessor(self.struct, XWAJVD, LXWAJV, ICXQIE, None),
-            WAJVDQ: GeckoBoolStructAccessor(self.struct, WAJVDQ, AJVDQL, XPICXQ, None),
-            JVDQLA: GeckoBoolStructAccessor(self.struct, JVDQLA, AJVDQL, ICXQIE, None),
-            VDQLAI: GeckoBoolStructAccessor(self.struct, VDQLAI, DQLAII, XPICXQ, None),
-            QLAIID: GeckoBoolStructAccessor(self.struct, QLAIID, JVHFTH, JUTYEK, None),
-            LAIIDN: GeckoBoolStructAccessor(self.struct, LAIIDN, BWJYKL, XPICXQ, None),
-            AIIDNI: GeckoBoolStructAccessor(self.struct, AIIDNI, BWJYKL, ICXQIE, None),
-            IIDNIB: GeckoBoolStructAccessor(self.struct, IIDNIB, IDNIBX, OCTHBS, None),
-            DNIBXT: GeckoBoolStructAccessor(self.struct, DNIBXT, IDNIBX, JUTYEK, None),
-            NIBXTI: GeckoBoolStructAccessor(self.struct, NIBXTI, LXWAJV, JUTYEK, None),
-            IBXTIA: GeckoBoolStructAccessor(self.struct, IBXTIA, LXWAJV, HEOCTH, None),
-            BXTIAC: GeckoBoolStructAccessor(self.struct, BXTIAC, LXWAJV, YEKCWA, None),
-            XTIACQ: GeckoBoolStructAccessor(self.struct, XTIACQ, LXWAJV, VHFTHE, None),
-            TIACQF: GeckoBoolStructAccessor(self.struct, TIACQF, AJVDQL, JUTYEK, None),
-            IACQFF: GeckoBoolStructAccessor(self.struct, IACQFF, AJVDQL, HEOCTH, None),
-            ACQFFT: GeckoBoolStructAccessor(self.struct, ACQFFT, AJVDQL, YEKCWA, None),
-            CQFFTT: GeckoBoolStructAccessor(self.struct, CQFFTT, AJVDQL, VHFTHE, None),
-            QFFTTI: GeckoBoolStructAccessor(self.struct, QFFTTI, FFTTID, OCTHBS, None),
-            FTTIDU: GeckoBoolStructAccessor(self.struct, FTTIDU, FFTTID, JUTYEK, None),
-            TTIDUB: GeckoBoolStructAccessor(self.struct, TTIDUB, IRYXBQ, JUTYEK, None),
-            TIDUBS: GeckoBoolStructAccessor(self.struct, TIDUBS, SPFTSI, XPICXQ, None),
-            IDUBSS: GeckoBoolStructAccessor(self.struct, IDUBSS, SPFTSI, ICXQIE, None),
-            DUBSSU: GeckoBoolStructAccessor(self.struct, DUBSSU, UBSSUH, XPICXQ, None),
-            BSSUHB: GeckoByteStructAccessor(self.struct, BSSUHB, SSUHBV, None),
-            SUHBVW: GeckoBoolStructAccessor(self.struct, SUHBVW, OAWBSI, XPICXQ, None),
-            UHBVWV: GeckoBoolStructAccessor(self.struct, UHBVWV, IDNIBX, XPICXQ, None),
-            HBVWVU: GeckoBoolStructAccessor(self.struct, HBVWVU, IDNIBX, ICXQIE, None),
-            BVWVUB: GeckoBoolStructAccessor(self.struct, BVWVUB, IDNIBX, HEOCTH, None),
-            VWVUBY: GeckoBoolStructAccessor(self.struct, VWVUBY, WVUBYG, XPICXQ, None),
-            VUBYGD: GeckoEnumStructAccessor(
-                self.struct, VUBYGD, WVUBYG, ICXQIE, UBYGDS, None, HEOCTH, None
+            "FilterAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "FilterAccess",
+                262,
+                0,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BYGDSB: GeckoBoolStructAccessor(self.struct, BYGDSB, WVUBYG, JUTYEK, None),
-            YGDSBD: GeckoWordStructAccessor(self.struct, YGDSBD, GDSBDJ, None),
-            DSBDJQ: GeckoBoolStructAccessor(self.struct, DSBDJQ, SBDJQR, XPICXQ, None),
-            BDJQRJ: GeckoBoolStructAccessor(self.struct, BDJQRJ, DJQRJJ, XPICXQ, None),
-            JQRJJJ: GeckoBoolStructAccessor(self.struct, JQRJJJ, DJQRJJ, ICXQIE, None),
-            QRJJJV: GeckoBoolStructAccessor(self.struct, QRJJJV, FFTTID, XPICXQ, None),
-            RJJJVY: GeckoBoolStructAccessor(self.struct, RJJJVY, FFTTID, ICXQIE, None),
-            JJJVYF: GeckoBoolStructAccessor(self.struct, JJJVYF, FFTTID, HEOCTH, None),
-            JJVYFC: GeckoWordStructAccessor(self.struct, JJVYFC, JVYFCR, None),
-            VYFCRT: GeckoByteStructAccessor(self.struct, VYFCRT, YFCRTF, None),
-            FCRTFM: GeckoByteStructAccessor(self.struct, FCRTFM, CRTFMN, None),
-            RTFMNH: GeckoEnumStructAccessor(
-                self.struct, RTFMNH, TFMNHT, None, PHUGTY, None, None, None
+            "RemoteFiltAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteFiltAction",
+                263,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            HUGTYI: GeckoEnumStructAccessor(
-                self.struct, HUGTYI, UGTYIY, XPICXQ, YWSKWI, None, HEOCTH, None
+            "RemoteFiltDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteFiltDur", 264, "ALL"
             ),
-            WSKWIV: GeckoEnumStructAccessor(
-                self.struct, WSKWIV, UGTYIY, OCTHBS, WIVDNQ, None, OCTHBS, None
+            "RemoteFiltDurPerDay": GeckoByteStructAccessor(
+                self.struct, "RemoteFiltDurPerDay", 266, "ALL"
             ),
-            IVDNQG: GeckoWordStructAccessor(self.struct, IVDNQG, VDNQGV, None),
-            DNQGVU: GeckoByteStructAccessor(self.struct, DNQGVU, NQGVUN, None),
-            QGVUNX: GeckoByteStructAccessor(self.struct, QGVUNX, GVUNXN, None),
-            VUNXNK: GeckoByteStructAccessor(self.struct, VUNXNK, UNXNKM, None),
-            NXNKML: GeckoByteStructAccessor(self.struct, NXNKML, XNKMLO, None),
-            NKMLOI: GeckoWordStructAccessor(self.struct, NKMLOI, KMLOIJ, None),
-            MLOIJU: GeckoByteStructAccessor(self.struct, MLOIJU, LOIJUG, None),
-            OIJUGS: GeckoByteStructAccessor(self.struct, OIJUGS, IJUGSE, None),
-            JUGSEL: GeckoWordStructAccessor(self.struct, JUGSEL, UGSELH, None),
-            GSELHB: GeckoEnumStructAccessor(
-                self.struct, GSELHB, SELHBQ, None, HBQNRX, None, OCTHBS, AKQXPI
+            "EconomyAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "EconomyAccess",
+                262,
+                2,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            BQNRXC: GeckoEnumStructAccessor(
-                self.struct, BQNRXC, QNRXCH, None, PUNRJZ, None, None, None
+            "RemoteEconAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteEconAction",
+                267,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            UNRJZT: GeckoWordStructAccessor(self.struct, UNRJZT, NRJZTA, None),
-            RJZTAT: GeckoByteStructAccessor(self.struct, RJZTAT, JZTATD, None),
-            ZTATDZ: GeckoByteStructAccessor(self.struct, ZTATDZ, TATDZX, None),
-            ATDZXN: GeckoEnumStructAccessor(
-                self.struct, ATDZXN, TDZXNQ, None, XNQTMF, None, None, AKQXPI
+            "RemoteEconDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteEconDur", 268, "ALL"
             ),
-            NQTMFZ: GeckoEnumStructAccessor(
-                self.struct, NQTMFZ, QTMFZD, None, SEMCGE, None, None, AKQXPI
+            "RemoteConfigIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteConfigIndex", 270, "ALL"
             ),
-            EMCGET: GeckoEnumStructAccessor(
-                self.struct, EMCGET, MCGETI, None, SEMCGE, None, None, AKQXPI
+            "RemoteNbOfPhases": GeckoByteStructAccessor(
+                self.struct, "RemoteNbOfPhases", 271, "ALL"
             ),
-            CGETIX: GeckoEnumStructAccessor(
-                self.struct, CGETIX, GETIXQ, None, SEMCGE, None, None, AKQXPI
+            "RemoteBreakerIndex": GeckoByteStructAccessor(
+                self.struct, "RemoteBreakerIndex", 272, "ALL"
             ),
-            ETIXQV: GeckoEnumStructAccessor(
-                self.struct, ETIXQV, TIXQVX, None, SEMCGE, None, None, AKQXPI
+            "ProgOutputAccess": GeckoEnumStructAccessor(
+                self.struct,
+                "ProgOutputAccess",
+                262,
+                1,
+                ["INTERNAL", "REMOTE"],
+                None,
+                2,
+                "ALL",
             ),
-            IXQVXO: GeckoEnumStructAccessor(
-                self.struct, IXQVXO, XQVXOI, None, SEMCGE, None, None, AKQXPI
+            "RemoteProgOutputAction": GeckoEnumStructAccessor(
+                self.struct,
+                "RemoteProgOutputAction",
+                380,
+                None,
+                ["IDLE", "STOP", "START", "NEW", "ACTIVE"],
+                None,
+                None,
+                "ALL",
             ),
-            QVXOIH: GeckoEnumStructAccessor(
-                self.struct, QVXOIH, VXOIHB, None, OIHBXI, None, None, AKQXPI
+            "RemoteProgOutputDur": GeckoTimeStructAccessor(
+                self.struct, "RemoteProgOutputDur", 381, "ALL"
             ),
-            IHBXIB: GeckoByteStructAccessor(self.struct, IHBXIB, HBXIBH, AKQXPI),
-            BXIBHZ: GeckoByteStructAccessor(self.struct, BXIBHZ, XIBHZV, AKQXPI),
-            IBHZVO: GeckoByteStructAccessor(self.struct, IBHZVO, BHZVOA, AKQXPI),
-            HZVOAC: GeckoByteStructAccessor(self.struct, HZVOAC, ZVOACM, AKQXPI),
-            VOACMC: GeckoByteStructAccessor(self.struct, VOACMC, OACMCV, AKQXPI),
-            ACMCVD: GeckoByteStructAccessor(self.struct, ACMCVD, CMCVDS, AKQXPI),
-            MCVDSS: GeckoEnumStructAccessor(
-                self.struct, MCVDSS, CVDSSR, None, DSSRUR, None, None, AKQXPI
+            "Clean": GeckoBoolStructAccessor(self.struct, "Clean", 273, 0, None),
+            "Purge": GeckoBoolStructAccessor(self.struct, "Purge", 273, 2, None),
+            "FiltSuspendByUD": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendByUD", 273, 3, None
             ),
-            SSRURA: GeckoEnumStructAccessor(
-                self.struct, SSRURA, VXOIHB, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByOT": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByOT", 273, 4, None
             ),
-            SRURAZ: GeckoEnumStructAccessor(
-                self.struct, SRURAZ, HBXIBH, None, DSSRUR, None, None, AKQXPI
+            "FiltSuspendedByErr": GeckoBoolStructAccessor(
+                self.struct, "FiltSuspendedByErr", 273, 5, None
             ),
-            RURAZM: GeckoEnumStructAccessor(
-                self.struct, RURAZM, XIBHZV, None, DSSRUR, None, None, AKQXPI
+            "CPOT": GeckoBoolStructAccessor(self.struct, "CPOT", 274, 2, None),
+            "SwmPurgeSusp": GeckoBoolStructAccessor(
+                self.struct, "SwmPurgeSusp", 282, 3, None
             ),
-            URAZMK: GeckoEnumStructAccessor(
-                self.struct, URAZMK, BHZVOA, None, DSSRUR, None, None, AKQXPI
+            "SwmPurge": GeckoBoolStructAccessor(self.struct, "SwmPurge", 282, 5, None),
+            "SwmActive": GeckoBoolStructAccessor(
+                self.struct, "SwmActive", 282, 6, None
             ),
-            RAZMKQ: GeckoEnumStructAccessor(
-                self.struct, RAZMKQ, ZVOACM, None, DSSRUR, None, None, AKQXPI
+            "SwmRisk": GeckoEnumStructAccessor(
+                self.struct,
+                "SwmRisk",
+                313,
+                None,
+                ["NO", "LO", "MED", "HI", "EXTREME"],
+                None,
+                None,
+                None,
             ),
-            AZMKQT: GeckoEnumStructAccessor(
-                self.struct, AZMKQT, OACMCV, None, DSSRUR, None, None, AKQXPI
+            "SlaveSwmPurge": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmPurge", 353, 5, None
             ),
-            ZMKQTD: GeckoEnumStructAccessor(
-                self.struct, ZMKQTD, MKQTDK, None, KQTDKH, None, None, AKQXPI
+            "SlaveSwmActive": GeckoBoolStructAccessor(
+                self.struct, "SlaveSwmActive", 353, 6, None
             ),
-            QTDKHT: GeckoEnumStructAccessor(
-                self.struct, QTDKHT, CMCVDS, None, KQTDKH, None, None, AKQXPI
+            "SwmAdc": GeckoWordStructAccessor(self.struct, "SwmAdc", 355, None),
+            "OverTemp": GeckoBoolStructAccessor(self.struct, "OverTemp", 274, 1, None),
+            "RealSetPointG": GeckoTempStructAccessor(
+                self.struct, "RealSetPointG", 275, None
             ),
-            TDKHTZ: GeckoByteStructAccessor(self.struct, TDKHTZ, DKHTZB, AKQXPI),
-            KHTZBB: GeckoByteStructAccessor(self.struct, KHTZBB, HTZBBE, AKQXPI),
-            TZBBEK: GeckoByteStructAccessor(self.struct, TZBBEK, ZBBEKB, AKQXPI),
-            BBEKBD: GeckoByteStructAccessor(self.struct, BBEKBD, BEKBDF, AKQXPI),
-            EKBDFS: GeckoByteStructAccessor(self.struct, EKBDFS, KBDFSR, AKQXPI),
-            BDFSRO: GeckoByteStructAccessor(self.struct, BDFSRO, DFSROG, AKQXPI),
-            FSROGM: GeckoByteStructAccessor(self.struct, FSROGM, SROGMD, AKQXPI),
-            ROGMDD: GeckoByteStructAccessor(self.struct, ROGMDD, OGMDDP, AKQXPI),
-            GMDDPM: GeckoByteStructAccessor(self.struct, GMDDPM, MDDPMX, AKQXPI),
-            HYUAXN: GeckoBoolStructAccessor(self.struct, HYUAXN, JVHFTH, YEKCWA, None),
-            YUAXNC: GeckoByteStructAccessor(self.struct, YUAXNC, UAXNCU, AKQXPI),
-            AXNCUG: GeckoByteStructAccessor(self.struct, AXNCUG, XNCUGU, AKQXPI),
-            NCUGUC: GeckoByteStructAccessor(self.struct, NCUGUC, CUGUCY, AKQXPI),
-            UGUCYR: GeckoEnumStructAccessor(
-                self.struct, UGUCYR, GUCYRA, None, PUMEAO, None, None, AKQXPI
+            "DisplayedTempG": GeckoTempStructAccessor(
+                self.struct, "DisplayedTempG", 277, None
             ),
-            UMEAOE: GeckoBoolStructAccessor(
-                self.struct, UMEAOE, MEAOES, XPICXQ, AKQXPI
+            "Heating": GeckoEnumStructAccessor(
+                self.struct,
+                "Heating",
+                260,
+                5,
+                ["", "Heating", "Heating", "Heating"],
+                None,
+                4,
+                None,
             ),
-            EAOESV: GeckoBoolStructAccessor(self.struct, EAOESV, TDZXNQ, XPICXQ, None),
+            "TempNotValid": GeckoBoolStructAccessor(
+                self.struct, "TempNotValid", 279, 2, None
+            ),
+            "ExtProbeDetected": GeckoBoolStructAccessor(
+                self.struct, "ExtProbeDetected", 279, 6, None
+            ),
+            "CheckFlo": GeckoBoolStructAccessor(self.struct, "CheckFlo", 280, 2, None),
+            "ProgEconActive": GeckoBoolStructAccessor(
+                self.struct, "ProgEconActive", 281, 1, None
+            ),
+            "EconActive": GeckoBoolStructAccessor(
+                self.struct, "EconActive", 281, 2, "ALL"
+            ),
+            "SlaveOverTemp": GeckoBoolStructAccessor(
+                self.struct, "SlaveOverTemp", 352, 1, None
+            ),
+            "SideHeatingDegG": GeckoByteStructAccessor(
+                self.struct, "SideHeatingDegG", 377, None
+            ),
+            "InGridDetected": GeckoBoolStructAccessor(
+                self.struct, "InGridDetected", 384, 0, None
+            ),
+            "CoolZoneDetected": GeckoBoolStructAccessor(
+                self.struct, "CoolZoneDetected", 378, 0, None
+            ),
+            "ModbusHeatPumpDetected": GeckoBoolStructAccessor(
+                self.struct, "ModbusHeatPumpDetected", 378, 1, None
+            ),
+            "HPCResHeaterRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCResHeaterRequest", 378, 4, None
+            ),
+            "HPCHeatRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCHeatRequest", 378, 5, None
+            ),
+            "HPCChillRequest": GeckoBoolStructAccessor(
+                self.struct, "HPCChillRequest", 378, 6, None
+            ),
+            "HPCAutoMode": GeckoEnumStructAccessor(
+                self.struct, "HPCAutoMode", 378, 7, ["HEAT", "CHILL"], None, 2, "ALL"
+            ),
+            "HPCState": GeckoEnumStructAccessor(
+                self.struct,
+                "HPCState",
+                379,
+                None,
+                [
+                    "IDLE",
+                    "HEAT_ON",
+                    "CHILL_ON",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "INVALID_REQUEST",
+                    "COIL_SENSOR_ERR",
+                    "AMBIENT_TEMP_ERR",
+                    "EE1_EE2_ERR",
+                    "PRESSURE_ERR",
+                    "OTHER_ERR",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHPCOutletProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCOutletProtection", 392, 0, None
+            ),
+            "ModbusHPCAmbientProtection": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCAmbientProtection", 392, 1, None
+            ),
+            "ModbusHPCRequestFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCRequestFlow", 392, 2, None
+            ),
+            "ModbusHPCActiveCheckFlow": GeckoBoolStructAccessor(
+                self.struct, "ModbusHPCActiveCheckFlow", 392, 3, None
+            ),
+            "ModbusHeatPumpType": GeckoEnumStructAccessor(
+                self.struct,
+                "ModbusHeatPumpType",
+                389,
+                None,
+                [
+                    "GENERIC",
+                    "GECKO_5000W_CE",
+                    "GECKO_7500W_CE",
+                    "GECKO_5000W_UL",
+                    "GECKO_7500W_UL",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "ModbusHeatPumpAmbient": GeckoWordStructAccessor(
+                self.struct, "ModbusHeatPumpAmbient", 390, None
+            ),
+            "HtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "HtrSuspendByPwrMng", 284, 0, None
+            ),
+            "Htr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "Htr2SuspendByPwrMng", 284, 1, None
+            ),
+            "SlaveHtrSuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrSuspendByPwrMng", 350, 0, None
+            ),
+            "SlaveHtr2SuspendByPwrMng": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtr2SuspendByPwrMng", 350, 1, None
+            ),
+            "SilentModeActive": GeckoBoolStructAccessor(
+                self.struct, "SilentModeActive", 383, 0, None
+            ),
+            "ThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "ThermFuseErr", 274, 3, None
+            ),
+            "ThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "ThermistanceErr", 282, 0, None
+            ),
+            "AmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "AmbiantOHLevel2", 282, 1, None
+            ),
+            "KinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "KinPumpOff", 283, 2, None
+            ),
+            "RegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "RegOverHeat", 283, 3, None
+            ),
+            "P1HStuck": GeckoBoolStructAccessor(self.struct, "P1HStuck", 284, 3, None),
+            "P2HStuck": GeckoBoolStructAccessor(self.struct, "P2HStuck", 284, 4, None),
+            "HeaterStuck": GeckoBoolStructAccessor(
+                self.struct, "HeaterStuck", 284, 5, None
+            ),
+            "RelayStuck": GeckoBoolStructAccessor(
+                self.struct, "RelayStuck", 284, 6, None
+            ),
+            "SlaveP1HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP1HStuck", 350, 3, None
+            ),
+            "SlaveP2HStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveP2HStuck", 350, 4, None
+            ),
+            "SlaveHtrStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveHtrStuck", 350, 5, None
+            ),
+            "SlaveRelayStuck": GeckoBoolStructAccessor(
+                self.struct, "SlaveRelayStuck", 350, 6, None
+            ),
+            "SlaveKinPumpOff": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinPumpOff", 351, 2, None
+            ),
+            "SlaveRegOverHeat": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegOverHeat", 351, 3, None
+            ),
+            "SlaveThermFuseErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermFuseErr", 352, 3, None
+            ),
+            "SlaveThermistanceErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveThermistanceErr", 353, 0, None
+            ),
+            "SlaveAmbiantOHLevel2": GeckoBoolStructAccessor(
+                self.struct, "SlaveAmbiantOHLevel2", 353, 1, None
+            ),
+            "SlaveMissingErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveMissingErr", 354, 0, None
+            ),
+            "ModbusHeatPumpErrorID": GeckoByteStructAccessor(
+                self.struct, "ModbusHeatPumpErrorID", 387, None
+            ),
+            "RhFloDetected": GeckoBoolStructAccessor(
+                self.struct, "RhFloDetected", 280, 0, None
+            ),
+            "RhHwHL": GeckoBoolStructAccessor(self.struct, "RhHwHL", 283, 0, None),
+            "RhRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "RhRegProbeErr", 283, 1, None
+            ),
+            "RhRegSlope": GeckoBoolStructAccessor(
+                self.struct, "RhRegSlope", 283, 4, None
+            ),
+            "RhHrKinNoFlo": GeckoBoolStructAccessor(
+                self.struct, "RhHrKinNoFlo", 309, 0, None
+            ),
+            "RhNoFloXTries": GeckoEnumStructAccessor(
+                self.struct,
+                "RhNoFloXTries",
+                309,
+                1,
+                ["", "RhNoFloXTries", "RhNoFloXTries", "RhNoFloXTries"],
+                None,
+                4,
+                None,
+            ),
+            "FLCErr": GeckoBoolStructAccessor(self.struct, "FLCErr", 309, 3, None),
+            "inTCipDelay": GeckoWordStructAccessor(
+                self.struct, "inTCipDelay", 311, None
+            ),
+            "SlaveFloDetected": GeckoBoolStructAccessor(
+                self.struct, "SlaveFloDetected", 314, 0, None
+            ),
+            "SlaveKinNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveKinNoFloErr", 315, 0, None
+            ),
+            "SlaveNoFloErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveNoFloErr", 315, 1, None
+            ),
+            "SlaveHLErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveHLErr", 351, 0, None
+            ),
+            "SlaveRegProbeErr": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegProbeErr", 351, 1, None
+            ),
+            "SlaveRegSlope": GeckoBoolStructAccessor(
+                self.struct, "SlaveRegSlope", 351, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 285, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 287, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 288, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                289,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                290,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackRegion": GeckoEnumStructAccessor(
+                self.struct, "PackRegion", 290, 2, ["UL", "CE"], None, 2, None
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 291, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 293, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 294, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 295, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 296, None
+            ),
+            "PackConfID": GeckoWordStructAccessor(self.struct, "PackConfID", 297, None),
+            "PackConfRev": GeckoByteStructAccessor(
+                self.struct, "PackConfRev", 299, None
+            ),
+            "PackConfRel": GeckoByteStructAccessor(
+                self.struct, "PackConfRel", 300, None
+            ),
+            "PackNumberOfConf": GeckoWordStructAccessor(
+                self.struct, "PackNumberOfConf", 301, None
+            ),
+            "PackLogTrig": GeckoEnumStructAccessor(
+                self.struct,
+                "PackLogTrig",
+                316,
+                None,
+                ["Restricted", "Full"],
+                None,
+                2,
+                "ALL",
+            ),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                357,
+                None,
+                [
+                    "K200",
+                    "K400",
+                    "K85",
+                    "K8",
+                    "K4",
+                    "K5",
+                    "K600LE",
+                    "K100",
+                    "K800",
+                    "",
+                    "",
+                    "",
+                    "K600HE",
+                    "K300",
+                    "INVALID_TYPE",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 358, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 360, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 361, None),
+            "PackReset": GeckoEnumStructAccessor(
+                self.struct, "PackReset", 376, None, ["---", "RESET"], None, None, "ALL"
+            ),
+            "SOut1": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut1",
+                320,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut2": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut2",
+                321,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut3": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut3",
+                322,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut4": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut4",
+                323,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut5": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut5",
+                324,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOutHtr": GeckoEnumStructAccessor(
+                self.struct,
+                "SOutHtr",
+                326,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "", "", "", "HTR"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut1Cur": GeckoByteStructAccessor(self.struct, "SOut1Cur", 327, "ALL"),
+            "SOut2Cur": GeckoByteStructAccessor(self.struct, "SOut2Cur", 328, "ALL"),
+            "SOut3Cur": GeckoByteStructAccessor(self.struct, "SOut3Cur", 329, "ALL"),
+            "SOut4Cur": GeckoByteStructAccessor(self.struct, "SOut4Cur", 330, "ALL"),
+            "SOut5Cur": GeckoByteStructAccessor(self.struct, "SOut5Cur", 331, "ALL"),
+            "SOutHtrCur": GeckoByteStructAccessor(
+                self.struct, "SOutHtrCur", 333, "ALL"
+            ),
+            "SOut6": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut6",
+                325,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut7": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut7",
+                326,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut8": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut8",
+                327,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut9": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut9",
+                328,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut10": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut10",
+                329,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut11": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut11",
+                330,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut12": GeckoEnumStructAccessor(
+                self.struct,
+                "SOut12",
+                331,
+                None,
+                [
+                    "NA",
+                    "P1H",
+                    "P1L",
+                    "P2H",
+                    "P2L",
+                    "P3H",
+                    "P3L",
+                    "P4H",
+                    "P4L",
+                    "P5",
+                    "BLO",
+                    "CP",
+                    "O3",
+                    "L120",
+                    "",
+                    "",
+                    "Fan",
+                    "",
+                    "",
+                    "FullOn",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "Waterfall",
+                    "AUX",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect",
+                332,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SDirect2": GeckoEnumStructAccessor(
+                self.struct,
+                "SDirect2",
+                333,
+                None,
+                ["NA", "", "", "", "", "", "", "", "", "", "", "CP"],
+                None,
+                None,
+                "ALL",
+            ),
+            "SOut6Cur": GeckoByteStructAccessor(self.struct, "SOut6Cur", 340, "ALL"),
+            "SOut7Cur": GeckoByteStructAccessor(self.struct, "SOut7Cur", 341, "ALL"),
+            "SOut8Cur": GeckoByteStructAccessor(self.struct, "SOut8Cur", 342, "ALL"),
+            "SOut9Cur": GeckoByteStructAccessor(self.struct, "SOut9Cur", 343, "ALL"),
+            "SOut10Cur": GeckoByteStructAccessor(self.struct, "SOut10Cur", 344, "ALL"),
+            "SOut11Cur": GeckoByteStructAccessor(self.struct, "SOut11Cur", 345, "ALL"),
+            "SOut12Cur": GeckoByteStructAccessor(self.struct, "SOut12Cur", 346, "ALL"),
+            "SDirectCur": GeckoByteStructAccessor(
+                self.struct, "SDirectCur", 347, "ALL"
+            ),
+            "SDirect2Cur": GeckoByteStructAccessor(
+                self.struct, "SDirect2Cur", 348, "ALL"
+            ),
+            "inFloPressureSwDetected": GeckoBoolStructAccessor(
+                self.struct, "inFloPressureSwDetected", 274, 5, None
+            ),
+            "inFloRatio": GeckoByteStructAccessor(
+                self.struct, "inFloRatio", 371, "ALL"
+            ),
+            "inFloRatioMinimum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMinimum", 372, "ALL"
+            ),
+            "inFloRatioMaximum": GeckoByteStructAccessor(
+                self.struct, "inFloRatioMaximum", 373, "ALL"
+            ),
+            "inFloErrorType": GeckoEnumStructAccessor(
+                self.struct,
+                "inFloErrorType",
+                374,
+                None,
+                [
+                    "FLOW_OK",
+                    "MODE_1_FAIL",
+                    "MODE_1_AND_2_FAIL",
+                    "MODE_1_AND_HEATING_FAIL",
+                    "HEATING_FAIL",
+                ],
+                None,
+                None,
+                "ALL",
+            ),
+            "ForceCheckFlo": GeckoBoolStructAccessor(
+                self.struct, "ForceCheckFlo", 375, 0, "ALL"
+            ),
+            "inFloJustReset": GeckoBoolStructAccessor(
+                self.struct, "inFloJustReset", 376, 0, None
+            ),
         }

--- a/src/geckolib/driver/packs/inyt-v2.py
+++ b/src/geckolib/driver/packs/inyt-v2.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/inyt.py
+++ b/src/geckolib/driver/packs/inyt.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/mas-ibc-16k.py
+++ b/src/geckolib/driver/packs/mas-ibc-16k.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/mas-ibc-32k-cfg-1.py
+++ b/src/geckolib/driver/packs/mas-ibc-32k-cfg-1.py
@@ -12,63 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-AHEOCT = 8
-AKQXPI = "".join(chr(c) for c in [66, 65, 83, 73, 67])
-ASSAKQ = "".join(chr(c) for c in [76, 76, 95, 67, 104, 114, 111, 109, 111])
-BMJVHF = "".join(chr(c) for c in [68, 85, 65, 76])
-CQBMJV = 0
-CTHBSK = 1
-CVYYPI = "".join(chr(c) for c in [73, 110, 116, 101, 110, 115, 105, 116, 121, 52])
-ECVYYP = "".join(chr(c) for c in [73, 110, 116, 101, 110, 115, 105, 116, 121, 51])
-EOCTHB = "".join(chr(c) for c in [76, 73])
-FTHECV = 1
-FXQGLR = "".join(
-    chr(c) for c in [76, 76, 95, 67, 111, 109, 102, 111, 114, 116, 74, 101, 116]
-)
-GLRAHE = "".join(chr(c) for c in [65, 67, 84, 73, 86, 65, 84, 69])
-HECVYY = "".join(chr(c) for c in [73, 110, 116, 101, 110, 115, 105, 116, 121, 50])
-HFTHEC = "".join(chr(c) for c in [76, 76, 95, 72, 101, 97, 116, 101, 114, 95, 49])
-ICXQIE = "".join(chr(c) for c in [77, 80, 51])
-IEFXQG = "".join(chr(c) for c in [72, 79, 84, 69, 76])
-IPIVLA = 3
-IVLASS = "".join(chr(c) for c in [72, 73, 71, 72])
-JVHFTH = "".join(
-    chr(c) for c in [68, 85, 65, 76, 95, 76, 73, 84, 69, 83, 84, 82, 69, 77, 69]
-)
-KQXPIC = "".join(chr(c) for c in [68, 69, 76, 85, 88, 69])
-MJVHFT = "".join(
-    chr(c) for c in [68, 85, 65, 76, 95, 84, 72, 69, 82, 77, 79, 80, 76, 65, 67, 69]
-)
-PICXQI = 5
-PIPIVL = "".join(chr(c) for c in [76, 76, 95, 66, 108, 111, 119, 101, 114])
-PIVLAS = "".join(chr(c) for c in [83, 84, 65, 78, 68, 65, 82, 68])
-QBMJVH = "".join(chr(c) for c in [83, 73, 78, 71, 76, 69])
-QGLRAH = "".join(chr(c) for c in [68, 69, 65, 67, 84, 73, 86, 65, 84, 69])
-QIEFXQ = 6
-RAHEOC = "".join(
-    chr(c) for c in [76, 76, 95, 65, 114, 111, 109, 97, 99, 108, 111, 117, 100]
-)
-SAKQXP = "".join(chr(c) for c in [78, 79, 78, 69])
-SSAKQX = 4
-THECVY = "".join(chr(c) for c in [73, 110, 116, 101, 110, 115, 105, 116, 121, 49])
-VLASSA = "".join(chr(c) for c in [76, 79, 87])
-XPICXQ = "".join(chr(c) for c in [76, 76, 95, 65, 117, 100, 105, 111])
-XQGLRA = 7
-XQIEFX = "".join(chr(c) for c in [76, 76, 95, 77, 101, 110, 117])
-YPIPIV = 2
-YYPIPI = "".join(chr(c) for c in [76, 76, 95, 72, 101, 97, 116, 101, 114, 95, 50])
-ZCQBMJ = "".join(chr(c) for c in [76, 76, 95, 66, 97, 99, 107, 114, 101, 115, 116])
-CXQIEF = [SAKQXP, ICXQIE]
-EFXQGL = [PIVLAS, IEFXQG]
-HEOCTH = []
-LASSAK = [PIVLAS, IVLASS, VLASSA]
-LRAHEO = [QGLRAH, GLRAHE]
-OCTHBS = [EOCTHB]
-QXPICX = [SAKQXP, AKQXPI, KQXPIC]
-VHFTHE = [QBMJVH, BMJVHF, MJVHFT, JVHFTH]
-VYYPIP = [THECVY, HECVYY, ECVYYP, CVYYPI]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -76,40 +19,89 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return CTHBSK
+        return 1
 
     @property
     def output_keys(self):
-        return HEOCTH
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoEnumStructAccessor(
-                self.struct, ZCQBMJ, CQBMJV, None, VHFTHE, None, None, None
+            "LL_Backrest": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_Backrest",
+                0,
+                None,
+                ["SINGLE", "DUAL", "DUAL_THERMOPLACE", "DUAL_LITESTREME"],
+                None,
+                None,
+                None,
             ),
-            HFTHEC: GeckoEnumStructAccessor(
-                self.struct, HFTHEC, FTHECV, None, VYYPIP, None, None, None
+            "LL_Heater_1": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_Heater_1",
+                1,
+                None,
+                ["Intensity1", "Intensity2", "Intensity3", "Intensity4"],
+                None,
+                None,
+                None,
             ),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, VYYPIP, None, None, None
+            "LL_Heater_2": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_Heater_2",
+                2,
+                None,
+                ["Intensity1", "Intensity2", "Intensity3", "Intensity4"],
+                None,
+                None,
+                None,
             ),
-            PIPIVL: GeckoEnumStructAccessor(
-                self.struct, PIPIVL, IPIVLA, None, LASSAK, None, None, None
+            "LL_Blower": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_Blower",
+                3,
+                None,
+                ["STANDARD", "HIGH", "LOW"],
+                None,
+                None,
+                None,
             ),
-            ASSAKQ: GeckoEnumStructAccessor(
-                self.struct, ASSAKQ, SSAKQX, None, QXPICX, None, None, None
+            "LL_Chromo": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_Chromo",
+                4,
+                None,
+                ["NONE", "BASIC", "DELUXE"],
+                None,
+                None,
+                None,
             ),
-            XPICXQ: GeckoEnumStructAccessor(
-                self.struct, XPICXQ, PICXQI, None, CXQIEF, None, None, None
+            "LL_Audio": GeckoEnumStructAccessor(
+                self.struct, "LL_Audio", 5, None, ["NONE", "MP3"], None, None, None
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, EFXQGL, None, None, None
+            "LL_Menu": GeckoEnumStructAccessor(
+                self.struct, "LL_Menu", 6, None, ["STANDARD", "HOTEL"], None, None, None
             ),
-            FXQGLR: GeckoEnumStructAccessor(
-                self.struct, FXQGLR, XQGLRA, None, LRAHEO, None, None, None
+            "LL_ComfortJet": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_ComfortJet",
+                7,
+                None,
+                ["DEACTIVATE", "ACTIVATE"],
+                None,
+                None,
+                None,
             ),
-            RAHEOC: GeckoEnumStructAccessor(
-                self.struct, RAHEOC, AHEOCT, None, LRAHEO, None, None, None
+            "LL_Aromacloud": GeckoEnumStructAccessor(
+                self.struct,
+                "LL_Aromacloud",
+                8,
+                None,
+                ["DEACTIVATE", "ACTIVATE"],
+                None,
+                None,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/mas-ibc-32k-log-1.py
+++ b/src/geckolib/driver/packs/mas-ibc-32k-log-1.py
@@ -12,404 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [52, 52])
-AHEOCT = 265
-AKQXPI = 260
-AONPYY = "".join(chr(c) for c in [50, 54])
-ASSAKQ = "".join(chr(c) for c in [72, 73, 71, 72])
-BFEGZU = "".join(
-    chr(c)
-    for c in [80, 117, 114, 103, 101, 68, 101, 108, 97, 121, 84, 105, 109, 101, 114]
-)
-BLKXSJ = 6
-BMJVHF = "".join(chr(c) for c in [85, 115, 101, 114, 67, 104, 114, 111, 109, 97])
-BSKSOK = "".join(chr(c) for c in [49, 53])
-BWJYKL = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-CBFEGZ = 1
-CCPQIP = "".join(chr(c) for c in [52, 54])
-CPQIPO = "".join(chr(c) for c in [52, 55])
-CQBMJV = 256
-CTHBSK = "".join(chr(c) for c in [])
-CVYYPI = "".join(chr(c) for c in [83, 67, 65, 78])
-CWAONP = "".join(chr(c) for c in [50, 51])
-CXQIEF = 262
-ECVYYP = "".join(chr(c) for c in [89, 69, 76, 76, 79, 87])
-EFJTAC = "".join(chr(c) for c in [51, 57])
-EFXQGL = 0
-EGZUQE = "".join(chr(c) for c in [50])
-EKCWAO = "".join(chr(c) for c in [50, 49])
-EOCTHB = 266
-EXLSXU = "".join(chr(c) for c in [56])
-FEFJTA = "".join(chr(c) for c in [51, 56])
-FEGZUQ = "".join(chr(c) for c in [49])
-FJTACC = "".join(chr(c) for c in [52, 49])
-FTHECV = "".join(chr(c) for c in [71, 82, 69, 69, 78])
-FTSIFJ = "".join(chr(c) for c in [49, 54, 75])
-FXQGLR = 2
-GLRAHE = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        68,
-        114,
-        121,
-        105,
-        110,
-        103,
-        77,
-        105,
-        110,
-        117,
-        116,
-        101,
-    ]
-)
-GQPLSP = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-GYOUSP = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-GZUQEX = "".join(chr(c) for c in [51])
-HBSKSO = "".join(chr(c) for c in [49, 48])
-HECVYY = "".join(chr(c) for c in [80, 85, 82, 80, 76, 69])
-HEOCTH = "".join(
-    chr(c)
-    for c in [85, 115, 101, 114, 68, 114, 121, 105, 110, 103, 68, 101, 108, 97, 121]
-)
-HFTHEC = "".join(chr(c) for c in [82, 69, 68])
-HIUSOO = 267
-HUOJRJ = "".join(chr(c) for c in [53, 48])
-IAMJMA = "".join(chr(c) for c in [76, 73])
-ICXQIE = "".join(
-    chr(c)
-    for c in [85, 115, 101, 114, 68, 114, 121, 105, 110, 103, 67, 121, 99, 108, 101]
-)
-IFJBIA = "".join(chr(c) for c in [54, 52, 75])
-IGYOUS = 278
-IPIVLA = 258
-IPOUYN = "".join(chr(c) for c in [53, 49])
-IUSOOQ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-IUXFEF = "".join(chr(c) for c in [51, 52])
-IVLASS = 259
-JBIAMJ = 4
-JHIUSO = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-JIGYOU = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-JMAOAW = 285
-JMCBFE = "".join(chr(c) for c in [65, 67, 84, 73, 86, 65, 84, 69])
-JTACCP = "".join(chr(c) for c in [52, 50])
-JUTYEK = "".join(chr(c) for c in [49, 54])
-JVHFTH = "".join(chr(c) for c in [79, 70, 70])
-JWMNZM = "".join(chr(c) for c in [66, 111, 111, 116, 73, 68])
-JYKLGQ = "".join(chr(c) for c in [68, 74, 83, 52])
-JYMOUN = "".join(chr(c) for c in [53, 57])
-KCWAON = "".join(chr(c) for c in [50, 50])
-KLGQPL = "".join(chr(c) for c in [105, 110, 88, 77])
-KPHUOJ = "".join(chr(c) for c in [52, 48])
-KQXPIC = "".join(chr(c) for c in [85, 115, 101, 114, 71, 101, 121, 115, 97, 105, 114])
-KSOKPH = "".join(chr(c) for c in [50, 53])
-KXSJWM = 283
-LASSAK = "".join(chr(c) for c in [77, 69, 68])
-LGQPLS = "".join(chr(c) for c in [75, 54, 48, 48])
-LIUXFE = "".join(chr(c) for c in [51, 51])
-LKXSJW = "".join(chr(c) for c in [80, 111, 119, 101, 114, 83, 116, 97, 116, 101])
-LRAHEO = 264
-LSXUJU = "".join(chr(c) for c in [49, 49])
-MJIGYO = 276
-MJMAOA = 256
-MJVHFT = 257
-MNZMJI = "".join(chr(c) for c in [66, 111, 111, 116, 82, 101, 118])
-MOUNBL = "".join(
-    chr(c) for c in [80, 117, 114, 103, 101, 83, 116, 97, 110, 100, 98, 121]
-)
-NPYYLI = "".join(chr(c) for c in [50, 56])
-NQJYMO = "".join(chr(c) for c in [53, 55])
-NZMJIG = 274
-OCTHBS = "".join(chr(c) for c in [48])
-OJRJHI = "".join(chr(c) for c in [54, 48])
-OKPHUO = "".join(chr(c) for c in [51, 53])
-ONPYYL = "".join(chr(c) for c in [50, 55])
-OOQNRS = 271
-OQNRSJ = "".join(chr(c) for c in [82, 85, 78])
-OUNBLK = "".join(chr(c) for c in [83, 84, 79, 80])
-OUSPBW = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-OUYNQJ = "".join(chr(c) for c in [53, 51])
-PBWJYK = "".join(chr(c) for c in [105, 110, 88, 69])
-PFTSIF = 282
-PHUOJR = "".join(chr(c) for c in [52, 53])
-PIPIVL = "".join(
-    chr(c) for c in [85, 115, 101, 114, 66, 97, 116, 104, 84, 105, 109, 101]
-)
-PIVLAS = "".join(chr(c) for c in [85, 115, 101, 114, 72, 101, 97, 116, 101, 114, 49])
-PLSPFT = "".join(chr(c) for c in [105, 110, 89, 84])
-POUYNQ = "".join(chr(c) for c in [53, 50])
-PQIPOU = "".join(chr(c) for c in [52, 56])
-PYYLIU = "".join(chr(c) for c in [50, 57])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QEXLSX = "".join(chr(c) for c in [55])
-QGLRAH = 263
-QIEFXQ = "".join(chr(c) for c in [68, 97, 105, 108, 121])
-QIPOUY = "".join(chr(c) for c in [52, 57])
-QJYMOU = "".join(chr(c) for c in [53, 56])
-QNRSJM = "".join(chr(c) for c in [83, 84, 65, 84, 69, 49, 48])
-QPLSPF = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-QXPICX = 261
-RAHEOC = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        68,
-        114,
-        121,
-        105,
-        110,
-        103,
-        83,
-        101,
-        99,
-        111,
-        110,
-        100,
-    ]
-)
-RJHIUS = 63
-RSJMCB = "".join(chr(c) for c in [80, 117, 114, 103, 101, 83, 116, 97, 114, 116])
-SAKQXP = "".join(chr(c) for c in [85, 115, 101, 114, 72, 101, 97, 116, 101, 114, 50])
-SIFJBI = "".join(chr(c) for c in [52, 56, 75])
-SJMCBF = "".join(chr(c) for c in [68, 69, 65, 67, 84, 73, 86, 65, 84, 69])
-SJWMNZ = 284
-SKSOKP = "".join(chr(c) for c in [50, 48])
-SOKPHU = "".join(chr(c) for c in [51, 48])
-SOOQNR = "".join(chr(c) for c in [66, 108, 111, 119, 101, 114, 83, 116, 97, 116, 101])
-SPBWJY = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-SPFTSI = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-SXUJUT = "".join(chr(c) for c in [49, 50])
-TACCPQ = "".join(chr(c) for c in [52, 51])
-THBSKS = "".join(chr(c) for c in [53])
-THECVY = "".join(chr(c) for c in [66, 76, 85, 69])
-TSIFJB = "".join(chr(c) for c in [51, 50, 75])
-TYEKCW = "".join(chr(c) for c in [49, 56])
-UJUTYE = "".join(chr(c) for c in [49, 52])
-UNBLKX = "".join(chr(c) for c in [83, 84, 65, 82, 84])
-UOJRJH = "".join(chr(c) for c in [53, 53])
-UQEXLS = "".join(chr(c) for c in [54])
-USOOQN = 269
-USPBWJ = 281
-UTYEKC = "".join(chr(c) for c in [49, 55])
-UXFEFJ = "".join(chr(c) for c in [51, 54])
-UYNQJY = "".join(chr(c) for c in [53, 52])
-VHFTHE = "".join(chr(c) for c in [87, 72, 73, 84, 69])
-VLASSA = "".join(chr(c) for c in [76, 79, 87])
-VYYPIP = "".join(chr(c) for c in [79, 82, 65, 78, 71, 69])
-WAONPY = "".join(chr(c) for c in [50, 52])
-WJYKLG = "".join(chr(c) for c in [77, 73, 65])
-WMNZMJ = 272
-XFEFJT = "".join(chr(c) for c in [51, 55])
-XLSXUJ = "".join(chr(c) for c in [57])
-XPICXQ = "".join(chr(c) for c in [79, 78])
-XQGLRA = "".join(
-    chr(c) for c in [85, 115, 101, 114, 68, 114, 121, 105, 110, 103, 72, 111, 117, 114]
-)
-XQIEFX = "".join(chr(c) for c in [65, 102, 116, 101, 114, 66, 97, 116, 104])
-XSJWMN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 76, 111, 99, 107])
-XUJUTY = "".join(chr(c) for c in [49, 51])
-YEKCWA = "".join(chr(c) for c in [49, 57])
-YKLGQP = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-YLIUXF = "".join(chr(c) for c in [51, 50])
-YNQJYM = "".join(chr(c) for c in [53, 54])
-YOUSPB = 280
-YYLIUX = "".join(chr(c) for c in [51, 49])
-YYPIPI = "".join(chr(c) for c in [80, 65, 85, 83, 69])
-ZCQBMJ = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        66,
-        108,
-        111,
-        119,
-        101,
-        114,
-        73,
-        110,
-        116,
-        101,
-        110,
-        115,
-        105,
-        116,
-        121,
-    ]
-)
-ZMJIGY = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-ZUQEXL = "".join(chr(c) for c in [52])
-AMJMAO = [JHIUSO, IUSOOQ, SOOQNR, RSJMCB, BFEGZU, MOUNBL, LKXSJW, XSJWMN, IAMJMA]
-BIAMJM = []
-FJBIAM = [FTSIFJ, TSIFJB, SIFJBI, IFJBIA]
-IEFXQG = [XQIEFX, QIEFXQ]
-JRJHIU = [
-    OCTHBS,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    THBSKS,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    HBSKSO,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    BSKSOK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    SKSOKP,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    KSOKPH,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    SOKPHU,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    OKPHUO,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    KPHUOJ,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    PHUOJR,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    HUOJRJ,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    UOJRJH,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    CTHBSK,
-    OJRJHI,
-]
-LSPFTS = [
-    SPBWJY,
-    PBWJYK,
-    BWJYKL,
-    WJYKLG,
-    JYKLGQ,
-    YKLGQP,
-    KLGQPL,
-    LGQPLS,
-    GQPLSP,
-    QPLSPF,
-    PLSPFT,
-]
-MCBFEG = [SJMCBF, JMCBFE]
-NBLKXS = [OUNBLK, UNBLKX]
-NRSJMC = [YYPIPI, OQNRSJ, QNRSJM]
-PICXQI = [JVHFTH, XPICXQ]
-SSAKQX = [JVHFTH, VLASSA, LASSAK, ASSAKQ]
-YMOUNB = [
-    OCTHBS,
-    FEGZUQ,
-    EGZUQE,
-    GZUQEX,
-    ZUQEXL,
-    THBSKS,
-    UQEXLS,
-    QEXLSX,
-    EXLSXU,
-    XLSXUJ,
-    HBSKSO,
-    LSXUJU,
-    SXUJUT,
-    XUJUTY,
-    UJUTYE,
-    BSKSOK,
-    JUTYEK,
-    UTYEKC,
-    TYEKCW,
-    YEKCWA,
-    SKSOKP,
-    EKCWAO,
-    KCWAON,
-    CWAONP,
-    WAONPY,
-    KSOKPH,
-    AONPYY,
-    ONPYYL,
-    NPYYLI,
-    PYYLIU,
-    SOKPHU,
-    YYLIUX,
-    YLIUXF,
-    LIUXFE,
-    IUXFEF,
-    OKPHUO,
-    UXFEFJ,
-    XFEFJT,
-    FEFJTA,
-    EFJTAC,
-    KPHUOJ,
-    FJTACC,
-    JTACCP,
-    TACCPQ,
-    ACCPQI,
-    PHUOJR,
-    CCPQIP,
-    CPQIPO,
-    PQIPOU,
-    QIPOUY,
-    HUOJRJ,
-    IPOUYN,
-    POUYNQ,
-    OUYNQJ,
-    UYNQJY,
-    UOJRJH,
-    YNQJYM,
-    NQJYMO,
-    QJYMOU,
-    JYMOUN,
-    OJRJHI,
-]
-YPIPIV = [
-    JVHFTH,
-    VHFTHE,
-    HFTHEC,
-    FTHECV,
-    THECVY,
-    HECVYY,
-    ECVYYP,
-    CVYYPI,
-    VYYPIP,
-    YYPIPI,
-]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -417,83 +19,324 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return CBFEGZ
+        return 1
 
     @property
     def begin(self):
-        return MJMAOA
+        return 256
 
     @property
     def end(self):
-        return JMAOAW
+        return 285
 
     @property
     def all_device_keys(self):
-        return AMJMAO
+        return [
+            "KeypadID",
+            "KeypadRev",
+            "BlowerState",
+            "PurgeStart",
+            "PurgeDelayTimer",
+            "PurgeStandby",
+            "PowerState",
+            "KeypadLock",
+            "LI",
+        ]
 
     @property
     def user_demand_keys(self):
-        return BIAMJM
+        return []
 
     @property
     def error_keys(self):
-        return BIAMJM
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoEnumStructAccessor(
-                self.struct, BMJVHF, MJVHFT, None, YPIPIV, None, None, QBMJVH
+            "UserBlowerIntensity": GeckoByteStructAccessor(
+                self.struct, "UserBlowerIntensity", 256, "ALL"
             ),
-            PIPIVL: GeckoByteStructAccessor(self.struct, PIPIVL, IPIVLA, QBMJVH),
-            PIVLAS: GeckoEnumStructAccessor(
-                self.struct, PIVLAS, IVLASS, None, SSAKQX, None, None, QBMJVH
+            "UserChroma": GeckoEnumStructAccessor(
+                self.struct,
+                "UserChroma",
+                257,
+                None,
+                [
+                    "OFF",
+                    "WHITE",
+                    "RED",
+                    "GREEN",
+                    "BLUE",
+                    "PURPLE",
+                    "YELLOW",
+                    "SCAN",
+                    "ORANGE",
+                    "PAUSE",
+                ],
+                None,
+                None,
+                "ALL",
             ),
-            SAKQXP: GeckoEnumStructAccessor(
-                self.struct, SAKQXP, AKQXPI, None, SSAKQX, None, None, QBMJVH
+            "UserBathTime": GeckoByteStructAccessor(
+                self.struct, "UserBathTime", 258, "ALL"
             ),
-            KQXPIC: GeckoEnumStructAccessor(
-                self.struct, KQXPIC, QXPICX, None, PICXQI, None, None, None
+            "UserHeater1": GeckoEnumStructAccessor(
+                self.struct,
+                "UserHeater1",
+                259,
+                None,
+                ["OFF", "LOW", "MED", "HIGH"],
+                None,
+                None,
+                "ALL",
             ),
-            ICXQIE: GeckoEnumStructAccessor(
-                self.struct, ICXQIE, CXQIEF, EFXQGL, IEFXQG, None, FXQGLR, QBMJVH
+            "UserHeater2": GeckoEnumStructAccessor(
+                self.struct,
+                "UserHeater2",
+                260,
+                None,
+                ["OFF", "LOW", "MED", "HIGH"],
+                None,
+                None,
+                "ALL",
             ),
-            XQGLRA: GeckoByteStructAccessor(self.struct, XQGLRA, QGLRAH, QBMJVH),
-            GLRAHE: GeckoByteStructAccessor(self.struct, GLRAHE, LRAHEO, QBMJVH),
-            RAHEOC: GeckoByteStructAccessor(self.struct, RAHEOC, AHEOCT, QBMJVH),
-            HEOCTH: GeckoEnumStructAccessor(
-                self.struct, HEOCTH, EOCTHB, EFXQGL, JRJHIU, None, RJHIUS, QBMJVH
+            "UserGeysair": GeckoEnumStructAccessor(
+                self.struct, "UserGeysair", 261, None, ["OFF", "ON"], None, None, None
             ),
-            JHIUSO: GeckoWordStructAccessor(self.struct, JHIUSO, HIUSOO, None),
-            IUSOOQ: GeckoWordStructAccessor(self.struct, IUSOOQ, USOOQN, None),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, NRSJMC, None, None, None
+            "UserDryingCycle": GeckoEnumStructAccessor(
+                self.struct,
+                "UserDryingCycle",
+                262,
+                0,
+                ["AfterBath", "Daily"],
+                None,
+                2,
+                "ALL",
             ),
-            RSJMCB: GeckoEnumStructAccessor(
-                self.struct, RSJMCB, CXQIEF, CBFEGZ, MCBFEG, None, None, None
+            "UserDryingHour": GeckoByteStructAccessor(
+                self.struct, "UserDryingHour", 263, "ALL"
             ),
-            BFEGZU: GeckoEnumStructAccessor(
-                self.struct, BFEGZU, CXQIEF, FXQGLR, YMOUNB, None, None, None
+            "UserDryingMinute": GeckoByteStructAccessor(
+                self.struct, "UserDryingMinute", 264, "ALL"
             ),
-            MOUNBL: GeckoEnumStructAccessor(
-                self.struct, MOUNBL, EOCTHB, BLKXSJ, NBLKXS, None, None, None
+            "UserDryingSecond": GeckoByteStructAccessor(
+                self.struct, "UserDryingSecond", 265, "ALL"
             ),
-            LKXSJW: GeckoEnumStructAccessor(
-                self.struct, LKXSJW, KXSJWM, None, PICXQI, None, None, None
+            "UserDryingDelay": GeckoEnumStructAccessor(
+                self.struct,
+                "UserDryingDelay",
+                266,
+                0,
+                [
+                    "0",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "5",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "10",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "15",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "20",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "25",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "30",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "35",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "40",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "45",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "50",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "55",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "60",
+                ],
+                None,
+                63,
+                "ALL",
             ),
-            XSJWMN: GeckoEnumStructAccessor(
-                self.struct, XSJWMN, SJWMNZ, None, PICXQI, None, None, None
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 267, None),
+            "KeypadRev": GeckoWordStructAccessor(self.struct, "KeypadRev", 269, None),
+            "BlowerState": GeckoEnumStructAccessor(
+                self.struct,
+                "BlowerState",
+                271,
+                None,
+                ["PAUSE", "RUN", "STATE10"],
+                None,
+                None,
+                None,
             ),
-            JWMNZM: GeckoWordStructAccessor(self.struct, JWMNZM, WMNZMJ, None),
-            MNZMJI: GeckoWordStructAccessor(self.struct, MNZMJI, NZMJIG, None),
-            ZMJIGY: GeckoWordStructAccessor(self.struct, ZMJIGY, MJIGYO, None),
-            JIGYOU: GeckoWordStructAccessor(self.struct, JIGYOU, IGYOUS, None),
-            GYOUSP: GeckoByteStructAccessor(self.struct, GYOUSP, YOUSPB, None),
-            OUSPBW: GeckoEnumStructAccessor(
-                self.struct, OUSPBW, USPBWJ, None, LSPFTS, None, None, None
+            "PurgeStart": GeckoEnumStructAccessor(
+                self.struct,
+                "PurgeStart",
+                262,
+                1,
+                ["DEACTIVATE", "ACTIVATE"],
+                None,
+                None,
+                None,
             ),
-            SPFTSI: GeckoEnumStructAccessor(
-                self.struct, SPFTSI, PFTSIF, EFXQGL, FJBIAM, None, JBIAMJ, None
+            "PurgeDelayTimer": GeckoEnumStructAccessor(
+                self.struct,
+                "PurgeDelayTimer",
+                262,
+                2,
+                [
+                    "0",
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                    "6",
+                    "7",
+                    "8",
+                    "9",
+                    "10",
+                    "11",
+                    "12",
+                    "13",
+                    "14",
+                    "15",
+                    "16",
+                    "17",
+                    "18",
+                    "19",
+                    "20",
+                    "21",
+                    "22",
+                    "23",
+                    "24",
+                    "25",
+                    "26",
+                    "27",
+                    "28",
+                    "29",
+                    "30",
+                    "31",
+                    "32",
+                    "33",
+                    "34",
+                    "35",
+                    "36",
+                    "37",
+                    "38",
+                    "39",
+                    "40",
+                    "41",
+                    "42",
+                    "43",
+                    "44",
+                    "45",
+                    "46",
+                    "47",
+                    "48",
+                    "49",
+                    "50",
+                    "51",
+                    "52",
+                    "53",
+                    "54",
+                    "55",
+                    "56",
+                    "57",
+                    "58",
+                    "59",
+                    "60",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PurgeStandby": GeckoEnumStructAccessor(
+                self.struct, "PurgeStandby", 266, 6, ["STOP", "START"], None, None, None
+            ),
+            "PowerState": GeckoEnumStructAccessor(
+                self.struct, "PowerState", 283, None, ["OFF", "ON"], None, None, None
+            ),
+            "KeypadLock": GeckoEnumStructAccessor(
+                self.struct, "KeypadLock", 284, None, ["OFF", "ON"], None, None, None
+            ),
+            "BootID": GeckoWordStructAccessor(self.struct, "BootID", 272, None),
+            "BootRev": GeckoWordStructAccessor(self.struct, "BootRev", 274, None),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 276, None),
+            "PackCoreRev": GeckoWordStructAccessor(
+                self.struct, "PackCoreRev", 278, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 280, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                281,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                282,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
             ),
         }

--- a/src/geckolib/driver/packs/mas-ibc-32k.py
+++ b/src/geckolib/driver/packs/mas-ibc-32k.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"

--- a/src/geckolib/driver/packs/mrsteam-cfg-1.py
+++ b/src/geckolib/driver/packs/mrsteam-cfg-1.py
@@ -12,41 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ASSAKQ = "".join(chr(c) for c in [76, 73])
-BMJVHF = "".join(
-    chr(c) for c in [80, 114, 111, 103, 49, 82, 117, 110, 116, 105, 109, 101]
-)
-CQBMJV = 0
-CVYYPI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 50, 82, 117, 110, 116, 105, 109, 101]
-)
-ECVYYP = 4
-FTHECV = "".join(chr(c) for c in [79, 78])
-HECVYY = "".join(
-    chr(c) for c in [80, 114, 111, 103, 50, 83, 101, 116, 112, 111, 105, 110, 116]
-)
-HFTHEC = "".join(chr(c) for c in [79, 70, 70])
-IPIVLA = 8
-IVLASS = "".join(chr(c) for c in [67])
-JVHFTH = "".join(chr(c) for c in [80, 114, 111, 103, 49, 65, 114, 111, 109, 97])
-MJVHFT = 1
-PIPIVL = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-PIVLAS = "".join(chr(c) for c in [70])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-SAKQXP = 1
-VHFTHE = 3
-VYYPIP = 5
-YPIPIV = 7
-YYPIPI = "".join(chr(c) for c in [80, 114, 111, 103, 50, 65, 114, 111, 109, 97])
-ZCQBMJ = "".join(
-    chr(c) for c in [80, 114, 111, 103, 49, 83, 101, 116, 112, 111, 105, 110, 116]
-)
-LASSAK = []
-SSAKQX = [ASSAKQ]
-THECVY = [HFTHEC, FTHECV]
-VLASSA = [PIVLAS, IVLASS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -54,26 +19,34 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return SAKQXP
+        return 1
 
     @property
     def output_keys(self):
-        return LASSAK
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoByteStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoWordStructAccessor(self.struct, BMJVHF, MJVHFT, QBMJVH),
-            JVHFTH: GeckoEnumStructAccessor(
-                self.struct, JVHFTH, VHFTHE, None, THECVY, None, None, QBMJVH
+            "Prog1Setpoint": GeckoByteStructAccessor(
+                self.struct, "Prog1Setpoint", 0, "ALL"
             ),
-            HECVYY: GeckoByteStructAccessor(self.struct, HECVYY, ECVYYP, QBMJVH),
-            CVYYPI: GeckoWordStructAccessor(self.struct, CVYYPI, VYYPIP, QBMJVH),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, THECVY, None, None, QBMJVH
+            "Prog1Runtime": GeckoWordStructAccessor(
+                self.struct, "Prog1Runtime", 1, "ALL"
             ),
-            PIPIVL: GeckoEnumStructAccessor(
-                self.struct, PIPIVL, IPIVLA, None, VLASSA, None, None, QBMJVH
+            "Prog1Aroma": GeckoEnumStructAccessor(
+                self.struct, "Prog1Aroma", 3, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "Prog2Setpoint": GeckoByteStructAccessor(
+                self.struct, "Prog2Setpoint", 4, "ALL"
+            ),
+            "Prog2Runtime": GeckoWordStructAccessor(
+                self.struct, "Prog2Runtime", 5, "ALL"
+            ),
+            "Prog2Aroma": GeckoEnumStructAccessor(
+                self.struct, "Prog2Aroma", 7, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 8, None, ["F", "C"], None, None, "ALL"
             ),
         }

--- a/src/geckolib/driver/packs/mrsteam-cfg-2.py
+++ b/src/geckolib/driver/packs/mrsteam-cfg-2.py
@@ -12,49 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ASSAKQ = 11
-BMJVHF = "".join(
-    chr(c) for c in [80, 114, 111, 103, 49, 82, 117, 110, 116, 105, 109, 101]
-)
-CQBMJV = 0
-CVYYPI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 50, 82, 117, 110, 116, 105, 109, 101]
-)
-ECVYYP = 5
-FTHECV = "".join(chr(c) for c in [79, 78])
-HECVYY = "".join(
-    chr(c) for c in [80, 114, 111, 103, 50, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-HFTHEC = "".join(chr(c) for c in [79, 70, 70])
-IPIVLA = 10
-IVLASS = "".join(chr(c) for c in [67])
-JVHFTH = "".join(chr(c) for c in [80, 114, 111, 103, 49, 65, 114, 111, 109, 97])
-KQXPIC = "".join(chr(c) for c in [76, 73])
-LASSAK = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJVHFT = 2
-PIPIVL = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-PIVLAS = "".join(chr(c) for c in [70])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-SAKQXP = 13
-SSAKQX = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VHFTHE = 4
-VYYPIP = 7
-XPICXQ = 2
-YPIPIV = 9
-YYPIPI = "".join(chr(c) for c in [80, 114, 111, 103, 50, 65, 114, 111, 109, 97])
-ZCQBMJ = "".join(
-    chr(c) for c in [80, 114, 111, 103, 49, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-AKQXPI = []
-QXPICX = [KQXPIC]
-THECVY = [HFTHEC, FTHECV]
-VLASSA = [PIVLAS, IVLASS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -62,28 +19,40 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return XPICXQ
+        return 2
 
     @property
     def output_keys(self):
-        return AKQXPI
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoWordStructAccessor(self.struct, BMJVHF, MJVHFT, QBMJVH),
-            JVHFTH: GeckoEnumStructAccessor(
-                self.struct, JVHFTH, VHFTHE, None, THECVY, None, None, QBMJVH
+            "Prog1SetpointG": GeckoTempStructAccessor(
+                self.struct, "Prog1SetpointG", 0, "ALL"
             ),
-            HECVYY: GeckoTempStructAccessor(self.struct, HECVYY, ECVYYP, QBMJVH),
-            CVYYPI: GeckoWordStructAccessor(self.struct, CVYYPI, VYYPIP, QBMJVH),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, THECVY, None, None, QBMJVH
+            "Prog1Runtime": GeckoWordStructAccessor(
+                self.struct, "Prog1Runtime", 2, "ALL"
             ),
-            PIPIVL: GeckoEnumStructAccessor(
-                self.struct, PIPIVL, IPIVLA, None, VLASSA, None, None, QBMJVH
+            "Prog1Aroma": GeckoEnumStructAccessor(
+                self.struct, "Prog1Aroma", 4, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            LASSAK: GeckoTempStructAccessor(self.struct, LASSAK, ASSAKQ, QBMJVH),
-            SSAKQX: GeckoTempStructAccessor(self.struct, SSAKQX, SAKQXP, QBMJVH),
+            "Prog2SetpointG": GeckoTempStructAccessor(
+                self.struct, "Prog2SetpointG", 5, "ALL"
+            ),
+            "Prog2Runtime": GeckoWordStructAccessor(
+                self.struct, "Prog2Runtime", 7, "ALL"
+            ),
+            "Prog2Aroma": GeckoEnumStructAccessor(
+                self.struct, "Prog2Aroma", 9, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 10, None, ["F", "C"], None, None, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 11, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 13, "ALL"
+            ),
         }

--- a/src/geckolib/driver/packs/mrsteam-cfg-3.py
+++ b/src/geckolib/driver/packs/mrsteam-cfg-3.py
@@ -12,66 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-AKQXPI = "".join(
-    chr(c) for c in [86, 97, 108, 118, 101, 79, 117, 116, 49, 84, 121, 112, 101]
-)
-ASSAKQ = 11
-BMJVHF = "".join(
-    chr(c) for c in [80, 114, 111, 103, 49, 82, 117, 110, 116, 105, 109, 101]
-)
-CQBMJV = 0
-CVYYPI = "".join(
-    chr(c) for c in [80, 114, 111, 103, 50, 82, 117, 110, 116, 105, 109, 101]
-)
-ECVYYP = 5
-EFXQGL = 17
-FTHECV = "".join(chr(c) for c in [79, 78])
-GLRAHE = 3
-HECVYY = "".join(
-    chr(c) for c in [80, 114, 111, 103, 50, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-HFTHEC = "".join(chr(c) for c in [79, 70, 70])
-ICXQIE = "".join(chr(c) for c in [87, 65, 78, 68])
-IEFXQG = "".join(
-    chr(c) for c in [86, 97, 108, 118, 101, 79, 117, 116, 51, 84, 121, 112, 101]
-)
-IPIVLA = 10
-IVLASS = "".join(chr(c) for c in [67])
-JVHFTH = "".join(chr(c) for c in [80, 114, 111, 103, 49, 65, 114, 111, 109, 97])
-KQXPIC = 15
-LASSAK = "".join(
-    chr(c) for c in [77, 105, 110, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-MJVHFT = 2
-PICXQI = "".join(chr(c) for c in [66, 79, 68, 89])
-PIPIVL = "".join(chr(c) for c in [84, 101, 109, 112, 85, 110, 105, 116, 115])
-PIVLAS = "".join(chr(c) for c in [70])
-QBMJVH = "".join(chr(c) for c in [65, 76, 76])
-QIEFXQ = 16
-QXPICX = "".join(chr(c) for c in [78, 79, 78, 69])
-SAKQXP = 13
-SSAKQX = "".join(
-    chr(c) for c in [77, 97, 120, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-VHFTHE = 4
-VYYPIP = 7
-XPICXQ = "".join(chr(c) for c in [72, 69, 65, 68])
-XQGLRA = "".join(chr(c) for c in [76, 73])
-XQIEFX = "".join(
-    chr(c) for c in [86, 97, 108, 118, 101, 79, 117, 116, 50, 84, 121, 112, 101]
-)
-YPIPIV = 9
-YYPIPI = "".join(chr(c) for c in [80, 114, 111, 103, 50, 65, 114, 111, 109, 97])
-ZCQBMJ = "".join(
-    chr(c) for c in [80, 114, 111, 103, 49, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-CXQIEF = [QXPICX, XPICXQ, PICXQI, ICXQIE]
-FXQGLR = []
-QGLRAH = [XQGLRA]
-THECVY = [HFTHEC, FTHECV]
-VLASSA = [PIVLAS, IVLASS]
-
 
 class GeckoConfigStruct:
     def __init__(self, struct_):
@@ -79,37 +19,70 @@ class GeckoConfigStruct:
 
     @property
     def version(self):
-        return GLRAHE
+        return 3
 
     @property
     def output_keys(self):
-        return FXQGLR
+        return []
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoTempStructAccessor(self.struct, ZCQBMJ, CQBMJV, QBMJVH),
-            BMJVHF: GeckoWordStructAccessor(self.struct, BMJVHF, MJVHFT, QBMJVH),
-            JVHFTH: GeckoEnumStructAccessor(
-                self.struct, JVHFTH, VHFTHE, None, THECVY, None, None, QBMJVH
+            "Prog1SetpointG": GeckoTempStructAccessor(
+                self.struct, "Prog1SetpointG", 0, "ALL"
             ),
-            HECVYY: GeckoTempStructAccessor(self.struct, HECVYY, ECVYYP, QBMJVH),
-            CVYYPI: GeckoWordStructAccessor(self.struct, CVYYPI, VYYPIP, QBMJVH),
-            YYPIPI: GeckoEnumStructAccessor(
-                self.struct, YYPIPI, YPIPIV, None, THECVY, None, None, QBMJVH
+            "Prog1Runtime": GeckoWordStructAccessor(
+                self.struct, "Prog1Runtime", 2, "ALL"
             ),
-            PIPIVL: GeckoEnumStructAccessor(
-                self.struct, PIPIVL, IPIVLA, None, VLASSA, None, None, QBMJVH
+            "Prog1Aroma": GeckoEnumStructAccessor(
+                self.struct, "Prog1Aroma", 4, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            LASSAK: GeckoTempStructAccessor(self.struct, LASSAK, ASSAKQ, QBMJVH),
-            SSAKQX: GeckoTempStructAccessor(self.struct, SSAKQX, SAKQXP, QBMJVH),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, CXQIEF, None, None, QBMJVH
+            "Prog2SetpointG": GeckoTempStructAccessor(
+                self.struct, "Prog2SetpointG", 5, "ALL"
             ),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, QIEFXQ, None, CXQIEF, None, None, QBMJVH
+            "Prog2Runtime": GeckoWordStructAccessor(
+                self.struct, "Prog2Runtime", 7, "ALL"
             ),
-            IEFXQG: GeckoEnumStructAccessor(
-                self.struct, IEFXQG, EFXQGL, None, CXQIEF, None, None, QBMJVH
+            "Prog2Aroma": GeckoEnumStructAccessor(
+                self.struct, "Prog2Aroma", 9, None, ["OFF", "ON"], None, None, "ALL"
+            ),
+            "TempUnits": GeckoEnumStructAccessor(
+                self.struct, "TempUnits", 10, None, ["F", "C"], None, None, "ALL"
+            ),
+            "MinSetpointG": GeckoTempStructAccessor(
+                self.struct, "MinSetpointG", 11, "ALL"
+            ),
+            "MaxSetpointG": GeckoTempStructAccessor(
+                self.struct, "MaxSetpointG", 13, "ALL"
+            ),
+            "ValveOut1Type": GeckoEnumStructAccessor(
+                self.struct,
+                "ValveOut1Type",
+                15,
+                None,
+                ["NONE", "HEAD", "BODY", "WAND"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ValveOut2Type": GeckoEnumStructAccessor(
+                self.struct,
+                "ValveOut2Type",
+                16,
+                None,
+                ["NONE", "HEAD", "BODY", "WAND"],
+                None,
+                None,
+                "ALL",
+            ),
+            "ValveOut3Type": GeckoEnumStructAccessor(
+                self.struct,
+                "ValveOut3Type",
+                17,
+                None,
+                ["NONE", "HEAD", "BODY", "WAND"],
+                None,
+                None,
+                "ALL",
             ),
         }

--- a/src/geckolib/driver/packs/mrsteam-log-1.py
+++ b/src/geckolib/driver/packs/mrsteam-log-1.py
@@ -12,151 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-AHEOCT = "".join(chr(c) for c in [72, 50, 79, 50, 69, 114, 114])
-AKQXPI = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-AONPYY = 279
-ASSAKQ = 263
-BFEGZU = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-BMJVHF = "".join(chr(c) for c in [79, 78])
-BSKSOK = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 51])
-CBFEGZ = "".join(chr(c) for c in [75, 54, 48, 48])
-CQBMJV = 257
-CTHBSK = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 57])
-CVYYPI = 3
-CWAONP = 278
-CXQIEF = "".join(chr(c) for c in [78, 111, 75, 101, 121, 112, 97, 100])
-ECVYYP = "".join(chr(c) for c in [67, 104, 114, 111, 109, 97, 83, 116, 97, 116, 101])
-EFXQGL = "".join(chr(c) for c in [83, 108, 97, 118, 101, 77, 111, 100, 101])
-EGZUQE = "".join(chr(c) for c in [105, 110, 89, 84])
-EKCWAO = 277
-EOCTHB = 4
-EXLSXU = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-FEGZUQ = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-FTHECV = "".join(chr(c) for c in [80, 97, 117, 115, 101])
-FXQGLR = 259
-GLRAHE = 260
-GZUQEX = "".join(
-    chr(c) for c in [67, 111, 108, 111, 114, 95, 75, 101, 121, 112, 97, 100]
-)
-HBSKSO = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 50])
-HECVYY = "".join(chr(c) for c in [68, 105, 97, 103, 110, 111, 115, 116, 105, 99])
-HEOCTH = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 50, 79, 50, 69, 114, 114])
-HFTHEC = "".join(chr(c) for c in [65, 76, 76])
-HIUSOO = 271
-HUOJRJ = 7
-ICXQIE = 2658
-IEFXQG = 5
-IPIVLA = "".join(chr(c) for c in [80, 114, 111, 103, 50])
-IUSOOQ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-IUXFEF = 256
-IVLASS = "".join(
-    chr(c) for c in [85, 115, 101, 114, 83, 101, 116, 112, 111, 105, 110, 116]
-)
-JHIUSO = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-JMCBFE = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-JRJHIU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-JVHFTH = 0
-KCWAON = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-KPHUOJ = 6
-KQXPIC = 256
-KSOKPH = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 53])
-LASSAK = "".join(chr(c) for c in [85, 115, 101, 114, 82, 117, 110, 116, 105, 109, 101])
-LRAHEO = "".join(chr(c) for c in [80, 114, 114, 50, 69, 114, 114])
-LSXUJU = "".join(chr(c) for c in [49, 54, 75])
-MCBFEG = "".join(chr(c) for c in [105, 110, 88, 77])
-NPYYLI = 280
-NRSJMC = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-OCTHBS = "".join(chr(c) for c in [75, 101, 121, 83, 116, 117, 99, 107, 69, 114, 114])
-OJRJHI = 267
-OKPHUO = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 55])
-ONPYYL = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-OOQNRS = 273
-OQNRSJ = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-PHUOJR = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 56])
-PICXQI = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-PIPIVL = "".join(chr(c) for c in [80, 114, 111, 103, 49])
-QBMJVH = "".join(chr(c) for c in [79, 70, 70])
-QGLRAH = "".join(
-    chr(c) for c in [80, 111, 119, 101, 114, 70, 97, 105, 108, 69, 114, 114]
-)
-QIEFXQ = "".join(
-    chr(c) for c in [69, 120, 112, 114, 101, 115, 115, 67, 121, 99, 108, 101]
-)
-QNRSJM = "".join(chr(c) for c in [105, 110, 88, 69])
-QXPICX = "".join(
-    chr(c) for c in [69, 120, 116, 101, 114, 110, 97, 108, 80, 114, 111, 98, 101]
-)
-RAHEOC = "".join(chr(c) for c in [80, 114, 114, 49, 69, 114, 114])
-RJHIUS = 269
-RSJMCB = "".join(chr(c) for c in [77, 73, 65])
-SAKQXP = 265
-SJMCBF = "".join(chr(c) for c in [68, 74, 83, 52])
-SKSOKP = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 52])
-SOKPHU = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 54])
-SOOQNR = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-SSAKQX = "".join(chr(c) for c in [85, 115, 101, 114, 65, 114, 111, 109, 97])
-SXUJUT = "".join(chr(c) for c in [51, 50, 75])
-THBSKS = 266
-THECVY = 1
-TYEKCW = 275
-UJUTYE = "".join(chr(c) for c in [54, 52, 75])
-UOJRJH = "".join(chr(c) for c in [77, 97, 120, 82, 117, 110, 116, 105, 109, 101])
-UQEXLS = "".join(chr(c) for c in [77, 114, 83, 116, 101, 97, 109])
-USOOQN = 272
-UTYEKC = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-UXFEFJ = 280
-VHFTHE = 2
-VLASSA = 262
-VYYPIP = "".join(
-    chr(c) for c in [83, 101, 108, 101, 99, 116, 101, 100, 80, 114, 111, 103]
-)
-WAONPY = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-XLSXUJ = 274
-XPICXQ = 258
-XQGLRA = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 72, 101, 97, 116, 101, 114, 83, 116, 97, 116, 101]
-)
-XQIEFX = "".join(
-    chr(c) for c in [78, 111, 82, 101, 103, 117, 108, 97, 116, 105, 111, 110]
-)
-XUJUTY = "".join(chr(c) for c in [52, 56, 75])
-YEKCWA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-YPIPIV = "".join(chr(c) for c in [85, 115, 101, 114])
-YYLIUX = "".join(chr(c) for c in [76, 73])
-YYPIPI = 261
-ZCQBMJ = "".join(chr(c) for c in [77, 111, 100, 101])
-ZUQEXL = "".join(chr(c) for c in [105, 110, 89, 74])
-JUTYEK = [LSXUJU, SXUJUT, XUJUTY, UJUTYE]
-LIUXFE = [QGLRAH, AHEOCT, RAHEOC, LRAHEO, HEOCTH, OCTHBS]
-MJVHFT = [QBMJVH, BMJVHF]
-PIVLAS = [YPIPIV, PIPIVL, IPIVLA]
-PYYLIU = []
-QEXLSX = [
-    OQNRSJ,
-    QNRSJM,
-    NRSJMC,
-    RSJMCB,
-    SJMCBF,
-    JMCBFE,
-    MCBFEG,
-    CBFEGZ,
-    BFEGZU,
-    FEGZUQ,
-    EGZUQE,
-    GZUQEX,
-    ZUQEXL,
-    UQEXLS,
-]
-YLIUXF = [YYLIUX]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -164,90 +19,161 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return THECVY
+        return 1
 
     @property
     def begin(self):
-        return IUXFEF
+        return 256
 
     @property
     def end(self):
-        return UXFEFJ
+        return 280
 
     @property
     def all_device_keys(self):
-        return YLIUXF
+        return ["LI"]
 
     @property
     def user_demand_keys(self):
-        return PYYLIU
+        return []
 
     @property
     def error_keys(self):
-        return LIUXFE
+        return [
+            "PowerFailErr",
+            "Prr2Err",
+            "SlaveH2O2Err",
+            "KeyStuckErr",
+            "Prr1Err",
+            "H2O2Err",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoEnumStructAccessor(
-                self.struct, ZCQBMJ, CQBMJV, JVHFTH, MJVHFT, None, VHFTHE, HFTHEC
+            "Mode": GeckoEnumStructAccessor(
+                self.struct, "Mode", 257, 0, ["OFF", "ON"], None, 2, "ALL"
             ),
-            FTHECV: GeckoBoolStructAccessor(
-                self.struct, FTHECV, CQBMJV, THECVY, HFTHEC
+            "Pause": GeckoBoolStructAccessor(self.struct, "Pause", 257, 1, "ALL"),
+            "Diagnostic": GeckoBoolStructAccessor(
+                self.struct, "Diagnostic", 257, 2, "ALL"
             ),
-            HECVYY: GeckoBoolStructAccessor(
-                self.struct, HECVYY, CQBMJV, VHFTHE, HFTHEC
+            "ChromaState": GeckoEnumStructAccessor(
+                self.struct, "ChromaState", 257, 3, ["OFF", "ON"], None, 2, "ALL"
             ),
-            ECVYYP: GeckoEnumStructAccessor(
-                self.struct, ECVYYP, CQBMJV, CVYYPI, MJVHFT, None, VHFTHE, HFTHEC
+            "SelectedProg": GeckoEnumStructAccessor(
+                self.struct,
+                "SelectedProg",
+                261,
+                None,
+                ["User", "Prog1", "Prog2"],
+                None,
+                None,
+                "ALL",
             ),
-            VYYPIP: GeckoEnumStructAccessor(
-                self.struct, VYYPIP, YYPIPI, None, PIVLAS, None, None, HFTHEC
+            "UserSetpoint": GeckoByteStructAccessor(
+                self.struct, "UserSetpoint", 262, "ALL"
             ),
-            IVLASS: GeckoByteStructAccessor(self.struct, IVLASS, VLASSA, HFTHEC),
-            LASSAK: GeckoWordStructAccessor(self.struct, LASSAK, ASSAKQ, HFTHEC),
-            SSAKQX: GeckoEnumStructAccessor(
-                self.struct, SSAKQX, SAKQXP, None, MJVHFT, None, None, HFTHEC
+            "UserRuntime": GeckoWordStructAccessor(
+                self.struct, "UserRuntime", 263, "ALL"
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoBoolStructAccessor(self.struct, QXPICX, XPICXQ, JVHFTH, None),
-            PICXQI: GeckoBoolStructAccessor(self.struct, PICXQI, ICXQIE, THECVY, None),
-            CXQIEF: GeckoBoolStructAccessor(self.struct, CXQIEF, XPICXQ, VHFTHE, None),
-            XQIEFX: GeckoBoolStructAccessor(self.struct, XQIEFX, XPICXQ, CVYYPI, None),
-            QIEFXQ: GeckoBoolStructAccessor(self.struct, QIEFXQ, XPICXQ, IEFXQG, None),
-            EFXQGL: GeckoEnumStructAccessor(
-                self.struct, EFXQGL, FXQGLR, THECVY, MJVHFT, None, VHFTHE, None
+            "UserAroma": GeckoEnumStructAccessor(
+                self.struct, "UserAroma", 265, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            XQGLRA: GeckoEnumStructAccessor(
-                self.struct, XQGLRA, FXQGLR, CVYYPI, MJVHFT, None, VHFTHE, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 256, None),
+            "ExternalProbe": GeckoBoolStructAccessor(
+                self.struct, "ExternalProbe", 258, 0, None
             ),
-            QGLRAH: GeckoBoolStructAccessor(self.struct, QGLRAH, GLRAHE, JVHFTH, None),
-            LRAHEO: GeckoBoolStructAccessor(self.struct, LRAHEO, GLRAHE, THECVY, None),
-            RAHEOC: GeckoBoolStructAccessor(self.struct, RAHEOC, GLRAHE, VHFTHE, None),
-            AHEOCT: GeckoBoolStructAccessor(self.struct, AHEOCT, GLRAHE, CVYYPI, None),
-            HEOCTH: GeckoBoolStructAccessor(self.struct, HEOCTH, GLRAHE, EOCTHB, None),
-            OCTHBS: GeckoBoolStructAccessor(self.struct, OCTHBS, GLRAHE, IEFXQG, None),
-            CTHBSK: GeckoBoolStructAccessor(self.struct, CTHBSK, THBSKS, JVHFTH, None),
-            HBSKSO: GeckoBoolStructAccessor(self.struct, HBSKSO, THBSKS, THECVY, None),
-            BSKSOK: GeckoBoolStructAccessor(self.struct, BSKSOK, THBSKS, VHFTHE, None),
-            SKSOKP: GeckoBoolStructAccessor(self.struct, SKSOKP, THBSKS, CVYYPI, None),
-            KSOKPH: GeckoBoolStructAccessor(self.struct, KSOKPH, THBSKS, EOCTHB, None),
-            SOKPHU: GeckoBoolStructAccessor(self.struct, SOKPHU, THBSKS, IEFXQG, None),
-            OKPHUO: GeckoBoolStructAccessor(self.struct, OKPHUO, THBSKS, KPHUOJ, None),
-            PHUOJR: GeckoBoolStructAccessor(self.struct, PHUOJR, THBSKS, HUOJRJ, None),
-            UOJRJH: GeckoWordStructAccessor(self.struct, UOJRJH, OJRJHI, None),
-            JRJHIU: GeckoWordStructAccessor(self.struct, JRJHIU, RJHIUS, None),
-            JHIUSO: GeckoByteStructAccessor(self.struct, JHIUSO, HIUSOO, None),
-            IUSOOQ: GeckoByteStructAccessor(self.struct, IUSOOQ, USOOQN, None),
-            SOOQNR: GeckoEnumStructAccessor(
-                self.struct, SOOQNR, OOQNRS, None, QEXLSX, None, None, None
+            "WaterDetected": GeckoBoolStructAccessor(
+                self.struct, "WaterDetected", 2658, 1, None
             ),
-            EXLSXU: GeckoEnumStructAccessor(
-                self.struct, EXLSXU, XLSXUJ, JVHFTH, JUTYEK, None, EOCTHB, None
+            "NoKeypad": GeckoBoolStructAccessor(self.struct, "NoKeypad", 258, 2, None),
+            "NoRegulation": GeckoBoolStructAccessor(
+                self.struct, "NoRegulation", 258, 3, None
             ),
-            UTYEKC: GeckoWordStructAccessor(self.struct, UTYEKC, TYEKCW, None),
-            YEKCWA: GeckoByteStructAccessor(self.struct, YEKCWA, EKCWAO, None),
-            KCWAON: GeckoByteStructAccessor(self.struct, KCWAON, CWAONP, None),
-            WAONPY: GeckoByteStructAccessor(self.struct, WAONPY, AONPYY, None),
-            ONPYYL: GeckoByteStructAccessor(self.struct, ONPYYL, NPYYLI, None),
+            "ExpressCycle": GeckoBoolStructAccessor(
+                self.struct, "ExpressCycle", 258, 5, None
+            ),
+            "SlaveMode": GeckoEnumStructAccessor(
+                self.struct, "SlaveMode", 259, 1, ["OFF", "ON"], None, 2, None
+            ),
+            "SlaveHeaterState": GeckoEnumStructAccessor(
+                self.struct, "SlaveHeaterState", 259, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "PowerFailErr": GeckoBoolStructAccessor(
+                self.struct, "PowerFailErr", 260, 0, None
+            ),
+            "Prr2Err": GeckoBoolStructAccessor(self.struct, "Prr2Err", 260, 1, None),
+            "Prr1Err": GeckoBoolStructAccessor(self.struct, "Prr1Err", 260, 2, None),
+            "H2O2Err": GeckoBoolStructAccessor(self.struct, "H2O2Err", 260, 3, None),
+            "SlaveH2O2Err": GeckoBoolStructAccessor(
+                self.struct, "SlaveH2O2Err", 260, 4, None
+            ),
+            "KeyStuckErr": GeckoBoolStructAccessor(
+                self.struct, "KeyStuckErr", 260, 5, None
+            ),
+            "Jumper9": GeckoBoolStructAccessor(self.struct, "Jumper9", 266, 0, None),
+            "Jumper2": GeckoBoolStructAccessor(self.struct, "Jumper2", 266, 1, None),
+            "Jumper3": GeckoBoolStructAccessor(self.struct, "Jumper3", 266, 2, None),
+            "Jumper4": GeckoBoolStructAccessor(self.struct, "Jumper4", 266, 3, None),
+            "Jumper5": GeckoBoolStructAccessor(self.struct, "Jumper5", 266, 4, None),
+            "Jumper6": GeckoBoolStructAccessor(self.struct, "Jumper6", 266, 5, None),
+            "Jumper7": GeckoBoolStructAccessor(self.struct, "Jumper7", 266, 6, None),
+            "Jumper8": GeckoBoolStructAccessor(self.struct, "Jumper8", 266, 7, None),
+            "MaxRuntime": GeckoWordStructAccessor(self.struct, "MaxRuntime", 267, None),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 269, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 271, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 272, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                273,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "Color_Keypad",
+                    "inYJ",
+                    "MrSteam",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                274,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 275, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 277, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 278, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 279, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 280, None
+            ),
         }

--- a/src/geckolib/driver/packs/mrsteam-log-2.py
+++ b/src/geckolib/driver/packs/mrsteam-log-2.py
@@ -12,224 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(chr(c) for c in [68, 74, 83, 52])
-AKQXPI = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-AONPYY = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 79, 117, 116, 112, 117, 116]
-)
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 103, 49])
-BFEGZU = "".join(chr(c) for c in [78, 79, 95, 84, 83, 67])
-BLKXSJ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-BMJVHF = "".join(chr(c) for c in [79, 78])
-BSKSOK = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 72, 101, 97, 116, 101, 114, 83, 116, 97, 116, 101]
-)
-CBFEGZ = 277
-CCPQIP = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-CPQIPO = "".join(chr(c) for c in [105, 110, 88, 77])
-CQBMJV = 256
-CTHBSK = "".join(
-    chr(c) for c in [69, 120, 112, 114, 101, 115, 115, 67, 121, 99, 108, 101]
-)
-CWAONP = 295
-CXQIEF = "".join(chr(c) for c in [80, 97, 117, 115, 101, 83, 116, 97, 116, 101])
-ECVYYP = 258
-EFJTAC = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-EFXQGL = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-EGZUQE = "".join(chr(c) for c in [84, 83, 67, 95, 53, 51])
-EKCWAO = 293
-EOCTHB = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 80, 114, 111, 98, 101])
-EXLSXU = 298
-FEFJTA = 285
-FEGZUQ = "".join(chr(c) for c in [83, 67, 95, 53, 52])
-FJTACC = "".join(chr(c) for c in [105, 110, 88, 69])
-FTHECV = 257
-FXQGLR = 4
-GLRAHE = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-GZUQEX = "".join(chr(c) for c in [65, 85, 88, 95, 83, 87])
-HBSKSO = 271
-HECVYY = "".join(chr(c) for c in [85, 115, 101, 114, 65, 114, 111, 109, 97])
-HEOCTH = 6
-HFTHEC = "".join(chr(c) for c in [85, 115, 101, 114, 80, 97, 117, 115, 101])
-HIUSOO = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 57])
-HUOJRJ = "".join(chr(c) for c in [75, 101, 121, 83, 116, 117, 99, 107, 69, 114, 114])
-ICXQIE = 2
-IEFXQG = 3
-IPIVLA = "".join(chr(c) for c in [85, 115, 101, 114, 82, 117, 110, 116, 105, 109, 101])
-IPOUYN = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-IUSOOQ = 274
-IUXFEF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-IVLASS = "".join(chr(c) for c in [85, 115, 101, 114, 80, 114, 111, 103])
-JHIUSO = 273
-JIGYOU = "".join(chr(c) for c in [76, 73])
-JMCBFE = 275
-JRJHIU = 7
-JTACCP = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-JUTYEK = 278
-JWMNZM = 290
-JYMOUN = 286
-KCWAON = "".join(
-    chr(c)
-    for c in [68, 114, 97, 105, 110, 86, 97, 108, 118, 101, 79, 117, 116, 112, 117, 116]
-)
-KPHUOJ = "".join(chr(c) for c in [72, 50, 79, 50, 69, 114, 114])
-KQXPIC = 268
-KSOKPH = 272
-KXSJWM = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-LASSAK = "".join(chr(c) for c in [85, 115, 101, 114])
-LIUXFE = 283
-LKXSJW = 287
-LRAHEO = "".join(chr(c) for c in [83, 76, 65, 86, 69])
-LSXUJU = 300
-MCBFEG = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-MJVHFT = "".join(chr(c) for c in [68, 73, 65, 71, 78, 79, 83, 84, 73, 67])
-MNZMJI = 291
-MOUNBL = "".join(chr(c) for c in [51, 50, 75])
-NPYYLI = "".join(
-    chr(c) for c in [67, 104, 114, 111, 109, 97, 79, 117, 116, 112, 117, 116]
-)
-NRSJMC = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 55])
-NZMJIG = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-OCTHBS = 270
-OJRJHI = "".join(chr(c) for c in [80, 114, 114, 51, 69, 114, 114])
-OKPHUO = "".join(chr(c) for c in [80, 114, 114, 49, 69, 114, 114])
-ONPYYL = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 86, 97, 108, 118, 101, 79, 117, 116, 112, 117, 116]
-)
-OOQNRS = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 52])
-OQNRSJ = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 53])
-OUNBLK = "".join(chr(c) for c in [52, 56, 75])
-OUSPBW = 301
-OUYNQJ = "".join(
-    chr(c) for c in [67, 111, 108, 111, 114, 95, 75, 101, 121, 112, 97, 100]
-)
-PHUOJR = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 50, 79, 50, 69, 114, 114])
-PICXQI = 0
-PIPIVL = 264
-PIVLAS = 261
-POUYNQ = "".join(chr(c) for c in [105, 110, 89, 84])
-PQIPOU = "".join(chr(c) for c in [75, 54, 48, 48])
-PYYLIU = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-QBMJVH = "".join(chr(c) for c in [79, 70, 70])
-QEXLSX = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-QGLRAH = 5
-QIEFXQ = "".join(
-    chr(c) for c in [69, 120, 116, 101, 114, 110, 97, 108, 80, 114, 111, 98, 101]
-)
-QIPOUY = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-QJYMOU = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-QNRSJM = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 54])
-QXPICX = "".join(chr(c) for c in [77, 111, 100, 101, 83, 116, 97, 116, 101])
-RAHEOC = "".join(chr(c) for c in [77, 65, 83, 84, 69, 82])
-RJHIUS = "".join(chr(c) for c in [80, 114, 114, 52, 69, 114, 114])
-RSJMCB = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 56])
-SJMCBF = "".join(chr(c) for c in [77, 97, 120, 82, 117, 110, 116, 105, 109, 101])
-SJWMNZ = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-SKSOKP = "".join(
-    chr(c) for c in [80, 111, 119, 101, 114, 70, 97, 105, 108, 69, 114, 114]
-)
-SOKPHU = "".join(chr(c) for c in [80, 114, 114, 50, 69, 114, 114])
-SOOQNR = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 51])
-SSAKQX = "".join(chr(c) for c in [80, 114, 111, 103, 50])
-SXUJUT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-TACCPQ = "".join(chr(c) for c in [77, 73, 65])
-THBSKS = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 110, 83, 116, 97, 116, 101]
-)
-THECVY = 1
-TYEKCW = 296
-UJUTYE = "".join(chr(c) for c in [82, 111, 111, 109, 84, 101, 109, 112, 71])
-UNBLKX = "".join(chr(c) for c in [54, 52, 75])
-UOJRJH = "".join(chr(c) for c in [70, 108, 97, 115, 104, 69, 114, 114])
-USOOQN = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 50])
-UTYEKC = "".join(chr(c) for c in [75, 49, 48, 48, 48, 84, 101, 109, 112, 71])
-UXFEFJ = 284
-UYNQJY = "".join(chr(c) for c in [105, 110, 89, 74])
-VHFTHE = "".join(chr(c) for c in [65, 76, 76])
-VLASSA = 263
-VYYPIP = "".join(chr(c) for c in [85, 115, 101, 114, 67, 104, 114, 111, 109, 97])
-WAONPY = "".join(chr(c) for c in [65, 114, 111, 109, 97, 79, 117, 116, 112, 117, 116])
-WMNZMJ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-XFEFJT = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-XLSXUJ = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-XPICXQ = 269
-XQGLRA = "".join(
-    chr(c) for c in [78, 111, 82, 101, 103, 117, 108, 97, 116, 105, 111, 110]
-)
-XQIEFX = "".join(
-    chr(c)
-    for c in [68, 105, 97, 103, 110, 111, 115, 116, 105, 99, 83, 116, 97, 116, 101]
-)
-XSJWMN = 289
-XUJUTY = 301
-YEKCWA = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        97,
-        105,
-        110,
-        105,
-        110,
-        103,
-        82,
-        117,
-        110,
-        116,
-        105,
-        109,
-        101,
-    ]
-)
-YLIUXF = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-YMOUNB = "".join(chr(c) for c in [49, 54, 75])
-YNQJYM = "".join(chr(c) for c in [77, 114, 83, 116, 101, 97, 109])
-YOUSPB = 256
-YPIPIV = "".join(
-    chr(c) for c in [85, 115, 101, 114, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-YYLIUX = 281
-YYPIPI = 259
-ZCQBMJ = "".join(chr(c) for c in [85, 115, 101, 114, 77, 111, 100, 101])
-ZMJIGY = 292
-ZUQEXL = "".join(chr(c) for c in [67, 79, 76, 79, 82, 95, 83, 69, 82, 73, 69, 83])
-AHEOCT = [LRAHEO, RAHEOC]
-CVYYPI = [QBMJVH, BMJVHF]
-GYOUSP = [SKSOKP, UOJRJH, KPHUOJ, OKPHUO, OJRJHI, RJHIUS, SOKPHU, PHUOJR, HUOJRJ]
-IGYOUS = [JIGYOU]
-JVHFTH = [QBMJVH, BMJVHF, MJVHFT]
-MJIGYO = []
-NBLKXS = [YMOUNB, MOUNBL, OUNBLK, UNBLKX]
-NQJYMO = [
-    EFJTAC,
-    FJTACC,
-    JTACCP,
-    TACCPQ,
-    ACCPQI,
-    CCPQIP,
-    CPQIPO,
-    PQIPOU,
-    QIPOUY,
-    IPOUYN,
-    POUYNQ,
-    OUYNQJ,
-    UYNQJY,
-    YNQJYM,
-]
-SAKQXP = [LASSAK, ASSAKQ, SSAKQX]
-UQEXLS = [BFEGZU, FEGZUQ, EGZUQE, GZUQEX, ZUQEXL]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -237,112 +19,222 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return ICXQIE
+        return 2
 
     @property
     def begin(self):
-        return YOUSPB
+        return 256
 
     @property
     def end(self):
-        return OUSPBW
+        return 301
 
     @property
     def all_device_keys(self):
-        return IGYOUS
+        return ["LI"]
 
     @property
     def user_demand_keys(self):
-        return MJIGYO
+        return []
 
     @property
     def error_keys(self):
-        return GYOUSP
+        return [
+            "PowerFailErr",
+            "Prr2Err",
+            "SlaveH2O2Err",
+            "KeyStuckErr",
+            "Prr3Err",
+            "Prr1Err",
+            "Prr4Err",
+            "H2O2Err",
+            "FlashErr",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoEnumStructAccessor(
-                self.struct, ZCQBMJ, CQBMJV, None, JVHFTH, None, None, VHFTHE
+            "UserMode": GeckoEnumStructAccessor(
+                self.struct,
+                "UserMode",
+                256,
+                None,
+                ["OFF", "ON", "DIAGNOSTIC"],
+                None,
+                None,
+                "ALL",
             ),
-            HFTHEC: GeckoBoolStructAccessor(
-                self.struct, HFTHEC, FTHECV, THECVY, VHFTHE
+            "UserPause": GeckoBoolStructAccessor(
+                self.struct, "UserPause", 257, 1, "ALL"
             ),
-            HECVYY: GeckoEnumStructAccessor(
-                self.struct, HECVYY, ECVYYP, None, CVYYPI, None, None, VHFTHE
+            "UserAroma": GeckoEnumStructAccessor(
+                self.struct, "UserAroma", 258, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            VYYPIP: GeckoEnumStructAccessor(
-                self.struct, VYYPIP, YYPIPI, None, CVYYPI, None, None, VHFTHE
+            "UserChroma": GeckoEnumStructAccessor(
+                self.struct, "UserChroma", 259, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            YPIPIV: GeckoTempStructAccessor(self.struct, YPIPIV, PIPIVL, VHFTHE),
-            IPIVLA: GeckoWordStructAccessor(self.struct, IPIVLA, PIVLAS, VHFTHE),
-            IVLASS: GeckoEnumStructAccessor(
-                self.struct, IVLASS, VLASSA, None, SAKQXP, None, None, VHFTHE
+            "UserSetpointG": GeckoTempStructAccessor(
+                self.struct, "UserSetpointG", 264, "ALL"
             ),
-            AKQXPI: GeckoByteStructAccessor(self.struct, AKQXPI, KQXPIC, None),
-            QXPICX: GeckoEnumStructAccessor(
-                self.struct, QXPICX, XPICXQ, PICXQI, CVYYPI, None, ICXQIE, None
+            "UserRuntime": GeckoWordStructAccessor(
+                self.struct, "UserRuntime", 261, "ALL"
             ),
-            CXQIEF: GeckoBoolStructAccessor(self.struct, CXQIEF, XPICXQ, THECVY, None),
-            XQIEFX: GeckoEnumStructAccessor(
-                self.struct, XQIEFX, XPICXQ, ICXQIE, CVYYPI, None, ICXQIE, None
+            "UserProg": GeckoEnumStructAccessor(
+                self.struct,
+                "UserProg",
+                263,
+                None,
+                ["User", "Prog1", "Prog2"],
+                None,
+                None,
+                "ALL",
             ),
-            QIEFXQ: GeckoBoolStructAccessor(self.struct, QIEFXQ, XPICXQ, IEFXQG, None),
-            EFXQGL: GeckoBoolStructAccessor(self.struct, EFXQGL, XPICXQ, FXQGLR, None),
-            XQGLRA: GeckoBoolStructAccessor(self.struct, XQGLRA, XPICXQ, QGLRAH, None),
-            GLRAHE: GeckoEnumStructAccessor(
-                self.struct, GLRAHE, XPICXQ, HEOCTH, AHEOCT, None, ICXQIE, None
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 268, None),
+            "ModeState": GeckoEnumStructAccessor(
+                self.struct, "ModeState", 269, 0, ["OFF", "ON"], None, 2, None
             ),
-            EOCTHB: GeckoBoolStructAccessor(self.struct, EOCTHB, OCTHBS, PICXQI, None),
-            CTHBSK: GeckoBoolStructAccessor(self.struct, CTHBSK, OCTHBS, THECVY, None),
-            THBSKS: GeckoBoolStructAccessor(self.struct, THBSKS, HBSKSO, THECVY, None),
-            BSKSOK: GeckoEnumStructAccessor(
-                self.struct, BSKSOK, HBSKSO, IEFXQG, CVYYPI, None, ICXQIE, None
+            "PauseState": GeckoBoolStructAccessor(
+                self.struct, "PauseState", 269, 1, None
             ),
-            SKSOKP: GeckoBoolStructAccessor(self.struct, SKSOKP, KSOKPH, PICXQI, None),
-            SOKPHU: GeckoBoolStructAccessor(self.struct, SOKPHU, KSOKPH, THECVY, None),
-            OKPHUO: GeckoBoolStructAccessor(self.struct, OKPHUO, KSOKPH, ICXQIE, None),
-            KPHUOJ: GeckoBoolStructAccessor(self.struct, KPHUOJ, KSOKPH, IEFXQG, None),
-            PHUOJR: GeckoBoolStructAccessor(self.struct, PHUOJR, KSOKPH, FXQGLR, None),
-            HUOJRJ: GeckoBoolStructAccessor(self.struct, HUOJRJ, KSOKPH, QGLRAH, None),
-            UOJRJH: GeckoBoolStructAccessor(self.struct, UOJRJH, KSOKPH, HEOCTH, None),
-            OJRJHI: GeckoBoolStructAccessor(self.struct, OJRJHI, KSOKPH, JRJHIU, None),
-            RJHIUS: GeckoBoolStructAccessor(self.struct, RJHIUS, JHIUSO, PICXQI, None),
-            HIUSOO: GeckoBoolStructAccessor(self.struct, HIUSOO, IUSOOQ, PICXQI, None),
-            USOOQN: GeckoBoolStructAccessor(self.struct, USOOQN, IUSOOQ, THECVY, None),
-            SOOQNR: GeckoBoolStructAccessor(self.struct, SOOQNR, IUSOOQ, ICXQIE, None),
-            OOQNRS: GeckoBoolStructAccessor(self.struct, OOQNRS, IUSOOQ, IEFXQG, None),
-            OQNRSJ: GeckoBoolStructAccessor(self.struct, OQNRSJ, IUSOOQ, FXQGLR, None),
-            QNRSJM: GeckoBoolStructAccessor(self.struct, QNRSJM, IUSOOQ, QGLRAH, None),
-            NRSJMC: GeckoBoolStructAccessor(self.struct, NRSJMC, IUSOOQ, HEOCTH, None),
-            RSJMCB: GeckoBoolStructAccessor(self.struct, RSJMCB, IUSOOQ, JRJHIU, None),
-            SJMCBF: GeckoWordStructAccessor(self.struct, SJMCBF, JMCBFE, None),
-            MCBFEG: GeckoEnumStructAccessor(
-                self.struct, MCBFEG, CBFEGZ, None, UQEXLS, None, None, None
+            "DiagnosticState": GeckoEnumStructAccessor(
+                self.struct, "DiagnosticState", 269, 2, ["OFF", "ON"], None, 2, None
             ),
-            QEXLSX: GeckoWordStructAccessor(self.struct, QEXLSX, EXLSXU, None),
-            XLSXUJ: GeckoByteStructAccessor(self.struct, XLSXUJ, LSXUJU, None),
-            SXUJUT: GeckoByteStructAccessor(self.struct, SXUJUT, XUJUTY, None),
-            UJUTYE: GeckoTempStructAccessor(self.struct, UJUTYE, JUTYEK, None),
-            UTYEKC: GeckoTempStructAccessor(self.struct, UTYEKC, TYEKCW, VHFTHE),
-            YEKCWA: GeckoWordStructAccessor(self.struct, YEKCWA, EKCWAO, None),
-            KCWAON: GeckoBoolStructAccessor(self.struct, KCWAON, CWAONP, PICXQI, None),
-            WAONPY: GeckoBoolStructAccessor(self.struct, WAONPY, CWAONP, THECVY, None),
-            AONPYY: GeckoBoolStructAccessor(self.struct, AONPYY, CWAONP, ICXQIE, None),
-            ONPYYL: GeckoBoolStructAccessor(self.struct, ONPYYL, CWAONP, IEFXQG, None),
-            NPYYLI: GeckoBoolStructAccessor(self.struct, NPYYLI, CWAONP, FXQGLR, None),
-            PYYLIU: GeckoWordStructAccessor(self.struct, PYYLIU, YYLIUX, None),
-            YLIUXF: GeckoByteStructAccessor(self.struct, YLIUXF, LIUXFE, None),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoEnumStructAccessor(
-                self.struct, XFEFJT, FEFJTA, None, NQJYMO, None, None, None
+            "ExternalProbe": GeckoBoolStructAccessor(
+                self.struct, "ExternalProbe", 269, 3, None
             ),
-            QJYMOU: GeckoEnumStructAccessor(
-                self.struct, QJYMOU, JYMOUN, PICXQI, NBLKXS, None, FXQGLR, None
+            "WaterDetected": GeckoBoolStructAccessor(
+                self.struct, "WaterDetected", 269, 4, None
             ),
-            BLKXSJ: GeckoWordStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, None),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, None),
-            WMNZMJ: GeckoByteStructAccessor(self.struct, WMNZMJ, MNZMJI, None),
-            NZMJIG: GeckoByteStructAccessor(self.struct, NZMJIG, ZMJIGY, None),
+            "NoRegulation": GeckoBoolStructAccessor(
+                self.struct, "NoRegulation", 269, 5, None
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct, "MasterSlave", 269, 6, ["SLAVE", "MASTER"], None, 2, None
+            ),
+            "KeypadProbe": GeckoBoolStructAccessor(
+                self.struct, "KeypadProbe", 270, 0, None
+            ),
+            "ExpressCycle": GeckoBoolStructAccessor(
+                self.struct, "ExpressCycle", 270, 1, None
+            ),
+            "SlaveOnState": GeckoBoolStructAccessor(
+                self.struct, "SlaveOnState", 271, 1, None
+            ),
+            "SlaveHeaterState": GeckoEnumStructAccessor(
+                self.struct, "SlaveHeaterState", 271, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "PowerFailErr": GeckoBoolStructAccessor(
+                self.struct, "PowerFailErr", 272, 0, None
+            ),
+            "Prr2Err": GeckoBoolStructAccessor(self.struct, "Prr2Err", 272, 1, None),
+            "Prr1Err": GeckoBoolStructAccessor(self.struct, "Prr1Err", 272, 2, None),
+            "H2O2Err": GeckoBoolStructAccessor(self.struct, "H2O2Err", 272, 3, None),
+            "SlaveH2O2Err": GeckoBoolStructAccessor(
+                self.struct, "SlaveH2O2Err", 272, 4, None
+            ),
+            "KeyStuckErr": GeckoBoolStructAccessor(
+                self.struct, "KeyStuckErr", 272, 5, None
+            ),
+            "FlashErr": GeckoBoolStructAccessor(self.struct, "FlashErr", 272, 6, None),
+            "Prr3Err": GeckoBoolStructAccessor(self.struct, "Prr3Err", 272, 7, None),
+            "Prr4Err": GeckoBoolStructAccessor(self.struct, "Prr4Err", 273, 0, None),
+            "Jumper9": GeckoBoolStructAccessor(self.struct, "Jumper9", 274, 0, None),
+            "Jumper2": GeckoBoolStructAccessor(self.struct, "Jumper2", 274, 1, None),
+            "Jumper3": GeckoBoolStructAccessor(self.struct, "Jumper3", 274, 2, None),
+            "Jumper4": GeckoBoolStructAccessor(self.struct, "Jumper4", 274, 3, None),
+            "Jumper5": GeckoBoolStructAccessor(self.struct, "Jumper5", 274, 4, None),
+            "Jumper6": GeckoBoolStructAccessor(self.struct, "Jumper6", 274, 5, None),
+            "Jumper7": GeckoBoolStructAccessor(self.struct, "Jumper7", 274, 6, None),
+            "Jumper8": GeckoBoolStructAccessor(self.struct, "Jumper8", 274, 7, None),
+            "MaxRuntime": GeckoWordStructAccessor(self.struct, "MaxRuntime", 275, None),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                277,
+                None,
+                ["NO_TSC", "SC_54", "TSC_53", "AUX_SW", "COLOR_SERIES"],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 298, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 300, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 301, None),
+            "RoomTempG": GeckoTempStructAccessor(self.struct, "RoomTempG", 278, None),
+            "K1000TempG": GeckoTempStructAccessor(
+                self.struct, "K1000TempG", 296, "ALL"
+            ),
+            "RemainingRuntime": GeckoWordStructAccessor(
+                self.struct, "RemainingRuntime", 293, None
+            ),
+            "DrainValveOutput": GeckoBoolStructAccessor(
+                self.struct, "DrainValveOutput", 295, 0, None
+            ),
+            "AromaOutput": GeckoBoolStructAccessor(
+                self.struct, "AromaOutput", 295, 1, None
+            ),
+            "HeaterOutput": GeckoBoolStructAccessor(
+                self.struct, "HeaterOutput", 295, 2, None
+            ),
+            "WaterValveOutput": GeckoBoolStructAccessor(
+                self.struct, "WaterValveOutput", 295, 3, None
+            ),
+            "ChromaOutput": GeckoBoolStructAccessor(
+                self.struct, "ChromaOutput", 295, 4, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 281, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 283, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 284, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                285,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "Color_Keypad",
+                    "inYJ",
+                    "MrSteam",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                286,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 287, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 289, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 290, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 291, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 292, None
+            ),
         }

--- a/src/geckolib/driver/packs/mrsteam-log-3.py
+++ b/src/geckolib/driver/packs/mrsteam-log-3.py
@@ -12,490 +12,6 @@ from . import (
     GeckoTempStructAccessor,
 )
 
-# Constants for this class
-ACCPQI = "".join(
-    chr(c)
-    for c in [
-        82,
-        101,
-        109,
-        97,
-        105,
-        110,
-        105,
-        110,
-        103,
-        82,
-        117,
-        110,
-        116,
-        105,
-        109,
-        101,
-    ]
-)
-AHEOCT = "".join(chr(c) for c in [65, 108, 108])
-AKQXPI = "".join(
-    chr(c) for c in [85, 115, 101, 114, 86, 97, 108, 118, 101, 80, 111, 119, 101, 114]
-)
-AMJMAO = 292
-AOAWBS = 336
-AONPYY = "".join(chr(c) for c in [83, 67, 95, 53, 52])
-ASSAKQ = "".join(chr(c) for c in [80, 114, 111, 103, 49])
-AWBSIR = 337
-BFEGZU = "".join(chr(c) for c in [83, 108, 97, 118, 101, 72, 50, 79, 50, 69, 114, 114])
-BIAMJM = 291
-BLKXSJ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 73, 68])
-BMJVHF = "".join(chr(c) for c in [79, 78])
-BSIRYX = "".join(chr(c) for c in [76, 73])
-BSKSOK = 0
-BWJYKL = "".join(
-    chr(c) for c in [67, 111, 108, 111, 114, 95, 75, 101, 121, 112, 97, 100]
-)
-CBFEGZ = "".join(chr(c) for c in [72, 50, 79, 50, 69, 114, 114])
-CCPQIP = 293
-CPQIPO = "".join(
-    chr(c)
-    for c in [68, 114, 97, 105, 110, 86, 97, 108, 118, 101, 79, 117, 116, 112, 117, 116]
-)
-CQBMJV = 256
-CTHBSK = 268
-CWAONP = 277
-CXQIEF = 304
-ECVYYP = 258
-EFJTAC = "".join(chr(c) for c in [82, 111, 111, 109, 84, 101, 109, 112, 71])
-EFXQGL = 307
-EGZUQE = "".join(chr(c) for c in [70, 108, 97, 115, 104, 69, 114, 114])
-EKCWAO = 275
-EOCTHB = 311
-EXLSXU = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 57])
-FEFJTA = 301
-FEGZUQ = "".join(chr(c) for c in [75, 101, 121, 83, 116, 117, 99, 107, 69, 114, 114])
-FJBIAM = 290
-FJTACC = 278
-FTHECV = 257
-FTSIFJ = 287
-FXQGLR = "".join(
-    chr(c)
-    for c in [85, 115, 101, 114, 86, 97, 108, 118, 101, 84, 101, 109, 112, 85, 112]
-)
-GLRAHE = 309
-GQPLSP = "".join(chr(c) for c in [49, 54, 75])
-GYOUSP = "".join(chr(c) for c in [105, 110, 67, 108, 101, 97, 114])
-GZUQEX = "".join(chr(c) for c in [80, 114, 114, 51, 69, 114, 114])
-HBSKSO = 269
-HECVYY = "".join(chr(c) for c in [85, 115, 101, 114, 65, 114, 111, 109, 97])
-HEOCTH = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        86,
-        97,
-        108,
-        118,
-        101,
-        65,
-        117,
-        116,
-        111,
-        67,
-        108,
-        101,
-        97,
-        110,
-    ]
-)
-HFTHEC = "".join(chr(c) for c in [85, 115, 101, 114, 80, 97, 117, 115, 101])
-HUOJRJ = 4
-IAMJMA = "".join(
-    chr(c) for c in [80, 97, 99, 107, 83, 116, 97, 116, 117, 115, 76, 105, 98]
-)
-ICXQIE = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        86,
-        97,
-        108,
-        118,
-        101,
-        68,
-        105,
-        115,
-        105,
-        110,
-        102,
-        101,
-        99,
-        116,
-        105,
-        111,
-        110,
-    ]
-)
-IEFXQG = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        86,
-        97,
-        108,
-        118,
-        101,
-        70,
-        108,
-        111,
-        119,
-        68,
-        111,
-        119,
-        110,
-    ]
-)
-IFJBIA = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 108])
-IGYOUS = "".join(chr(c) for c in [68, 74, 83, 52])
-IPIVLA = "".join(chr(c) for c in [85, 115, 101, 114, 82, 117, 110, 116, 105, 109, 101])
-IPOUYN = "".join(
-    chr(c) for c in [72, 101, 97, 116, 101, 114, 79, 117, 116, 112, 117, 116]
-)
-IUSOOQ = 6
-IUXFEF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 118])
-IVLASS = "".join(chr(c) for c in [85, 115, 101, 114, 80, 114, 111, 103])
-JBIAMJ = "".join(
-    chr(c) for c in [80, 97, 99, 107, 67, 111, 110, 102, 105, 103, 76, 105, 98]
-)
-JHIUSO = "".join(chr(c) for c in [77, 65, 83, 84, 69, 82])
-JIGYOU = "".join(chr(c) for c in [77, 73, 65])
-JMAOAW = 334
-JMCBFE = "".join(chr(c) for c in [80, 114, 114, 50, 69, 114, 114])
-JRJHIU = "".join(chr(c) for c in [77, 97, 115, 116, 101, 114, 83, 108, 97, 118, 101])
-JTACCP = "".join(chr(c) for c in [75, 49, 48, 48, 48, 84, 101, 109, 112, 71])
-JUTYEK = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 54])
-JWMNZM = 284
-JYKLGQ = "".join(chr(c) for c in [77, 114, 83, 116, 101, 97, 109])
-JYMOUN = "".join(
-    chr(c) for c in [83, 104, 111, 119, 101, 114, 70, 108, 111, 119, 82, 97, 116, 101]
-)
-KCWAON = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 84, 121, 112, 101])
-KLGQPL = "".join(chr(c) for c in [80, 97, 99, 107, 77, 101, 109, 82, 97, 110, 103, 101])
-KPHUOJ = 3
-KQXPIC = 302
-KSOKPH = "".join(chr(c) for c in [80, 97, 117, 115, 101, 83, 116, 97, 116, 101])
-KXSJWM = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 118])
-LASSAK = "".join(chr(c) for c in [85, 115, 101, 114])
-LGQPLS = 286
-LIUXFE = 298
-LKXSJW = 281
-LRAHEO = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        86,
-        97,
-        108,
-        118,
-        101,
-        76,
-        101,
-        97,
-        114,
-        110,
-        105,
-        110,
-        103,
-    ]
-)
-LSPFTS = "".join(chr(c) for c in [54, 52, 75])
-LSXUJU = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 50])
-MAOAWB = "".join(
-    chr(c)
-    for c in [
-        73,
-        50,
-        67,
-        116,
-        111,
-        82,
-        83,
-        52,
-        56,
-        53,
-        67,
-        111,
-        110,
-        118,
-        101,
-        114,
-        116,
-        101,
-        114,
-        82,
-        101,
-        118,
-    ]
-)
-MCBFEG = "".join(chr(c) for c in [80, 114, 114, 49, 69, 114, 114])
-MJIGYO = "".join(chr(c) for c in [77, 97, 115, 73, 66, 67])
-MJMAOA = "".join(
-    chr(c)
-    for c in [
-        73,
-        50,
-        67,
-        116,
-        111,
-        82,
-        83,
-        52,
-        56,
-        53,
-        67,
-        111,
-        110,
-        118,
-        101,
-        114,
-        116,
-        101,
-        114,
-        73,
-        68,
-    ]
-)
-MJVHFT = "".join(chr(c) for c in [68, 73, 65, 71, 78, 79, 83, 84, 73, 67])
-MNZMJI = 285
-MOUNBL = "".join(
-    chr(c)
-    for c in [65, 118, 97, 105, 108, 97, 98, 108, 101, 79, 117, 116, 108, 101, 116]
-)
-NBLKXS = 322
-NPYYLI = "".join(chr(c) for c in [65, 85, 88, 95, 83, 87])
-NQJYMO = "".join(
-    chr(c)
-    for c in [83, 104, 111, 119, 101, 114, 86, 97, 108, 118, 101, 84, 101, 109, 112, 67]
-)
-NRSJMC = "".join(
-    chr(c)
-    for c in [83, 108, 97, 118, 101, 72, 101, 97, 116, 101, 114, 83, 116, 97, 116, 101]
-)
-NZMJIG = "".join(chr(c) for c in [85, 110, 107, 110, 111, 119, 110])
-OAWBSI = "".join(
-    chr(c)
-    for c in [
-        73,
-        50,
-        67,
-        116,
-        111,
-        82,
-        83,
-        52,
-        56,
-        53,
-        67,
-        111,
-        110,
-        118,
-        101,
-        114,
-        116,
-        101,
-        114,
-        82,
-        101,
-        108,
-    ]
-)
-OCTHBS = "".join(chr(c) for c in [72, 111, 117, 114, 115])
-OJRJHI = 5
-OKPHUO = "".join(
-    chr(c) for c in [69, 120, 116, 101, 114, 110, 97, 108, 80, 114, 111, 98, 101]
-)
-ONPYYL = "".join(chr(c) for c in [84, 83, 67, 95, 53, 51])
-OOQNRS = "".join(
-    chr(c) for c in [69, 120, 112, 114, 101, 115, 115, 67, 121, 99, 108, 101]
-)
-OQNRSJ = "".join(
-    chr(c) for c in [83, 108, 97, 118, 101, 79, 110, 83, 116, 97, 116, 101]
-)
-OUNBLK = 318
-OUSPBW = "".join(chr(c) for c in [75, 54, 48, 48])
-OUYNQJ = "".join(
-    chr(c) for c in [67, 104, 114, 111, 109, 97, 79, 117, 116, 112, 117, 116]
-)
-PBWJYK = "".join(chr(c) for c in [105, 110, 89, 84])
-PFTSIF = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 73, 68])
-PHUOJR = "".join(
-    chr(c) for c in [87, 97, 116, 101, 114, 68, 101, 116, 101, 99, 116, 101, 100]
-)
-PICXQI = 303
-PIPIVL = 264
-PIVLAS = 261
-PLSPFT = "".join(chr(c) for c in [52, 56, 75])
-POUYNQ = "".join(
-    chr(c)
-    for c in [87, 97, 116, 101, 114, 86, 97, 108, 118, 101, 79, 117, 116, 112, 117, 116]
-)
-PQIPOU = 295
-PYYLIU = "".join(chr(c) for c in [67, 79, 76, 79, 82, 95, 83, 69, 82, 73, 69, 83])
-QBMJVH = "".join(chr(c) for c in [79, 70, 70])
-QEXLSX = 273
-QGLRAH = "".join(
-    chr(c)
-    for c in [
-        85,
-        115,
-        101,
-        114,
-        86,
-        97,
-        108,
-        118,
-        101,
-        84,
-        101,
-        109,
-        112,
-        68,
-        111,
-        119,
-        110,
-    ]
-)
-QIEFXQ = 306
-QIPOUY = "".join(chr(c) for c in [65, 114, 111, 109, 97, 79, 117, 116, 112, 117, 116])
-QJYMOU = 314
-QNRSJM = 271
-QPLSPF = "".join(chr(c) for c in [51, 50, 75])
-RAHEOC = 310
-RJHIUS = "".join(chr(c) for c in [83, 76, 65, 86, 69])
-RSJMCB = "".join(
-    chr(c) for c in [80, 111, 119, 101, 114, 70, 97, 105, 108, 69, 114, 114]
-)
-RYXBQF = 256
-SIFJBI = 289
-SJMCBF = 272
-SJWMNZ = "".join(chr(c) for c in [80, 97, 99, 107, 66, 111, 111, 116, 82, 101, 108])
-SKSOKP = 2
-SOKPHU = "".join(
-    chr(c)
-    for c in [68, 105, 97, 103, 110, 111, 115, 116, 105, 99, 83, 116, 97, 116, 101]
-)
-SOOQNR = 270
-SPBWJY = "".join(chr(c) for c in [105, 110, 84, 111, 117, 99, 104])
-SSAKQX = "".join(chr(c) for c in [80, 114, 111, 103, 50])
-SXUJUT = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 51])
-TACCPQ = 296
-THBSKS = "".join(chr(c) for c in [77, 111, 100, 101, 83, 116, 97, 116, 101])
-THECVY = 1
-TSIFJB = "".join(chr(c) for c in [80, 97, 99, 107, 67, 111, 114, 101, 82, 101, 118])
-TYEKCW = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 56])
-UJUTYE = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 53])
-UNBLKX = "".join(
-    chr(c)
-    for c in [83, 104, 111, 119, 101, 114, 86, 97, 108, 118, 101, 65, 108, 97, 114, 109]
-)
-UOJRJH = "".join(
-    chr(c) for c in [78, 111, 82, 101, 103, 117, 108, 97, 116, 105, 111, 110]
-)
-UQEXLS = "".join(chr(c) for c in [80, 114, 114, 52, 69, 114, 114])
-USOOQN = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 80, 114, 111, 98, 101])
-USPBWJ = "".join(chr(c) for c in [105, 110, 84, 101, 114, 102, 97, 99, 101])
-UTYEKC = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 55])
-UXFEFJ = 300
-UYNQJY = "".join(
-    chr(c)
-    for c in [
-        83,
-        104,
-        111,
-        119,
-        101,
-        114,
-        86,
-        97,
-        108,
-        118,
-        101,
-        83,
-        116,
-        97,
-        116,
-        117,
-        115,
-    ]
-)
-VHFTHE = "".join(chr(c) for c in [65, 76, 76])
-VLASSA = 263
-VYYPIP = "".join(chr(c) for c in [85, 115, 101, 114, 67, 104, 114, 111, 109, 97])
-WAONPY = "".join(chr(c) for c in [78, 79, 95, 84, 83, 67])
-WJYKLG = "".join(chr(c) for c in [105, 110, 89, 74])
-WMNZMJ = "".join(chr(c) for c in [80, 97, 99, 107, 84, 121, 112, 101])
-XFEFJT = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 82, 101, 108])
-XLSXUJ = 274
-XPICXQ = "".join(
-    chr(c)
-    for c in [85, 115, 101, 114, 86, 97, 108, 118, 101, 79, 117, 116, 112, 117, 116]
-)
-XQGLRA = 308
-XQIEFX = "".join(
-    chr(c)
-    for c in [85, 115, 101, 114, 86, 97, 108, 118, 101, 70, 108, 111, 119, 85, 112]
-)
-XSJWMN = 283
-XUJUTY = "".join(chr(c) for c in [74, 117, 109, 112, 101, 114, 52])
-YEKCWA = "".join(chr(c) for c in [77, 97, 120, 82, 117, 110, 116, 105, 109, 101])
-YLIUXF = "".join(chr(c) for c in [75, 101, 121, 112, 97, 100, 73, 68])
-YMOUNB = 316
-YNQJYM = 312
-YOUSPB = "".join(chr(c) for c in [105, 110, 88, 77])
-YPIPIV = "".join(
-    chr(c) for c in [85, 115, 101, 114, 83, 101, 116, 112, 111, 105, 110, 116, 71]
-)
-YXBQFY = 337
-YYPIPI = 259
-ZCQBMJ = "".join(chr(c) for c in [85, 115, 101, 114, 77, 111, 100, 101])
-ZMJIGY = "".join(chr(c) for c in [105, 110, 88, 69])
-ZUQEXL = 7
-CVYYPI = [QBMJVH, BMJVHF]
-HIUSOO = [RJHIUS, JHIUSO]
-IRYXBQ = [RSJMCB, EGZUQE, CBFEGZ, MCBFEG, GZUQEX, UQEXLS, JMCBFE, BFEGZU, FEGZUQ]
-JVHFTH = [QBMJVH, BMJVHF, MJVHFT]
-QXPICX = [BMJVHF, QBMJVH]
-SAKQXP = [LASSAK, ASSAKQ, SSAKQX]
-SIRYXB = [BSIRYX]
-SPFTSI = [GQPLSP, QPLSPF, PLSPFT, LSPFTS]
-WBSIRY = []
-YKLGQP = [
-    NZMJIG,
-    ZMJIGY,
-    MJIGYO,
-    JIGYOU,
-    IGYOUS,
-    GYOUSP,
-    YOUSPB,
-    OUSPBW,
-    USPBWJ,
-    SPBWJY,
-    PBWJYK,
-    BWJYKL,
-    WJYKLG,
-    JYKLGQ,
-]
-YYLIUX = [WAONPY, AONPYY, ONPYYL, NPYYLI, PYYLIU]
-
 
 class GeckoLogStruct:
     def __init__(self, struct_):
@@ -503,131 +19,280 @@ class GeckoLogStruct:
 
     @property
     def version(self):
-        return KPHUOJ
+        return 3
 
     @property
     def begin(self):
-        return RYXBQF
+        return 256
 
     @property
     def end(self):
-        return YXBQFY
+        return 337
 
     @property
     def all_device_keys(self):
-        return SIRYXB
+        return ["LI"]
 
     @property
     def user_demand_keys(self):
-        return WBSIRY
+        return []
 
     @property
     def error_keys(self):
-        return IRYXBQ
+        return [
+            "PowerFailErr",
+            "Prr2Err",
+            "SlaveH2O2Err",
+            "KeyStuckErr",
+            "Prr3Err",
+            "Prr1Err",
+            "Prr4Err",
+            "H2O2Err",
+            "FlashErr",
+        ]
 
     @property
     def accessors(self):
         return {
-            ZCQBMJ: GeckoEnumStructAccessor(
-                self.struct, ZCQBMJ, CQBMJV, None, JVHFTH, None, None, VHFTHE
+            "UserMode": GeckoEnumStructAccessor(
+                self.struct,
+                "UserMode",
+                256,
+                None,
+                ["OFF", "ON", "DIAGNOSTIC"],
+                None,
+                None,
+                "ALL",
             ),
-            HFTHEC: GeckoBoolStructAccessor(
-                self.struct, HFTHEC, FTHECV, THECVY, VHFTHE
+            "UserPause": GeckoBoolStructAccessor(
+                self.struct, "UserPause", 257, 1, "ALL"
             ),
-            HECVYY: GeckoEnumStructAccessor(
-                self.struct, HECVYY, ECVYYP, None, CVYYPI, None, None, VHFTHE
+            "UserAroma": GeckoEnumStructAccessor(
+                self.struct, "UserAroma", 258, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            VYYPIP: GeckoEnumStructAccessor(
-                self.struct, VYYPIP, YYPIPI, None, CVYYPI, None, None, VHFTHE
+            "UserChroma": GeckoEnumStructAccessor(
+                self.struct, "UserChroma", 259, None, ["OFF", "ON"], None, None, "ALL"
             ),
-            YPIPIV: GeckoTempStructAccessor(self.struct, YPIPIV, PIPIVL, VHFTHE),
-            IPIVLA: GeckoWordStructAccessor(self.struct, IPIVLA, PIVLAS, VHFTHE),
-            IVLASS: GeckoEnumStructAccessor(
-                self.struct, IVLASS, VLASSA, None, SAKQXP, None, None, VHFTHE
+            "UserSetpointG": GeckoTempStructAccessor(
+                self.struct, "UserSetpointG", 264, "ALL"
             ),
-            AKQXPI: GeckoEnumStructAccessor(
-                self.struct, AKQXPI, KQXPIC, None, QXPICX, None, None, VHFTHE
+            "UserRuntime": GeckoWordStructAccessor(
+                self.struct, "UserRuntime", 261, "ALL"
             ),
-            XPICXQ: GeckoByteStructAccessor(self.struct, XPICXQ, PICXQI, VHFTHE),
-            ICXQIE: GeckoBoolStructAccessor(self.struct, ICXQIE, CXQIEF, None, VHFTHE),
-            XQIEFX: GeckoBoolStructAccessor(self.struct, XQIEFX, QIEFXQ, None, VHFTHE),
-            IEFXQG: GeckoBoolStructAccessor(self.struct, IEFXQG, EFXQGL, None, VHFTHE),
-            FXQGLR: GeckoBoolStructAccessor(self.struct, FXQGLR, XQGLRA, None, VHFTHE),
-            QGLRAH: GeckoBoolStructAccessor(self.struct, QGLRAH, GLRAHE, None, VHFTHE),
-            LRAHEO: GeckoBoolStructAccessor(self.struct, LRAHEO, RAHEOC, None, AHEOCT),
-            HEOCTH: GeckoBoolStructAccessor(self.struct, HEOCTH, EOCTHB, None, AHEOCT),
-            OCTHBS: GeckoByteStructAccessor(self.struct, OCTHBS, CTHBSK, None),
-            THBSKS: GeckoEnumStructAccessor(
-                self.struct, THBSKS, HBSKSO, BSKSOK, CVYYPI, None, SKSOKP, None
+            "UserProg": GeckoEnumStructAccessor(
+                self.struct,
+                "UserProg",
+                263,
+                None,
+                ["User", "Prog1", "Prog2"],
+                None,
+                None,
+                "ALL",
             ),
-            KSOKPH: GeckoBoolStructAccessor(self.struct, KSOKPH, HBSKSO, THECVY, None),
-            SOKPHU: GeckoEnumStructAccessor(
-                self.struct, SOKPHU, HBSKSO, SKSOKP, CVYYPI, None, SKSOKP, None
+            "UserValvePower": GeckoEnumStructAccessor(
+                self.struct,
+                "UserValvePower",
+                302,
+                None,
+                ["ON", "OFF"],
+                None,
+                None,
+                "ALL",
             ),
-            OKPHUO: GeckoBoolStructAccessor(self.struct, OKPHUO, HBSKSO, KPHUOJ, None),
-            PHUOJR: GeckoBoolStructAccessor(self.struct, PHUOJR, HBSKSO, HUOJRJ, None),
-            UOJRJH: GeckoBoolStructAccessor(self.struct, UOJRJH, HBSKSO, OJRJHI, None),
-            JRJHIU: GeckoEnumStructAccessor(
-                self.struct, JRJHIU, HBSKSO, IUSOOQ, HIUSOO, None, SKSOKP, None
+            "UserValveOutput": GeckoByteStructAccessor(
+                self.struct, "UserValveOutput", 303, "ALL"
             ),
-            USOOQN: GeckoBoolStructAccessor(self.struct, USOOQN, SOOQNR, BSKSOK, None),
-            OOQNRS: GeckoBoolStructAccessor(self.struct, OOQNRS, SOOQNR, THECVY, None),
-            OQNRSJ: GeckoBoolStructAccessor(self.struct, OQNRSJ, QNRSJM, THECVY, None),
-            NRSJMC: GeckoEnumStructAccessor(
-                self.struct, NRSJMC, QNRSJM, KPHUOJ, CVYYPI, None, SKSOKP, None
+            "UserValveDisinfection": GeckoBoolStructAccessor(
+                self.struct, "UserValveDisinfection", 304, None, "ALL"
             ),
-            RSJMCB: GeckoBoolStructAccessor(self.struct, RSJMCB, SJMCBF, BSKSOK, None),
-            JMCBFE: GeckoBoolStructAccessor(self.struct, JMCBFE, SJMCBF, THECVY, None),
-            MCBFEG: GeckoBoolStructAccessor(self.struct, MCBFEG, SJMCBF, SKSOKP, None),
-            CBFEGZ: GeckoBoolStructAccessor(self.struct, CBFEGZ, SJMCBF, KPHUOJ, None),
-            BFEGZU: GeckoBoolStructAccessor(self.struct, BFEGZU, SJMCBF, HUOJRJ, None),
-            FEGZUQ: GeckoBoolStructAccessor(self.struct, FEGZUQ, SJMCBF, OJRJHI, None),
-            EGZUQE: GeckoBoolStructAccessor(self.struct, EGZUQE, SJMCBF, IUSOOQ, None),
-            GZUQEX: GeckoBoolStructAccessor(self.struct, GZUQEX, SJMCBF, ZUQEXL, None),
-            UQEXLS: GeckoBoolStructAccessor(self.struct, UQEXLS, QEXLSX, BSKSOK, None),
-            EXLSXU: GeckoBoolStructAccessor(self.struct, EXLSXU, XLSXUJ, BSKSOK, None),
-            LSXUJU: GeckoBoolStructAccessor(self.struct, LSXUJU, XLSXUJ, THECVY, None),
-            SXUJUT: GeckoBoolStructAccessor(self.struct, SXUJUT, XLSXUJ, SKSOKP, None),
-            XUJUTY: GeckoBoolStructAccessor(self.struct, XUJUTY, XLSXUJ, KPHUOJ, None),
-            UJUTYE: GeckoBoolStructAccessor(self.struct, UJUTYE, XLSXUJ, HUOJRJ, None),
-            JUTYEK: GeckoBoolStructAccessor(self.struct, JUTYEK, XLSXUJ, OJRJHI, None),
-            UTYEKC: GeckoBoolStructAccessor(self.struct, UTYEKC, XLSXUJ, IUSOOQ, None),
-            TYEKCW: GeckoBoolStructAccessor(self.struct, TYEKCW, XLSXUJ, ZUQEXL, None),
-            YEKCWA: GeckoWordStructAccessor(self.struct, YEKCWA, EKCWAO, None),
-            KCWAON: GeckoEnumStructAccessor(
-                self.struct, KCWAON, CWAONP, None, YYLIUX, None, None, None
+            "UserValveFlowUp": GeckoBoolStructAccessor(
+                self.struct, "UserValveFlowUp", 306, None, "ALL"
             ),
-            YLIUXF: GeckoWordStructAccessor(self.struct, YLIUXF, LIUXFE, None),
-            IUXFEF: GeckoByteStructAccessor(self.struct, IUXFEF, UXFEFJ, None),
-            XFEFJT: GeckoByteStructAccessor(self.struct, XFEFJT, FEFJTA, None),
-            EFJTAC: GeckoTempStructAccessor(self.struct, EFJTAC, FJTACC, None),
-            JTACCP: GeckoTempStructAccessor(self.struct, JTACCP, TACCPQ, VHFTHE),
-            ACCPQI: GeckoWordStructAccessor(self.struct, ACCPQI, CCPQIP, None),
-            CPQIPO: GeckoBoolStructAccessor(self.struct, CPQIPO, PQIPOU, BSKSOK, None),
-            QIPOUY: GeckoBoolStructAccessor(self.struct, QIPOUY, PQIPOU, THECVY, None),
-            IPOUYN: GeckoBoolStructAccessor(self.struct, IPOUYN, PQIPOU, SKSOKP, None),
-            POUYNQ: GeckoBoolStructAccessor(self.struct, POUYNQ, PQIPOU, KPHUOJ, None),
-            OUYNQJ: GeckoBoolStructAccessor(self.struct, OUYNQJ, PQIPOU, HUOJRJ, None),
-            UYNQJY: GeckoWordStructAccessor(self.struct, UYNQJY, YNQJYM, None),
-            NQJYMO: GeckoTempStructAccessor(self.struct, NQJYMO, QJYMOU, None),
-            JYMOUN: GeckoWordStructAccessor(self.struct, JYMOUN, YMOUNB, None),
-            MOUNBL: GeckoWordStructAccessor(self.struct, MOUNBL, OUNBLK, None),
-            UNBLKX: GeckoWordStructAccessor(self.struct, UNBLKX, NBLKXS, None),
-            BLKXSJ: GeckoWordStructAccessor(self.struct, BLKXSJ, LKXSJW, None),
-            KXSJWM: GeckoByteStructAccessor(self.struct, KXSJWM, XSJWMN, None),
-            SJWMNZ: GeckoByteStructAccessor(self.struct, SJWMNZ, JWMNZM, None),
-            WMNZMJ: GeckoEnumStructAccessor(
-                self.struct, WMNZMJ, MNZMJI, None, YKLGQP, None, None, None
+            "UserValveFlowDown": GeckoBoolStructAccessor(
+                self.struct, "UserValveFlowDown", 307, None, "ALL"
             ),
-            KLGQPL: GeckoEnumStructAccessor(
-                self.struct, KLGQPL, LGQPLS, BSKSOK, SPFTSI, None, HUOJRJ, None
+            "UserValveTempUp": GeckoBoolStructAccessor(
+                self.struct, "UserValveTempUp", 308, None, "ALL"
             ),
-            PFTSIF: GeckoWordStructAccessor(self.struct, PFTSIF, FTSIFJ, None),
-            TSIFJB: GeckoByteStructAccessor(self.struct, TSIFJB, SIFJBI, None),
-            IFJBIA: GeckoByteStructAccessor(self.struct, IFJBIA, FJBIAM, None),
-            JBIAMJ: GeckoByteStructAccessor(self.struct, JBIAMJ, BIAMJM, None),
-            IAMJMA: GeckoByteStructAccessor(self.struct, IAMJMA, AMJMAO, None),
-            MJMAOA: GeckoWordStructAccessor(self.struct, MJMAOA, JMAOAW, None),
-            MAOAWB: GeckoByteStructAccessor(self.struct, MAOAWB, AOAWBS, None),
-            OAWBSI: GeckoByteStructAccessor(self.struct, OAWBSI, AWBSIR, None),
+            "UserValveTempDown": GeckoBoolStructAccessor(
+                self.struct, "UserValveTempDown", 309, None, "ALL"
+            ),
+            "UserValveLearning": GeckoBoolStructAccessor(
+                self.struct, "UserValveLearning", 310, None, "All"
+            ),
+            "UserValveAutoClean": GeckoBoolStructAccessor(
+                self.struct, "UserValveAutoClean", 311, None, "All"
+            ),
+            "Hours": GeckoByteStructAccessor(self.struct, "Hours", 268, None),
+            "ModeState": GeckoEnumStructAccessor(
+                self.struct, "ModeState", 269, 0, ["OFF", "ON"], None, 2, None
+            ),
+            "PauseState": GeckoBoolStructAccessor(
+                self.struct, "PauseState", 269, 1, None
+            ),
+            "DiagnosticState": GeckoEnumStructAccessor(
+                self.struct, "DiagnosticState", 269, 2, ["OFF", "ON"], None, 2, None
+            ),
+            "ExternalProbe": GeckoBoolStructAccessor(
+                self.struct, "ExternalProbe", 269, 3, None
+            ),
+            "WaterDetected": GeckoBoolStructAccessor(
+                self.struct, "WaterDetected", 269, 4, None
+            ),
+            "NoRegulation": GeckoBoolStructAccessor(
+                self.struct, "NoRegulation", 269, 5, None
+            ),
+            "MasterSlave": GeckoEnumStructAccessor(
+                self.struct, "MasterSlave", 269, 6, ["SLAVE", "MASTER"], None, 2, None
+            ),
+            "KeypadProbe": GeckoBoolStructAccessor(
+                self.struct, "KeypadProbe", 270, 0, None
+            ),
+            "ExpressCycle": GeckoBoolStructAccessor(
+                self.struct, "ExpressCycle", 270, 1, None
+            ),
+            "SlaveOnState": GeckoBoolStructAccessor(
+                self.struct, "SlaveOnState", 271, 1, None
+            ),
+            "SlaveHeaterState": GeckoEnumStructAccessor(
+                self.struct, "SlaveHeaterState", 271, 3, ["OFF", "ON"], None, 2, None
+            ),
+            "PowerFailErr": GeckoBoolStructAccessor(
+                self.struct, "PowerFailErr", 272, 0, None
+            ),
+            "Prr2Err": GeckoBoolStructAccessor(self.struct, "Prr2Err", 272, 1, None),
+            "Prr1Err": GeckoBoolStructAccessor(self.struct, "Prr1Err", 272, 2, None),
+            "H2O2Err": GeckoBoolStructAccessor(self.struct, "H2O2Err", 272, 3, None),
+            "SlaveH2O2Err": GeckoBoolStructAccessor(
+                self.struct, "SlaveH2O2Err", 272, 4, None
+            ),
+            "KeyStuckErr": GeckoBoolStructAccessor(
+                self.struct, "KeyStuckErr", 272, 5, None
+            ),
+            "FlashErr": GeckoBoolStructAccessor(self.struct, "FlashErr", 272, 6, None),
+            "Prr3Err": GeckoBoolStructAccessor(self.struct, "Prr3Err", 272, 7, None),
+            "Prr4Err": GeckoBoolStructAccessor(self.struct, "Prr4Err", 273, 0, None),
+            "Jumper9": GeckoBoolStructAccessor(self.struct, "Jumper9", 274, 0, None),
+            "Jumper2": GeckoBoolStructAccessor(self.struct, "Jumper2", 274, 1, None),
+            "Jumper3": GeckoBoolStructAccessor(self.struct, "Jumper3", 274, 2, None),
+            "Jumper4": GeckoBoolStructAccessor(self.struct, "Jumper4", 274, 3, None),
+            "Jumper5": GeckoBoolStructAccessor(self.struct, "Jumper5", 274, 4, None),
+            "Jumper6": GeckoBoolStructAccessor(self.struct, "Jumper6", 274, 5, None),
+            "Jumper7": GeckoBoolStructAccessor(self.struct, "Jumper7", 274, 6, None),
+            "Jumper8": GeckoBoolStructAccessor(self.struct, "Jumper8", 274, 7, None),
+            "MaxRuntime": GeckoWordStructAccessor(self.struct, "MaxRuntime", 275, None),
+            "KeypadType": GeckoEnumStructAccessor(
+                self.struct,
+                "KeypadType",
+                277,
+                None,
+                ["NO_TSC", "SC_54", "TSC_53", "AUX_SW", "COLOR_SERIES"],
+                None,
+                None,
+                None,
+            ),
+            "KeypadID": GeckoWordStructAccessor(self.struct, "KeypadID", 298, None),
+            "KeypadRev": GeckoByteStructAccessor(self.struct, "KeypadRev", 300, None),
+            "KeypadRel": GeckoByteStructAccessor(self.struct, "KeypadRel", 301, None),
+            "RoomTempG": GeckoTempStructAccessor(self.struct, "RoomTempG", 278, None),
+            "K1000TempG": GeckoTempStructAccessor(
+                self.struct, "K1000TempG", 296, "ALL"
+            ),
+            "RemainingRuntime": GeckoWordStructAccessor(
+                self.struct, "RemainingRuntime", 293, None
+            ),
+            "DrainValveOutput": GeckoBoolStructAccessor(
+                self.struct, "DrainValveOutput", 295, 0, None
+            ),
+            "AromaOutput": GeckoBoolStructAccessor(
+                self.struct, "AromaOutput", 295, 1, None
+            ),
+            "HeaterOutput": GeckoBoolStructAccessor(
+                self.struct, "HeaterOutput", 295, 2, None
+            ),
+            "WaterValveOutput": GeckoBoolStructAccessor(
+                self.struct, "WaterValveOutput", 295, 3, None
+            ),
+            "ChromaOutput": GeckoBoolStructAccessor(
+                self.struct, "ChromaOutput", 295, 4, None
+            ),
+            "ShowerValveStatus": GeckoWordStructAccessor(
+                self.struct, "ShowerValveStatus", 312, None
+            ),
+            "ShowerValveTempC": GeckoTempStructAccessor(
+                self.struct, "ShowerValveTempC", 314, None
+            ),
+            "ShowerFlowRate": GeckoWordStructAccessor(
+                self.struct, "ShowerFlowRate", 316, None
+            ),
+            "AvailableOutlet": GeckoWordStructAccessor(
+                self.struct, "AvailableOutlet", 318, None
+            ),
+            "ShowerValveAlarm": GeckoWordStructAccessor(
+                self.struct, "ShowerValveAlarm", 322, None
+            ),
+            "PackBootID": GeckoWordStructAccessor(self.struct, "PackBootID", 281, None),
+            "PackBootRev": GeckoByteStructAccessor(
+                self.struct, "PackBootRev", 283, None
+            ),
+            "PackBootRel": GeckoByteStructAccessor(
+                self.struct, "PackBootRel", 284, None
+            ),
+            "PackType": GeckoEnumStructAccessor(
+                self.struct,
+                "PackType",
+                285,
+                None,
+                [
+                    "Unknown",
+                    "inXE",
+                    "MasIBC",
+                    "MIA",
+                    "DJS4",
+                    "inClear",
+                    "inXM",
+                    "K600",
+                    "inTerface",
+                    "inTouch",
+                    "inYT",
+                    "Color_Keypad",
+                    "inYJ",
+                    "MrSteam",
+                ],
+                None,
+                None,
+                None,
+            ),
+            "PackMemRange": GeckoEnumStructAccessor(
+                self.struct,
+                "PackMemRange",
+                286,
+                0,
+                ["16K", "32K", "48K", "64K"],
+                None,
+                4,
+                None,
+            ),
+            "PackCoreID": GeckoWordStructAccessor(self.struct, "PackCoreID", 287, None),
+            "PackCoreRev": GeckoByteStructAccessor(
+                self.struct, "PackCoreRev", 289, None
+            ),
+            "PackCoreRel": GeckoByteStructAccessor(
+                self.struct, "PackCoreRel", 290, None
+            ),
+            "PackConfigLib": GeckoByteStructAccessor(
+                self.struct, "PackConfigLib", 291, None
+            ),
+            "PackStatusLib": GeckoByteStructAccessor(
+                self.struct, "PackStatusLib", 292, None
+            ),
+            "I2CtoRS485ConverterID": GeckoWordStructAccessor(
+                self.struct, "I2CtoRS485ConverterID", 334, None
+            ),
+            "I2CtoRS485ConverterRev": GeckoByteStructAccessor(
+                self.struct, "I2CtoRS485ConverterRev", 336, None
+            ),
+            "I2CtoRS485ConverterRel": GeckoByteStructAccessor(
+                self.struct, "I2CtoRS485ConverterRel", 337, None
+            ),
         }

--- a/src/geckolib/driver/packs/mrsteam.py
+++ b/src/geckolib/driver/packs/mrsteam.py
@@ -18,4 +18,4 @@ class GeckoPack:
 
     @property
     def revision(self):
-        return "36.01"
+        return "39.0"


### PR DESCRIPTION
- updated structs to latest spapack version (v39.0). Needed to support my 2024 Bullfrog spa with IN.YT-9 spa pack
- fixed python_required in setup.cfg

Let me know if you'd like me to redo the structs with obfuscation enabled